### PR TITLE
Add cloudscraper to fetch utils

### DIFF
--- a/infrastructure/helpers/fetch_utils.py
+++ b/infrastructure/helpers/fetch_utils.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
-import requests
+
 import random
-import time
+import ssl
 from typing import Optional
+
+import certifi
+import cloudscraper
+import requests
+
 from infrastructure.config import Config
 from infrastructure.logging import Logger
 from infrastructure.helpers.time_utils import TimeUtils
@@ -31,12 +36,50 @@ class FetchUtils:
             self.logger.log(f"Header generation failed: {e}", level="warning")
             return {
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                              "(KHTML, like Gecko) Chrome/114.0.5735.199 Safari/537.36",
+                "(KHTML, like Gecko) Chrome/114.0.5735.199 Safari/537.36",
                 "Referer": "https://www.google.com/",
                 "Accept-Language": "en-US,en;q=0.9",
             }
 
-    def test_internet(self, url: Optional[str] = None, timeout: Optional[int] = None) -> bool:
+    def create_scraper(self, insecure: bool = False):
+        """Return a configured cloudscraper session.
+
+        Args:
+            insecure: Whether to disable SSL verification (useful for some domains).
+
+        Returns:
+            Configured cloudscraper session.
+        """
+        headers = self.header_random()
+
+        if insecure:
+            context = ssl.create_default_context()
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
+            class InsecureAdapter(requests.adapters.HTTPAdapter):
+                def init_poolmanager(self, *args, **kwargs):
+                    kwargs["ssl_context"] = context
+                    self.poolmanager = (
+                        requests.packages.urllib3.poolmanager.PoolManager(
+                            *args, **kwargs
+                        )
+                    )
+
+            session = requests.Session()
+            session.mount("https://", InsecureAdapter())
+            session.headers.update(headers)
+            scraper = cloudscraper.create_scraper(sess=session)
+        else:
+            scraper = cloudscraper.create_scraper()
+            scraper.headers.update(headers)
+            scraper.verify = certifi.where()
+
+        return scraper
+
+    def test_internet(
+        self, url: Optional[str] = None, timeout: Optional[int] = None
+    ) -> bool:
         """
         Checks if internet connection is active via HTTP GET request.
         """
@@ -50,22 +93,29 @@ class FetchUtils:
             self.logger.log(f"Internet test failed: {e}", level="debug")
             return False
 
-    def fetch_with_retry(self, scraper, url: str, max_attempts: Optional[int] = None, timeout: Optional[int] = None):
-        """
-        Fetches a URL with retry and randomized headers.
-        """
+    def fetch_with_retry(
+        self,
+        scraper: Optional[requests.Session],
+        url: str,
+        max_attempts: Optional[int] = None,
+        timeout: Optional[int] = None,
+        insecure: bool = False,
+    ):
+        """Fetch a URL with retries, recreating the scraper on failure."""
+
         max_attempts = max_attempts or self.config.scraping.max_attempts or 5
         timeout = timeout or self.config.scraping.timeout or 5
+        scraper = scraper or self.create_scraper(insecure=insecure)
 
         for attempt in range(1, max_attempts + 1):
             try:
-                response = scraper.get(url, headers=self.header_random())
+                response = scraper.get(url, timeout=timeout)
                 if response.status_code == 200:
                     return response
             except Exception as e:
                 self.logger.log(f"Attempt {attempt} failed: {e}", level="warning")
 
-            time_utils = TimeUtils(self.config)
-            time_utils.sleep_dynamic()
+            TimeUtils(self.config).sleep_dynamic()
+            scraper = self.create_scraper(insecure=insecure)
 
         raise ConnectionError(f"Failed to fetch {url} after {max_attempts} attempts.")

--- a/infrastructure/scrapers/company_b3_scraper.py
+++ b/infrastructure/scrapers/company_b3_scraper.py
@@ -7,7 +7,6 @@ from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 import threading
 
-import requests
 
 from infrastructure.config import Config
 from infrastructure.logging import Logger
@@ -62,8 +61,8 @@ class CompanyB3Scraper:
         self.endpoint_detail = config.b3.company_endpoint["detail"]
         self.endpoint_financial = config.b3.company_endpoint["financial"]
 
-        # Initialize a requests session for HTTP requests
-        self.session = requests.Session()
+        # Initialize a cloudscraper session for HTTP requests
+        self.session = self.fetch_utils.create_scraper()
 
     def fetch_all(
         self,

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import time
 from typing import List, Dict, Optional, Callable
 
-import requests
 from bs4 import BeautifulSoup
 import re
 
@@ -22,7 +21,7 @@ class NsdScraper:
         self.logger = logger
         self.data_cleaner = data_cleaner
         self.fetch_utils = FetchUtils(config, logger)
-        self.session = requests.Session()
+        self.session = self.fetch_utils.create_scraper()
 
         self.nsd_endpoint = self.config.b3.nsd_endpoint
 


### PR DESCRIPTION
## Summary
- add cloudscraper dependency to `FetchUtils`
- create helper method to build a cloudscraper session (optionally insecure)
- retry logic now recreates the scraper on failures
- use the new session in B3 and NSD scrapers

## Testing
- `ruff format infrastructure/helpers/fetch_utils.py`
- `ruff check infrastructure/helpers/fetch_utils.py --fix`
- `ruff format infrastructure/scrapers/company_b3_scraper.py`
- `ruff check infrastructure/scrapers/company_b3_scraper.py --fix`
- `ruff format infrastructure/scrapers/nsd_scraper.py`
- `ruff check infrastructure/scrapers/nsd_scraper.py --fix`
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c8785f8c832eaf51a20f31847f56