### PR TITLE
Introduce detail DTO and mapping layer

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -1,1 +1,3 @@
-# Aplication layer entry point (kept empty to avoid tight coupling between submodules)
+from .mappers.company_mapper import CompanyMapper
+
+__all__ = ["CompanyMapper"]

--- a/application/mappers/company_mapper.py
+++ b/application/mappers/company_mapper.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from infrastructure.helpers.data_cleaner import DataCleaner
+from domain.dto import (
+    RawBaseCompanyDTO,
+    RawDetailCompanyDTO,
+    RawParsedCompanyDTO,
+)
+
+
+class CompanyMapper:
+    """Merge base and detail company data into a parsed DTO."""
+
+    def __init__(self, data_cleaner: DataCleaner):
+        self.data_cleaner = data_cleaner
+
+    def merge(
+        self,
+        base: RawBaseCompanyDTO,
+        detail: RawDetailCompanyDTO,
+    ) -> RawParsedCompanyDTO:
+        codes = detail.other_codes
+        ticker_codes = [c.code for c in codes if c.code]
+        isin_codes = [c.isin for c in codes if c.isin]
+
+        industry = detail.industry_classification or ""
+        parts = [p.strip() for p in industry.split("/")]
+
+        ticker = self.data_cleaner.clean_text(base.issuing_company)
+        company_name = self.data_cleaner.clean_text(base.company_name)
+        cvm_code = self.data_cleaner.clean_text(base.cvm_code)
+        cnpj = self.data_cleaner.clean_text(detail.cnpj)
+        trading_name = self.data_cleaner.clean_text(detail.trading_name)
+        listing = self.data_cleaner.clean_text(detail.listing_segment)
+        registrar = self.data_cleaner.clean_text(detail.registrar)
+        website = detail.website
+        sector = self.data_cleaner.clean_text(parts[0]) if len(parts) > 0 else None
+        subsector = (
+            self.data_cleaner.clean_text(parts[1]) if len(parts) > 1 else None
+        )
+        segment = self.data_cleaner.clean_text(parts[2]) if len(parts) > 2 else None
+
+        market_indicator = self.data_cleaner.clean_text(
+            base.market_indicator or detail.market_indicator
+        )
+        bdr_type = self.data_cleaner.clean_text(base.type_bdr or detail.type_bdr)
+        listing_date = self.data_cleaner.clean_date(base.date_listing)
+        status = self.data_cleaner.clean_text(base.status or detail.status)
+        segment_b3 = self.data_cleaner.clean_text(base.segment_b3)
+        segment_eng = self.data_cleaner.clean_text(base.segment_eng)
+        company_type = self.data_cleaner.clean_text(base.company_type)
+        market = self.data_cleaner.clean_text(base.market or detail.market)
+        industry_classification = detail.industry_classification
+        industry_classification_eng = detail.industry_classification_eng
+        activity = detail.activity
+        institution_common = self.data_cleaner.clean_text(detail.institution_common)
+        institution_preferred = self.data_cleaner.clean_text(
+            detail.institution_preferred
+        )
+        last_date = self.data_cleaner.clean_date(detail.last_date)
+        describle_category_bvmf = self.data_cleaner.clean_text(
+            detail.describle_category_bvmf
+        )
+        quotation_date = self.data_cleaner.clean_date(detail.date_quotation)
+
+        return RawParsedCompanyDTO(
+            ticker=ticker,
+            company_name=company_name,
+            cvm_code=cvm_code,
+            cnpj=cnpj,
+            trading_name=trading_name,
+            listing=listing,
+            registrar=registrar,
+            website=website,
+            ticker_codes=ticker_codes,
+            isin_codes=isin_codes,
+            other_codes=codes,
+            sector=sector,
+            subsector=subsector,
+            segment=segment,
+            market_indicator=market_indicator,
+            bdr_type=bdr_type,
+            listing_date=listing_date,
+            status=status,
+            segment_b3=segment_b3,
+            segment_eng=segment_eng,
+            company_type=company_type,
+            market=market,
+            industry_classification=industry_classification,
+            industry_classification_eng=industry_classification_eng,
+            activity=activity,
+            has_quotation=detail.has_quotation,
+            institution_common=institution_common,
+            institution_preferred=institution_preferred,
+            last_date=last_date,
+            has_emissions=detail.has_emissions,
+            has_bdr=detail.has_bdr,
+            describle_category_bvmf=describle_category_bvmf,
+            quotation_date=quotation_date,
+        )

--- a/domain/dto/__init__.py
+++ b/domain/dto/__init__.py
@@ -1,5 +1,17 @@
 from .company_dto import CompanyDTO
 from .nsd_dto import NSDDTO
-from .raw_company_dto import CodeDTO, RawParsedCompanyDTO
+from .raw_company_dto import (
+    CodeDTO,
+    RawBaseCompanyDTO,
+    RawDetailCompanyDTO,
+    RawParsedCompanyDTO,
+)
 
-__all__ = ["CompanyDTO", "NSDDTO", "RawParsedCompanyDTO", "CodeDTO"]
+__all__ = [
+    "CompanyDTO",
+    "NSDDTO",
+    "RawParsedCompanyDTO",
+    "RawBaseCompanyDTO",
+    "RawDetailCompanyDTO",
+    "CodeDTO",
+]

--- a/domain/dto/raw_company_dto.py
+++ b/domain/dto/raw_company_dto.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Optional
+import json
 
 
 @dataclass(frozen=True)
@@ -9,6 +10,96 @@ class CodeDTO:
 
     code: Optional[str]
     isin: Optional[str]
+
+
+@dataclass(frozen=True)
+class RawBaseCompanyDTO:
+    """DTO for base company data from the list endpoint."""
+
+    issuing_company: Optional[str]
+    company_name: Optional[str]
+    cvm_code: Optional[str]
+    market_indicator: Optional[str]
+    type_bdr: Optional[str]
+    date_listing: Optional[str]
+    status: Optional[str]
+    segment_b3: Optional[str]
+    segment_eng: Optional[str]
+    company_type: Optional[str]
+    market: Optional[str]
+
+    @staticmethod
+    def from_dict(raw: dict) -> "RawBaseCompanyDTO":
+        return RawBaseCompanyDTO(
+            issuing_company=raw.get("issuingCompany"),
+            company_name=raw.get("companyName"),
+            cvm_code=raw.get("codeCVM"),
+            market_indicator=raw.get("marketIndicator"),
+            type_bdr=raw.get("typeBDR"),
+            date_listing=raw.get("dateListing"),
+            status=raw.get("status"),
+            segment_b3=raw.get("segment"),
+            segment_eng=raw.get("segmentEng"),
+            company_type=raw.get("type"),
+            market=raw.get("market"),
+        )
+
+
+@dataclass(frozen=True)
+class RawDetailCompanyDTO:
+    """DTO for detailed company data from the detail endpoint."""
+
+    cnpj: Optional[str]
+    trading_name: Optional[str]
+    listing_segment: Optional[str]
+    registrar: Optional[str]
+    website: Optional[str]
+    other_codes: List[CodeDTO]
+    market_indicator: Optional[str]
+    type_bdr: Optional[str]
+    status: Optional[str]
+    market: Optional[str]
+    industry_classification: Optional[str]
+    industry_classification_eng: Optional[str]
+    activity: Optional[str]
+    has_quotation: Optional[bool]
+    institution_common: Optional[str]
+    institution_preferred: Optional[str]
+    last_date: Optional[datetime]
+    has_emissions: Optional[bool]
+    has_bdr: Optional[bool]
+    describle_category_bvmf: Optional[str]
+    date_quotation: Optional[datetime]
+
+    @staticmethod
+    def from_dict(raw: dict) -> "RawDetailCompanyDTO":
+        codes = raw.get("otherCodes") or []
+        if isinstance(codes, str):
+            codes = json.loads(codes)
+        code_dtos = [CodeDTO(code=c.get("code"), isin=c.get("isin")) for c in codes]
+        return RawDetailCompanyDTO(
+            cnpj=raw.get("cnpj"),
+            trading_name=raw.get("tradingName"),
+            listing_segment=raw.get("listingSegment"),
+            registrar=raw.get("registrar"),
+            website=raw.get("website"),
+            other_codes=code_dtos,
+            market_indicator=raw.get("marketIndicator"),
+            type_bdr=raw.get("typeBDR"),
+            status=raw.get("status"),
+            market=raw.get("market"),
+            industry_classification=raw.get("industryClassification"),
+            industry_classification_eng=raw.get("industryClassificationEng"),
+            activity=raw.get("activity"),
+            has_quotation=raw.get("hasQuotation"),
+            institution_common=raw.get("institutionCommon"),
+            institution_preferred=raw.get("institutionPreferred"),
+            last_date=raw.get("lastDate"),
+            has_emissions=raw.get("hasEmissions"),
+            has_bdr=raw.get("hasBDR"),
+            describle_category_bvmf=raw.get("describleCategoryBVMF"),
+            date_quotation=raw.get("dateQuotation"),
+        )
 
 
 @dataclass(frozen=True)

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -4,6 +4,7 @@ from infrastructure.logging import Logger
 from infrastructure.repositories import SQLiteCompanyRepository
 from infrastructure.scrapers.company_b3_scraper import CompanyB3Scraper
 from infrastructure.scrapers.nsd_scraper import NsdScraper
+from application import CompanyMapper
 from application.services.company_services import CompanyService
 from application.services.nsd_service import NsdService
 from infrastructure.repositories.nsd_repository import SQLiteNSDRepository
@@ -40,8 +41,12 @@ class CLIController:
         self.logger.log("Start Companies Sync Use Case", level="info")
 
         company_repo = SQLiteCompanyRepository(config=self.config, logger=self.logger)
+        mapper = CompanyMapper(self.data_cleaner)
         company_scraper = CompanyB3Scraper(
-            config=self.config, logger=self.logger, data_cleaner=self.data_cleaner
+            config=self.config,
+            logger=self.logger,
+            data_cleaner=self.data_cleaner,
+            mapper=mapper,
         )
         company_service = CompanyService(
             config=self.config,


### PR DESCRIPTION
## Summary
- support typed company detail data with `RawDetailCompanyDTO`
- add `RawBaseCompanyDTO` for list data
- implement `CompanyMapper` to merge base and detail
- wire mapper into CLI and scraper

## Testing
- `python -m compileall -q application infrastructure domain presentation`
- `python run.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685b3530e4ec832e8d3b70a28a355ff4