### PR TITLE
Improve architecture docs and instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,11 @@ They are orchestrated by the CLI controller (`CLIController`), which boots the s
 
 ### CompanyService
 - **Layer:** Application  
-- **Role:** Orchestrates synchronization of company metadata from B3 to the local database.  
+- **Role:** Coordinates synchronization of company metadata from B3 to the local database.  
 - **Dependencies:**  
   - `SyncCompaniesUseCase` (application use case)  
-  - `CompanyB3Scraper` (infrastructure scraper)  
-  - `SQLiteCompanyRepository` (persistence adapter)  
+  - `CompanyB3Scraper` (infrastructure scraper implementing `CompanySource`)  
+  - `SQLiteCompanyRepository` (persistence adapter implementing `CompanyRepository`)  
 - **Workflow:** logger → use case → repository  
 - **I/O:** `CompanyDTO`
 
@@ -41,12 +41,13 @@ They are orchestrated by the CLI controller (`CLIController`), which boots the s
   1. Load existing CVM codes  
   2. Call `scraper.fetch_all(skip=existing, save_callback=self._save_batch)`  
   3. Convert each raw dict to `CompanyDTO` and `repository.save_all(...)`
+- **Note:** This use case coordinates scraping and persistence, but only the repository performs writes. The use case itself has no direct side effects.
 
 ### NsdService
 - **Layer:** Application  
-- **Role:** Orchestrates scraping and persistence of NSD (document number) records.  
+- **Role:** Coordinates scraping and persistence of NSD (document number) records.  
 - **Dependencies:**  
-  - `SyncNSDUseCase` (if exists) or direct use of `NsdScraper` + `SQLiteNSDRepository`  
+  - `SyncNSDUseCase` (if exists) or direct use of `NsdScraper` (implements `NsdSource`) + `SQLiteNSDRepository` (implements `NSDRepository`)  
 - **I/O:** `NSDDTO`
 
 ---

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,11 @@ A estrutura segue o padrão da **Arquitetura Hexagonal (Ports and Adapters)** co
 >
 > O dono da FLY possui alguns cadernos DTOs diferentes. Um DTO para os dados cadastrais das companhias, como nome, CNPJ, ticker de negociação e outras informações desse tipo. Outro DTO para controlar a sequência das publicações dos relatórios da bolsa de valores (número serial de documento, NSD). Também existe outro DTO para registrar o conteúdo das publicações dos demonstrativos financeiros das companhias (DFP, ITR), que contém dados como patrimônio, lucro líquido do trimestre e outras informações periódicas.
 
-## 1.2. Portas e Interfaces
+## 1.2. Entidades
+As entidades representam objetos do domínio que encapsulam regras e comportamentos. Embora ainda não estejam implementadas neste projeto, elas futuramente concentrarão validações e lógica de negócio. Diferentemente dos DTOs, que são dados puros, as entidades manterão métodos e garantias de consistência.
+
+
+## 1.3. Portas e Interfaces
 São contratos abstratos formais que o domínio usa para padronizar a comunicação com o mundo exterior ao código. `Source` para obter dados e `Repository` para salvar e recuperar dados. Elas definem de forma agnóstica o que precisa ser feito, sem definir de que forma será feito. Apenas definem assinaturas de métodos, sem lógica interna. O objetivo é impor de forma radical um desacoplamento entre a lógica do negócio e as dependências de tecnologia da infraestrutura.
 
 > A **persistência** é como o **depósito** da empresa FLY, onde os arquivos ficam guardados de forma permanente e organizada. O `Repository` é como o **manual de regras do depósito**, que define as únicas operações permitidas no arquivo oficial.

--- a/LOGGING_CONTRACT.md
+++ b/LOGGING_CONTRACT.md
@@ -3,9 +3,15 @@
 This document summarizes the expected log messages emitted by the main workflow.
 
 ## SyncCompaniesUseCase
-- "Start SyncCompaniesUseCase" when the use case is initialized.
-- "Get Existing Companies from B3" when fetching the initial list from the API.
+- "Start SyncCompaniesUseCase" when the use case begins.
+- "Get Existing Companies from B3" when loading the initial list.
 - "Start CompanyB3Scraper fetch_all" when iterating over company details.
-- "Saved X companies" when a batch is persisted.
+- "Saved X companies" after each persistence batch.
 
-All other modules follow the same pattern of emitting a start message and relevant progress logs.
+Example:
+```json
+{"level": "info", "message": "Saved 50 companies", "progress": {"current": 50, "total": 200}, "extra": {"batch": 1}}
+```
+
+## Responsibilities
+Each processing agent must emit logs upon start, at meaningful checkpoints, and after major operations (e.g., save, skip, error). Scrapers and UseCases are required to log these events. Mappers and helper utilities may log as needed but are optional.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Finance Ledger Yearly (FLY)
 
 ### What is This?
-Finance Ledger Yearly (**FLY**) is a comprehensive **financial data app** designed to automate the extraction and processing of financial data from various online sources. The app retrieves detailed company information, financial documents, and **standardized financial statements**, storing this data in a local database for easy access and analysis.
+Finance Ledger Yearly (FLY) gathers financial documents from companies listed on B3. It scrapes company profiles, sequential document numbers (NSDs) and standardized statements, storing everything in a local database for analysis.
 
 ## How It Works, Behind the Wheels
-FLY is designed following the Hexagonal Architecture (Ports and Adapters) pattern to ensure a clear separation between business logic and technical details. For a complete explanation of the design, see our [Architecture Document](ARCHITECTURE.md).
+FLY follows the Hexagonal Architecture (Ports and Adapters) to keep business logic separate from infrastructure. The list below outlines the core steps in fetching company data and financial documents. For a complete explanation, see our [Architecture Document](ARCHITECTURE.md).
 
 1. **Company Information Scraping**  
    - Finds company names, tickers, sectors, and registration data.
@@ -24,7 +24,7 @@ FLY is designed following the Hexagonal Architecture (Ports and Adapters) patter
    - Matches stock performance with financial statements.
 
 5. **Performance & Optimization**
-   - Processes data using a configurable number of workers.
+   - Supports concurrent processing with a configurable number of workers for improved performance.
    - Tracks memory and execution time to keep things running smoothly.
 
 
@@ -54,7 +54,7 @@ pip install -r requirements.txt
 ### **Run the Full System**
 To run everything at once and process all available data:
 ```sh
-python b3.py
+python run.py
 ```
 
 ## Contributing

--- a/code style manual.md
+++ b/code style manual.md
@@ -4,6 +4,24 @@ This manual outlines coding style guidelines to ensure consistency, readability,
 
 ---
 
+## 6. Architecture and Design
+- Use best softwarte architecture principles. Low Coupling and High Cohesion. 
+- Consider MVC (Model-View-Controller), DDD (Domain-Driven Design), Hexagonal Architecture (Ports and Adapters), Clean Architecture, Microservices, Monolith, and Event-Driven Architecture. 
+- Consider MVC, DDD, hexagonal, clean, microservices, monolith, event-driven and others.
+- Use logical layers (presentation, application, domain, infrastructure).
+- Use components within layers (Controller, Domain, Service, Repository, Entities)
+- VO, aggregates, business rules, DTO.
+- For persistence and ORM, SQLAlchemy and SQLite.
+
+### 6.1 Single Responsibility
+- **Focus**: Every function must implement exactly one business or technical responsibility, in accordance with the Single Responsibility Principle.
+
+### 6.2 Parameter Handling
+- **Descriptive Names**: Use clear and descriptive names for parameters.
+- **Default Values**: Provide default values for optional parameters.
+- **Grouping**: If a function requires many parameters, consider grouping them into a dictionary or passing an object. Use dataclasses and DTO whenever possible. 
+
+
 ## 1. Code Structure and Organization
 
 ### 1.1 Import Statements
@@ -206,25 +224,6 @@ ruff check . --fix  # aplicar lint e autofix
 
 ### 5.2 Indentation
 - **Spacing**: Use 4 spaces per indentation level. Do not use tabs.
-
-## 6. Architecture and Design
-- Use best softwarte architecture principles. Low Coupling and High Cohesion. 
-- Consider MVC (Model-View-Controller), DDD (Domain-Driven Design), Hexagonal Architecture (Ports and Adapters), Clean Architecture, Microservices, Monolith, and Event-Driven Architecture. 
-- Consider MVC, DDD, hexagonal, clean, microservices, monolith, event-driven and others.
-- Use logical layers (presentation, application, domain, infrastructure).
-- Use components within layers (Controller, Domain, Service, Repository, Entities)
-- VO, aggregates, business rules, DTO.
-- For persistence and ORM, SQLAlchemy and SQLite.
-
-### 6.1 Single Responsibility
-- **Focus**: Each function should have a single, well-defined responsibility. If a function does too much, refactor it into smaller, more focused functions.
-
-### 6.2 Parameter Handling
-- **Descriptive Names**: Use clear and descriptive names for parameters.
-- **Default Values**: Provide default values for optional parameters.
-- **Grouping**: If a function requires many parameters, consider grouping them into a dictionary or passing an object. Use dataclasses and DTO whenever possible. 
-
-## 7. Performance Logging and Benchmarking
 
 ### 7.1 Performance Logging
 - **Guidelines**: All time-based measurements should use a centralized performance logging function rather than time.time() directly. Purpose: Standardized performance logging ensures consistent reporting and benchmarking across modules.

--- a/scope.md
+++ b/scope.md
@@ -3,6 +3,12 @@
 ## **1. Objective**
 The **Finance Ledger Yearly (FLY)** project is designed to **capture, process, and store** financial data related to **companies, NSDs (Sequential Document Numbers), corporate events, and stock market data**. The system ensures **periodic updates** by identifying and processing only **new or modified** data.
 
+### Architecture Overview
+- **Presentation layer:** processors such as `company_processor.py` invoke application services.
+- **Application layer:** services like `CompanyService` and `NsdService` coordinate use cases.
+- **Domain layer:** DTOs and planned Entities hold the business rules.
+- **Infrastructure layer:** scrapers and repositories implement the external interfaces.
+
 ## **2. Data Capture Overview**
 The system extracts data from various online sources using **web scraping** and **automated data processing**. It is structured into the following main components:
 
@@ -34,7 +40,7 @@ The system extracts data from various online sources using **web scraping** and 
 **Modules:** `nsd_processor.py`
 - **Sequential NSD Capture:**
   - Extract published **NSD numbers, submission dates, and company associations**.
-  - Implement **gap filling & dynamic sequence tracking**:
+  - Detects and fills gaps in document sequences through intelligent backfilling and estimation logic:
     - Detect **missing NSD numbers** and intelligently estimate missing data.
     - Adjust for **irregular NSD publication** patterns.
 
@@ -43,7 +49,7 @@ The system extracts data from various online sources using **web scraping** and 
   - Exception handling ensures **no failures in sequential data processing**.
 
 - **Database Storage:**
-  - Data is saved to `tbl_nsd`, **maintaining historical versions**.
+  - The repository saves data in `tbl_nsd`, **maintaining historical versions**.
 
 ---
 
@@ -60,7 +66,7 @@ The system extracts data from various online sources using **web scraping** and 
     - **Accounts starting with '6' or '7'** → Ensure correct aggregation.
 
 - **Storage & Versioning:**
-  - Data is stored in:
+  - The repository stores data in:
     - `tbl_statements_raw` (Raw statements before processing)
     - `tbl_statements_normalized` (Standardized financial data)
   - Only the **latest version** is marked as "current" while preserving **historical changes**.


### PR DESCRIPTION
## Summary
- clarify separation between DTOs and entities
- refine agent responsibilities and interfaces
- improve README intro and command names
- expand logging contract with examples
- move architecture section to top of style guide
- update scope overview and wording

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3d073264832e8eff5f61da1d55e6