### PR TITLE
Fix company sync batch logic

### DIFF
--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -4,7 +4,6 @@ from infrastructure.config import Config
 
 from infrastructure.logging import Logger
 from domain.dto.company_dto import CompanyDTO
-from domain.dto.raw_company_dto import CompanyDTO
 from infrastructure.repositories import SQLiteCompanyRepository
 from infrastructure.scrapers.company_b3_scraper import CompanyB3Scraper
 
@@ -50,5 +49,4 @@ class SyncCompaniesUseCase:
         )
 
     def _save_batch(self, buffer: List[CompanyDTO]) -> None:
-        dtos = [CompanyDTO.from_raw(item) for item in buffer if item]
-        self.repository.save_all(dtos)
+        self.repository.save_all(buffer)


### PR DESCRIPTION
## Summary
- fix imports in `SyncCompaniesUseCase`
- simplify `_save_batch` to store DTOs directly
- rework company scraper batching to use `_handle_save`

## Testing
- `python -m py_compile application/usecases/sync_companies.py infrastructure/scrapers/company_b3_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_685d6ff66260832e8cf2ee3d989fea2b