### PR TITLE
Introduce WorkerPool executor

### DIFF
--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -1,0 +1,3 @@
+from .worker_pool_port import WorkerPoolPort, Metrics, LoggerPort
+
+__all__ = ["WorkerPoolPort", "Metrics", "LoggerPort"]

--- a/domain/ports/worker_pool_port.py
+++ b/domain/ports/worker_pool_port.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Optional, Protocol, Tuple, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+class LoggerPort(Protocol):
+    def log(
+        self,
+        message: str,
+        level: str = "info",
+        progress: Optional[dict] = None,
+        extra: Optional[dict] = None,
+        worker_id: Optional[str] = None,
+    ) -> None: ...
+
+
+@dataclass
+class Metrics:
+    elapsed_time: float
+    download_bytes: int
+    failures: int = 0
+
+
+class WorkerPoolPort(Protocol):
+    def run(
+        self,
+        tasks: Iterable[T],
+        processor: Callable[[T], R],
+        logger: LoggerPort,
+        post_callback: Optional[Callable[[List[R]], None]] = None,
+    ) -> Tuple[List[R], Metrics]: ...

--- a/infrastructure/helpers/__init__.py
+++ b/infrastructure/helpers/__init__.py
@@ -1,5 +1,6 @@
 from .fetch_utils import FetchUtils
 from .time_utils import TimeUtils
 from .data_cleaner import DataCleaner
+from .worker_pool import WorkerPool
 
-__all__ = ["FetchUtils", "TimeUtils", "DataCleaner"]
+__all__ = ["FetchUtils", "TimeUtils", "DataCleaner", "WorkerPool"]

--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
+from typing import Callable, Iterable, List, Optional, Tuple, TypeVar
+
+from infrastructure.config import Config
+from infrastructure.helpers.byte_formatter import ByteFormatter
+from domain.ports.worker_pool_port import LoggerPort, Metrics, WorkerPoolPort
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+class WorkerPool(WorkerPoolPort):
+    def __init__(self, config: Config, max_workers: Optional[int] = None):
+        self.config = config
+        self.max_workers = max_workers or config.global_settings.max_workers or 1
+        self.byte_formatter = ByteFormatter()
+
+    def run(
+        self,
+        tasks: Iterable[T],
+        processor: Callable[[T], R],
+        logger: LoggerPort,
+        post_callback: Optional[Callable[[List[R]], None]] = None,
+    ) -> Tuple[List[R], Metrics]:
+        results: List[R] = []
+        queue: Queue = Queue(self.config.global_settings.queue_size)
+        lock = threading.Lock()
+        sentinel = object()
+
+        start_time = time.time()
+
+        def worker(worker_id: str) -> int:
+            downloaded = 0
+            while True:
+                item = queue.get()
+                if item is sentinel:
+                    queue.task_done()
+                    return downloaded
+                try:
+                    result = processor(item)
+                    downloaded += len(json.dumps(result, default=str).encode("utf-8"))
+                    with lock:
+                        results.append(result)
+                    logger.log("task processed", level="debug", worker_id=worker_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.log(
+                        f"worker error: {exc}", level="warning", worker_id=worker_id
+                    )
+                finally:
+                    queue.task_done()
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures = [
+                executor.submit(worker, uuid.uuid4().hex[:8])
+                for _ in range(self.max_workers)
+            ]
+
+            for task in tasks:
+                queue.put(task)
+
+            for _ in range(self.max_workers):
+                queue.put(sentinel)
+
+            queue.join()
+
+        bytes_total = sum(f.result() for f in futures)
+        elapsed = time.time() - start_time
+        metrics = Metrics(elapsed_time=elapsed, download_bytes=bytes_total)
+
+        if callable(post_callback):
+            post_callback(results)
+
+        logger.log(
+            f"Executed {len(results)} tasks in {elapsed:.2f}s ({self.byte_formatter.format_bytes(bytes_total)})",
+            level="info",
+        )
+
+        return results, metrics

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -3,6 +3,7 @@ from infrastructure.logging import Logger
 
 from infrastructure.repositories import SQLiteCompanyRepository
 from infrastructure.scrapers.company_b3_scraper import CompanyB3Scraper
+from infrastructure.helpers import WorkerPool
 from infrastructure.scrapers.nsd_scraper import NsdScraper
 from application import CompanyMapper
 from application.services.company_services import CompanyService
@@ -42,11 +43,13 @@ class CLIController:
 
         company_repo = SQLiteCompanyRepository(config=self.config, logger=self.logger)
         mapper = CompanyMapper(self.data_cleaner)
+        executor = WorkerPool(self.config)
         company_scraper = CompanyB3Scraper(
             config=self.config,
             logger=self.logger,
             data_cleaner=self.data_cleaner,
             mapper=mapper,
+            executor=executor,
         )
         company_service = CompanyService(
             config=self.config,


### PR DESCRIPTION
## Summary
- define `WorkerPoolPort` interface and metrics in domain layer
- implement `WorkerPool` helper using `ThreadPoolExecutor`
- inject worker pool into `CompanyB3Scraper` and CLI controller
- adapt company scraping methods to use the new executor

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c19b314f0832ebd71e4bd44989bf4