### PR TITLE
Add testing framework with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install .[dev] || true
+      - name: Ruff
+        run: ruff .
+      - name: Black
+        run: black --check .
+      - name: Isort
+        run: isort --check-only .
+      - name: Pytest
+        run: pytest --cov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.110
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false
+        args:
+          - --maxfail=1
+          - --disable-warnings
+          - --cov
+          - --cov=fly
+          - --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Finance Ledger Yearly (FLY)
+[![CI](https://github.com/faustostangler/FLY/actions/workflows/ci.yml/badge.svg)](https://github.com/faustostangler/FLY/actions/workflows/ci.yml)
+[![Coverage Status](https://img.shields.io/badge/coverage-unknown-lightgrey)](https://github.com/faustostangler/FLY/actions/workflows/ci.yml)
+
 
 ### What is This?
 Finance Ledger Yearly (FLY) gathers financial documents from companies listed on B3. It scrapes company profiles, sequential document numbers (NSDs) and standardized statements, storing everything in a local database for analysis.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fly"
+version = "0.1.0"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "ruff",
+    "black",
+    "isort",
+    "pre-commit"
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--maxfail=1 --disable-warnings --cov=fly --cov-report=term-missing"
+
+[tool.ruff]
+select = ["E", "F", "W", "I"]
+ignore = ["E501"]
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+pytest
+pytest-cov
+ruff
+black
+isort
+pre-commit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture(scope="session")
+def engine():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def SessionLocal(engine):
+    Session = sessionmaker(bind=engine)
+    return Session
+
+
+class DummyLogger:
+    def log(self, *args, **kwargs):
+        pass
+
+
+class DummyConfig:
+    class Database:
+        connection_string = "sqlite:///:memory:"
+
+    database = Database()
+
+    class Global:
+        app_name = "TEST"
+
+    global_settings = Global()

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -1,0 +1,16 @@
+import pytest
+
+from domain.dto.company_dto import CompanyDTO
+from domain.dto.nsd_dto import NSDDTO
+
+
+def test_company_dto_from_dict():
+    raw = {"ticker": "XYZ", "company_name": "Xyz Corp"}
+    dto = CompanyDTO.from_dict(raw)
+    assert dto.ticker == "XYZ"
+    assert dto.company_name == "Xyz Corp"
+
+
+def test_nsd_dto_invalid_nsd():
+    with pytest.raises(ValueError):
+        NSDDTO.from_dict({"nsd": "not_a_number"})

--- a/tests/infrastructure/test_company_repository.py
+++ b/tests/infrastructure/test_company_repository.py
@@ -1,0 +1,24 @@
+from sqlalchemy import text
+
+from domain.dto.company_dto import CompanyDTO
+from infrastructure.models.company_model import Base
+from infrastructure.repositories.company_repository import SQLiteCompanyRepository
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def test_save_all(SessionLocal, engine):
+    repo = SQLiteCompanyRepository(config=DummyConfig(), logger=DummyLogger())
+    # use shared engine
+    repo.engine = engine
+    repo.Session = SessionLocal
+    Base.metadata.create_all(engine)
+
+    companies = [
+        CompanyDTO.from_dict({"ticker": "AAA", "company_name": "Alpha"}),
+        CompanyDTO.from_dict({"ticker": "BBB", "company_name": "Beta"}),
+    ]
+    repo.save_all(companies)
+
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT COUNT(*) FROM tbl_company")).scalar()
+    assert result == 2


### PR DESCRIPTION
## Summary
- set up testing layout under `tests/`
- provide reusable fixtures in `tests/conftest.py`
- add first repository and DTO tests
- configure pytest, ruff, black and isort via `pyproject.toml`
- configure pre-commit hooks
- add GitHub Actions workflow
- include development requirements
- show CI and coverage badges in README

## Testing
- `pre-commit run --files tests/conftest.py tests/infrastructure/test_company_repository.py tests/domain/test_dtos.py pyproject.toml .pre-commit-config.yaml .github/workflows/ci.yml README.md requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da5afaeb0832e8cd2867f3c95a5ee