### PR TITLE
Replace cloudscraper with requests session

### DIFF
--- a/infrastructure/scrapers/company_b3_scraper.py
+++ b/infrastructure/scrapers/company_b3_scraper.py
@@ -61,7 +61,7 @@ class CompanyB3Scraper:
         self.endpoint_detail = config.b3.company_endpoint["detail"]
         self.endpoint_financial = config.b3.company_endpoint["financial"]
 
-        # Initialize a cloudscraper session for HTTP requests
+        # Initialize a requests session for HTTP requests
         self.session = self.fetch_utils.create_scraper()
 
     def fetch_all(


### PR DESCRIPTION
## Summary
- remove cloudscraper from FetchUtils
- rework `create_scraper` to return a plain `requests.Session`
- update retry logic in `fetch_with_retry` to recreate session when blocked
- adjust comment in CompanyB3Scraper

## Testing
- `ruff format infrastructure/helpers/fetch_utils.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py`
- `ruff check infrastructure/helpers/fetch_utils.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py --fix`
- `python -m compileall -q infrastructure/helpers/fetch_utils.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_6858cbde94f4832e95c06267aaccab01