### PR TITLE
Add per-item callback to WorkerPool

### DIFF
--- a/domain/ports/worker_pool_port.py
+++ b/domain/ports/worker_pool_port.py
@@ -15,7 +15,7 @@ class LoggerPort(Protocol):
         progress: Optional[dict] = None,
         extra: Optional[dict] = None,
         worker_id: Optional[str] = None,
-    ) -> None: 
+    ) -> None:
         raise NotImplemented
 
 
@@ -32,6 +32,7 @@ class WorkerPoolPort(Protocol):
         tasks: Iterable[T],
         processor: Callable[[T], R],
         logger: LoggerPort,
+        on_result: Optional[Callable[[R], None]] = None,
         post_callback: Optional[Callable[[List[R]], None]] = None,
-    ) -> Tuple[List[R], Metrics]: 
+    ) -> Tuple[List[R], Metrics]:
         raise NotImplemented


### PR DESCRIPTION
## Summary
- expose optional `on_result` hook in `WorkerPoolPort`
- implement `on_result` support in `WorkerPool`
- batch company results in `CompanyB3Scraper` using the new callback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d678cf9bc832e9ec5077f9b1680ee