### PR TITLE
Add SQLiteNSDRepository

### DIFF
--- a/infrastructure/models/__init__.py
+++ b/infrastructure/models/__init__.py
@@ -1,3 +1,4 @@
 from .company_model import CompanyModel
+from .nsd_model import NSDModel
 
-__all__ = ["CompanyModel"]
+__all__ = ["CompanyModel", "NSDModel"]

--- a/infrastructure/models/nsd_model.py
+++ b/infrastructure/models/nsd_model.py
@@ -1,0 +1,52 @@
+from sqlalchemy.orm import Mapped, mapped_column
+from typing import Optional
+from .company_model import Base
+from domain.dto.nsd_dto import NSDDTO
+
+class NSDModel(Base):
+    """ORM model for the tbl_nsd table."""
+
+    __tablename__ = "tbl_nsd"
+
+    nsd: Mapped[int] = mapped_column(primary_key=True)
+    company_name: Mapped[Optional[str]] = mapped_column()
+    quarter: Mapped[Optional[str]] = mapped_column()
+    version: Mapped[Optional[str]] = mapped_column()
+    nsd_type: Mapped[Optional[str]] = mapped_column()
+    dri: Mapped[Optional[str]] = mapped_column()
+    auditor: Mapped[Optional[str]] = mapped_column()
+    responsible_auditor: Mapped[Optional[str]] = mapped_column()
+    protocol: Mapped[Optional[str]] = mapped_column()
+    sent_date: Mapped[Optional[str]] = mapped_column()
+    reason: Mapped[Optional[str]] = mapped_column()
+
+    @staticmethod
+    def from_dto(dto: NSDDTO) -> "NSDModel":
+        return NSDModel(
+            nsd=dto.nsd,
+            company_name=dto.company_name,
+            quarter=dto.quarter,
+            version=dto.version,
+            nsd_type=dto.nsd_type,
+            dri=dto.dri,
+            auditor=dto.auditor,
+            responsible_auditor=dto.responsible_auditor,
+            protocol=dto.protocol,
+            sent_date=dto.sent_date,
+            reason=dto.reason,
+        )
+
+    def to_dto(self) -> NSDDTO:
+        return NSDDTO(
+            nsd=self.nsd,
+            company_name=self.company_name,
+            quarter=self.quarter,
+            version=self.version,
+            nsd_type=self.nsd_type,
+            dri=self.dri,
+            auditor=self.auditor,
+            responsible_auditor=self.responsible_auditor,
+            protocol=self.protocol,
+            sent_date=self.sent_date,
+            reason=self.reason,
+        )

--- a/infrastructure/repositories/__init__.py
+++ b/infrastructure/repositories/__init__.py
@@ -1,8 +1,8 @@
 from .company_repository import SQLiteCompanyRepository
-# from .nsd_repository import SQLiteNSDRepository
+from .nsd_repository import SQLiteNSDRepository
 
 __all__ = [
-    "SQLiteCompanyRepository", 
-    # "SQLiteNSDRepository", 
+    "SQLiteCompanyRepository",
+    "SQLiteNSDRepository",
     ]
 


### PR DESCRIPTION
## Summary
- implement `SQLiteNSDRepository` with SQLAlchemy session handling
- add NSDModel ORM and export it
- expose `SQLiteNSDRepository` from repositories package

## Testing
- `python -m py_compile infrastructure/models/nsd_model.py infrastructure/repositories/nsd_repository.py infrastructure/models/__init__.py infrastructure/repositories/__init__.py`
- `find . -name '*.py' -print0 | while IFS= read -r -d '' file; do python -m py_compile "$file"; done`

------
https://chatgpt.com/codex/tasks/task_e_6856271307b8832eb257fe22b25ef829