### PR TITLE
Add nsd_columns to domain config

### DIFF
--- a/infrastructure/config/domain.py
+++ b/infrastructure/config/domain.py
@@ -6,7 +6,22 @@ WORDS_TO_REMOVE = [
     "EXTRAJUDICIAL",
     "EM RECUPERACAO JUDICIAL",
     "EM REC JUDICIAL",
-    "EMPRESA FALIDA"
+    "EMPRESA FALIDA",
+]
+
+# Default column names for NSD related data structures
+NSD_COLUMNS = [
+    "nsd",
+    "company_name",
+    "quarter",
+    "version",
+    "nsd_type",
+    "dri",
+    "auditor",
+    "responsible_auditor",
+    "protocol",
+    "sent_date",
+    "reason",
 ]
 
 @dataclass(frozen=True)
@@ -16,9 +31,11 @@ class DomainConfig:
 
     Attributes:
         words_to_remove (list): A list of words to be removed, initialized with the default value from WORDS_TO_REMOVE.
+        nsd_columns (list): Default column names for NSD data structures.
     """
-    # Configuration attributes with defaults from WORDS_TO_REMOVE
+    # Configuration attributes with defaults
     words_to_remove: list = field(default_factory=lambda: WORDS_TO_REMOVE.copy())
+    nsd_columns: list = field(default_factory=lambda: NSD_COLUMNS.copy())
 
 def load_domain_config() -> DomainConfig:
     """
@@ -30,4 +47,5 @@ def load_domain_config() -> DomainConfig:
     # Load domain settings using default constants
     return DomainConfig(
         words_to_remove=WORDS_TO_REMOVE,
+        nsd_columns=NSD_COLUMNS,
     )


### PR DESCRIPTION
## Summary
- store a new list of NSD column names in `infrastructure/config/domain.py`
- expose `nsd_columns` via `DomainConfig` and `load_domain_config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856273717a8832e8fff181c2fede965