### PR TITLE
Improve NSD scraper

### DIFF
--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -55,7 +55,9 @@ class CLIController:
         self.logger.log("Start NSD Sync Use Case", level="info")
 
         repo = SQLiteNSDRepository(config=self.config, logger=self.logger)
-        scraper = NsdScraper(config=self.config, logger=self.logger)
+        scraper = NsdScraper(
+            config=self.config, logger=self.logger, data_cleaner=self.data_cleaner
+        )
         service = NsdService(logger=self.logger, repository=repo, scraper=scraper)
 
         service.run()


### PR DESCRIPTION
## Summary
- inject DataCleaner into `NsdScraper`
- use real CVM URL
- parse NSD HTML with CSS ids and normalize data
- stop on missing sent date
- pass DataCleaner when constructing `NsdScraper`

## Testing
- `pytest -q`
- `python -m py_compile infrastructure/scrapers/nsd_scraper.py presentation/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6856c02845f4832e83bef129b5a1b3c2