### PR TITLE
Improve threaded company scraping

### DIFF
--- a/infrastructure/helpers/thread_utils.py
+++ b/infrastructure/helpers/thread_utils.py
@@ -28,5 +28,5 @@ class WorkerThreadIdentifier:
             str: Nome como "W1", "W2", etc.
         """
         if not hasattr(self._thread_local, "worker_name"):
-            self._thread_local.worker_name = f"{next(self._counter)}"
-        return str(threading.get_ident())
+            self._thread_local.worker_name = f"W{next(self._counter)}"
+        return self._thread_local.worker_name


### PR DESCRIPTION
## Summary
- fix WorkerThreadIdentifier naming logic
- share code between threaded and single company scraping
- implement producer/consumer queue with sentinels for company scraper

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`
- `ruff format infrastructure/scrapers/company_b3_scraper.py infrastructure/helpers/thread_utils.py`
- `ruff check infrastructure/scrapers/company_b3_scraper.py infrastructure/helpers/thread_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6858c5026c78832e9c24b45d79cae76c