### PR TITLE
Fix inconsistent company field names

### DIFF
--- a/application/mappers/company_mapper.py
+++ b/application/mappers/company_mapper.py
@@ -4,7 +4,7 @@ from infrastructure.helpers.data_cleaner import DataCleaner
 from domain.dto import (
     BseCompanyDTO,
     DetailCompanyDTO,
-    CompanyDTO,
+    RawCompanyDTO,
 )
 
 
@@ -18,7 +18,7 @@ class CompanyMapper:
         self,
         base: BseCompanyDTO,
         detail: DetailCompanyDTO,
-    ) -> CompanyDTO:
+    ) -> RawCompanyDTO:
         codes = detail.other_codes
         ticker_codes = [c.code for c in codes if c.code]
         isin_codes = [c.isin for c in codes if c.isin]
@@ -35,10 +35,10 @@ class CompanyMapper:
         registrar = self.data_cleaner.clean_text(detail.registrar)
         website = detail.website
         sector = self.data_cleaner.clean_text(parts[0]) if len(parts) > 0 else None
-        subsector = (
-            self.data_cleaner.clean_text(parts[1]) if len(parts) > 1 else None
+        subsector = self.data_cleaner.clean_text(parts[1]) if len(parts) > 1 else None
+        industry_segment = (
+            self.data_cleaner.clean_text(parts[2]) if len(parts) > 2 else None
         )
-        segment = self.data_cleaner.clean_text(parts[2]) if len(parts) > 2 else None
 
         market_indicator = self.data_cleaner.clean_text(
             base.market_indicator or detail.market_indicator
@@ -46,7 +46,7 @@ class CompanyMapper:
         bdr_type = self.data_cleaner.clean_text(base.type_bdr or detail.type_bdr)
         listing_date = self.data_cleaner.clean_date(base.listing_date)
         status = self.data_cleaner.clean_text(base.status or detail.status)
-        segment_b3 = self.data_cleaner.clean_text(base.segment_b3)
+        segment = self.data_cleaner.clean_text(base.segment)
         segment_eng = self.data_cleaner.clean_text(base.segment_eng)
         company_type = self.data_cleaner.clean_text(base.company_type)
         market = self.data_cleaner.clean_text(base.market or detail.market)
@@ -58,12 +58,10 @@ class CompanyMapper:
             detail.institution_preferred
         )
         last_date = self.data_cleaner.clean_date(detail.last_date)
-        describle_category_bvmf = self.data_cleaner.clean_text(
-            detail.describle_category_bvmf
-        )
+        company_category = self.data_cleaner.clean_text(detail.company_category)
         quotation_date = self.data_cleaner.clean_date(detail.date_quotation)
 
-        return CompanyDTO(
+        return RawCompanyDTO(
             ticker=ticker,
             company_name=company_name,
             cvm_code=cvm_code,
@@ -77,12 +75,12 @@ class CompanyMapper:
             other_codes=codes,
             sector=sector,
             subsector=subsector,
-            segment=segment,
+            industry_segment=industry_segment,
             market_indicator=market_indicator,
             bdr_type=bdr_type,
             listing_date=listing_date,
             status=status,
-            segment_b3=segment_b3,
+            segment=segment,
             segment_eng=segment_eng,
             company_type=company_type,
             market=market,
@@ -95,6 +93,6 @@ class CompanyMapper:
             last_date=last_date,
             has_emissions=detail.has_emissions,
             has_bdr=detail.has_bdr,
-            describle_category_bvmf=describle_category_bvmf,
+            company_category=company_category,
             quotation_date=quotation_date,
         )

--- a/domain/dto/__init__.py
+++ b/domain/dto/__init__.py
@@ -4,13 +4,13 @@ from .raw_company_dto import (
     CodeDTO,
     BseCompanyDTO,
     DetailCompanyDTO,
-    CompanyDTO,
+    RawCompanyDTO,
 )
 
 __all__ = [
     "CompanyDTO",
     "NSDDTO",
-    "CompanyDTO",
+    "RawCompanyDTO",
     "BseCompanyDTO",
     "DetailCompanyDTO",
     "CodeDTO",

--- a/domain/dto/company_dto.py
+++ b/domain/dto/company_dto.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Optional
 import json
 
-from .raw_company_dto import CompanyDTO
+from .raw_company_dto import RawCompanyDTO
 
 
 @dataclass(frozen=True)
@@ -26,10 +26,9 @@ class CompanyDTO:
 
     company_type: Optional[str]
     status: Optional[str]
-    b3_code: Optional[str]
     company_category: Optional[str]
     corporate_name: Optional[str]
-    registration_date: Optional[str]
+    listing_date: Optional[str]
     start_situation_date: Optional[str]
     situation: Optional[str]
     situation_date: Optional[str]
@@ -59,10 +58,9 @@ class CompanyDTO:
             website=raw.get("website"),
             company_type=raw.get("company_type"),
             status=raw.get("status"),
-            b3_code=raw.get("b3_code"),
             company_category=raw.get("company_category"),
             corporate_name=raw.get("corporate_name"),
-            registration_date=raw.get("registration_date"),
+            listing_date=raw.get("listing_date"),
             start_situation_date=raw.get("start_situation_date"),
             situation=raw.get("situation"),
             situation_date=raw.get("situation_date"),
@@ -72,7 +70,7 @@ class CompanyDTO:
         )
 
     @staticmethod
-    def from_raw(raw: CompanyDTO) -> "CompanyDTO":
+    def from_raw(raw: RawCompanyDTO) -> "CompanyDTO":
         """Builds a CompanyDTO from a CompanyDTO instance."""
 
         return CompanyDTO(
@@ -84,7 +82,7 @@ class CompanyDTO:
             trading_name=raw.trading_name,
             sector=raw.sector,
             subsector=raw.subsector,
-            segment=raw.segment,
+            segment=raw.industry_segment,
             listing=raw.listing,
             activity=raw.activity,
             registrar=raw.registrar,
@@ -92,10 +90,9 @@ class CompanyDTO:
             website=raw.website,
             company_type=raw.company_type,
             status=raw.status,
-            b3_code=None,
             company_category=None,
             corporate_name=None,
-            registration_date=(
+            listing_date=(
                 raw.listing_date.strftime("%Y-%m-%d") if raw.listing_date else None
             ),
             start_situation_date=None,

--- a/domain/dto/raw_company_dto.py
+++ b/domain/dto/raw_company_dto.py
@@ -23,7 +23,7 @@ class BseCompanyDTO:
     type_bdr: Optional[str]
     listing_date: Optional[str]
     status: Optional[str]
-    segment_b3: Optional[str]
+    segment: Optional[str]
     segment_eng: Optional[str]
     company_type: Optional[str]
     market: Optional[str]
@@ -38,7 +38,7 @@ class BseCompanyDTO:
             type_bdr=raw.get("typeBDR"),
             listing_date=raw.get("dateListing"),
             status=raw.get("status"),
-            segment_b3=raw.get("segment"),
+            segment=raw.get("segment"),
             segment_eng=raw.get("segmentEng"),
             company_type=raw.get("type"),
             market=raw.get("market"),
@@ -68,7 +68,7 @@ class DetailCompanyDTO:
     last_date: Optional[datetime]
     has_emissions: Optional[bool]
     has_bdr: Optional[bool]
-    describle_category_bvmf: Optional[str]
+    company_category: Optional[str]
     date_quotation: Optional[datetime]
 
     @staticmethod
@@ -97,13 +97,13 @@ class DetailCompanyDTO:
             last_date=raw.get("lastDate"),
             has_emissions=raw.get("hasEmissions"),
             has_bdr=raw.get("hasBDR"),
-            describle_category_bvmf=raw.get("describleCategoryBVMF"),
+            company_category=raw.get("describleCategoryBVMF"),
             date_quotation=raw.get("dateQuotation"),
         )
 
 
 @dataclass(frozen=True)
-class CompanyDTO:
+class RawCompanyDTO:
     """Raw parsed data returned by the scraper before mapping to the domain."""
 
     ticker: Optional[str]
@@ -119,12 +119,12 @@ class CompanyDTO:
     other_codes: List[CodeDTO]
     sector: Optional[str]
     subsector: Optional[str]
-    segment: Optional[str]
+    industry_segment: Optional[str]
     market_indicator: Optional[str]
     bdr_type: Optional[str]
     listing_date: Optional[datetime]
     status: Optional[str]
-    segment_b3: Optional[str]
+    segment: Optional[str]
     segment_eng: Optional[str]
     company_type: Optional[str]
     market: Optional[str]
@@ -137,5 +137,5 @@ class CompanyDTO:
     last_date: Optional[datetime]
     has_emissions: Optional[bool]
     has_bdr: Optional[bool]
-    describle_category_bvmf: Optional[str]
+    company_category: Optional[str]
     quotation_date: Optional[datetime]

--- a/infrastructure/models/company_model.py
+++ b/infrastructure/models/company_model.py
@@ -2,20 +2,23 @@ from sqlalchemy.orm import Mapped, mapped_column, DeclarativeBase
 from typing import Optional
 from domain.dto.company_dto import CompanyDTO
 
+
 class Base(DeclarativeBase):
     pass
+
 
 class CompanyModel(Base):
     """
     Modelo ORM da tabela de empresas no banco de dados.
     Serve como adaptador entre o domínio (DTO) e o banco (SQLAlchemy).
     """
+
     __tablename__ = "tbl_company"
 
-    ticker: Mapped[str] = mapped_column(primary_key=True)
+    cvm_code: Mapped[str] = mapped_column(primary_key=True)
+    ticker: Mapped[Optional[str]] = mapped_column()
     company_name: Mapped[str] = mapped_column()
     cnpj: Mapped[Optional[str]] = mapped_column()
-    cvm_code: Mapped[Optional[str]] = mapped_column()
     ticker_codes: Mapped[Optional[str]] = mapped_column()
     isin_codes: Mapped[Optional[str]] = mapped_column()
     trading_name: Mapped[Optional[str]] = mapped_column()
@@ -29,10 +32,9 @@ class CompanyModel(Base):
 
     company_type: Mapped[Optional[str]] = mapped_column()
     status: Mapped[Optional[str]] = mapped_column()
-    b3_code: Mapped[Optional[str]] = mapped_column()
     company_category: Mapped[Optional[str]] = mapped_column()
     corporate_name: Mapped[Optional[str]] = mapped_column()
-    registration_date: Mapped[Optional[str]] = mapped_column()
+    listing_date: Mapped[Optional[str]] = mapped_column()
     start_situation_date: Mapped[Optional[str]] = mapped_column()
     situation: Mapped[Optional[str]] = mapped_column()
     situation_date: Mapped[Optional[str]] = mapped_column()
@@ -60,19 +62,17 @@ class CompanyModel(Base):
             activity=dto.activity,
             registrar=dto.registrar,
             website=dto.website,
-
             company_type=dto.company_type,
             status=dto.status,
-            b3_code=dto.b3_code,
             company_category=dto.company_category,
             corporate_name=dto.corporate_name,
-            registration_date=dto.registration_date,
+            listing_date=dto.listing_date,
             start_situation_date=dto.start_situation_date,
             situation=dto.situation,
             situation_date=dto.situation_date,
             country=dto.country,
             state=dto.state,
-            city=dto.city
+            city=dto.city,
         )
 
     def to_dto(self) -> CompanyDTO:
@@ -94,17 +94,15 @@ class CompanyModel(Base):
             activity=self.activity,
             registrar=self.registrar,
             website=self.website,
-            
             company_type=self.company_type,
             status=self.status,
-            b3_code=self.b3_code,
             company_category=self.company_category,
             corporate_name=self.corporate_name,
-            registration_date=self.registration_date,
+            listing_date=self.listing_date,
             start_situation_date=self.start_situation_date,
             situation=self.situation,
             situation_date=self.situation_date,
             country=self.country,
             state=self.state,
-            city=self.city
+            city=self.city,
         )

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -62,15 +62,15 @@ class SQLiteCompanyRepository(BaseRepository[CompanyDTO]):
 
     def has_item(self, identifier: str) -> bool:
         """
-        Checks if a company with the given ticker exists in the database.
+        Checks if a company with the given CVM code exists in the database.
 
-        :param identifier: Ticker symbol to verify
+        :param identifier: CVM code to verify
         :return: True if the company exists, False otherwise
         """
         session = self.Session()
         try:
             return (
-                session.query(CompanyModel).filter_by(ticker=identifier).first()
+                session.query(CompanyModel).filter_by(cvm_code=identifier).first()
                 is not None
             )
         finally:
@@ -78,15 +78,15 @@ class SQLiteCompanyRepository(BaseRepository[CompanyDTO]):
 
     def get_by_id(self, id: str) -> CompanyDTO:
         """
-        Retrieves a single company from the database by ticker.
+        Retrieves a single company from the database by CVM code.
 
-        :param id: The ticker identifier
+        :param id: The CVM code identifier
         :return: A CompanyDTO representing the retrieved company
         :raises ValueError: If no company is found
         """
         session = self.Session()
         try:
-            obj = session.query(CompanyModel).filter_by(ticker=id).first()
+            obj = session.query(CompanyModel).filter_by(cvm_code=id).first()
             if not obj:
                 raise ValueError(f"Company not found: {id}")
             return obj.to_dto()


### PR DESCRIPTION
## Summary
- rename raw company dto class and fields
- align domain CompanyDTO naming
- switch ORM primary key to cvm_code
- update repository and scrapers for new names

## Testing
- `ruff format application/mappers/company_mapper.py domain/dto/__init__.py domain/dto/company_dto.py domain/dto/raw_company_dto.py infrastructure/models/company_model.py infrastructure/repositories/company_repository.py infrastructure/scrapers/company_b3_scraper.py`
- `ruff check application/mappers/company_mapper.py domain/dto/__init__.py domain/dto/company_dto.py domain/dto/raw_company_dto.py infrastructure/models/company_model.py infrastructure/repositories/company_repository.py infrastructure/scrapers/company_b3_scraper.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da8f672d8832e82cd21dce9d76260