### PR TITLE
OVERALL MultiThread Improvements

### DIFF
--- a/COMPANY_DETAIL_PIPELINE.md
+++ b/COMPANY_DETAIL_PIPELINE.md
@@ -1,0 +1,10 @@
+# Company Detail Processing Pipeline
+
+The company detail workflow uses a small pipeline of processors to keep each step focused on a single responsibility:
+
+1. **EntryCleaner** – normalizes raw listing data and converts it to `BseCompanyDTO`.
+2. **DetailFetcher** – retrieves the detail page for a company and converts it to `DetailCompanyDTO` while recording network metrics.
+3. **CompanyMerger** – merges the base and detail DTOs into a single `RawCompanyDTO`.
+4. **CompanyDetailProcessor** – orchestrates the three steps above and returns the final DTO.
+
+This pipeline is instantiated in `CompanyB3Scraper` and used inside `_fetch_companies_details`. Each processor is a class with its dependencies injected via the constructor, following the project’s hexagonal architecture guidelines.

--- a/WORKER_POOL.md
+++ b/WORKER_POOL.md
@@ -1,0 +1,8 @@
+# WorkerPool Callbacks
+
+`WorkerPool.run` provides two optional callbacks to handle results:
+
+- `on_result(item: R)`: Invoked for every item returned by the worker. Use it for incremental persistence, real-time progress updates, or in-place validation and enrichment.
+- `post_callback(items: List[R])`: Executed once after all workers finish. Use it for final batch persistence, consolidated reporting, or cleanup logic.
+
+A common pattern is to pass a save callback via `on_result` for periodic flushes and rely on `post_callback` for the final flush and summary metrics. This keeps the worker pool generic while allowing callers to handle persistence and reporting according to their own needs.

--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -1,9 +1,8 @@
 from typing import List
 
-from infrastructure.config import Config
-
-from infrastructure.logging import Logger
 from domain.dto.company_dto import CompanyDTO
+from infrastructure.config import Config
+from infrastructure.logging import Logger
 from infrastructure.repositories import SQLiteCompanyRepository
 from infrastructure.scrapers.company_b3_scraper import CompanyB3Scraper
 
@@ -44,7 +43,7 @@ class SyncCompaniesUseCase:
             max_workers=self.config.global_settings.max_workers,
         )
         self.logger.log(
-            f"Downloaded {self.scraper.total_bytes_downloaded} bytes",
+            f"Downloaded {self.scraper.metrics_collector.network_bytes} bytes",
             level="info",
         )
 

--- a/application/usecases/sync_nsd.py
+++ b/application/usecases/sync_nsd.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from infrastructure.logging import Logger
 from domain.dto.nsd_dto import NSDDTO
+from infrastructure.logging import Logger
 from infrastructure.repositories.nsd_repository import SQLiteNSDRepository
 from infrastructure.scrapers.nsd_scraper import NsdScraper
 
@@ -26,7 +26,7 @@ class SyncNSDUseCase:
             save_callback=self._save_batch,
         )
         self.logger.log(
-            f"Downloaded {self.scraper.total_bytes_downloaded} bytes",
+            f"Downloaded {self.scraper.metrics_collector.network_bytes} bytes",
             level="info",
         )
 

--- a/domain/dto/__init__.py
+++ b/domain/dto/__init__.py
@@ -1,8 +1,9 @@
 from .company_dto import CompanyDTO
 from .nsd_dto import NSDDTO
+from .page_result_dto import PageResultDTO
 from .raw_company_dto import (
-    CodeDTO,
     BseCompanyDTO,
+    CodeDTO,
     DetailCompanyDTO,
     RawCompanyDTO,
 )
@@ -14,4 +15,5 @@ __all__ = [
     "BseCompanyDTO",
     "DetailCompanyDTO",
     "CodeDTO",
+    "PageResultDTO",
 ]

--- a/domain/dto/page_result_dto.py
+++ b/domain/dto/page_result_dto.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class PageResultDTO:
+    """Container for paginated fetch results and metadata."""
+
+    items: List[Dict]
+    total_pages: int
+    bytes_downloaded: int

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -1,3 +1,3 @@
-from .worker_pool_port import WorkerPoolPort, Metrics, LoggerPort
+from .worker_pool_port import ExecutionResult, LoggerPort, Metrics, WorkerPoolPort
 
-__all__ = ["WorkerPoolPort", "Metrics", "LoggerPort"]
+__all__ = ["WorkerPoolPort", "Metrics", "LoggerPort", "ExecutionResult"]

--- a/domain/ports/worker_pool_port.py
+++ b/domain/ports/worker_pool_port.py
@@ -16,13 +16,14 @@ class LoggerPort(Protocol):
         extra: Optional[dict] = None,
         worker_id: Optional[str] = None,
     ) -> None:
-        raise NotImplemented
+        raise NotImplementedError
 
 
 @dataclass
 class Metrics:
     elapsed_time: float
-    download_bytes: int
+    network_bytes: int = 0
+    processing_bytes: int = 0
     failures: int = 0
 
 
@@ -35,4 +36,4 @@ class WorkerPoolPort(Protocol):
         on_result: Optional[Callable[[R], None]] = None,
         post_callback: Optional[Callable[[List[R]], None]] = None,
     ) -> Tuple[List[R], Metrics]:
-        raise NotImplemented
+        raise NotImplementedError

--- a/domain/ports/worker_pool_port.py
+++ b/domain/ports/worker_pool_port.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Iterable, List, Optional, Protocol, Tuple, TypeVar
+from typing import Callable, Generic, Iterable, List, Optional, Protocol, TypeVar
 
 T = TypeVar("T")
 R = TypeVar("R")
@@ -27,6 +27,14 @@ class Metrics:
     failures: int = 0
 
 
+@dataclass
+class ExecutionResult(Generic[R]):
+    """Results and metrics returned by :class:`WorkerPoolPort.run`."""
+
+    items: List[R]
+    metrics: Metrics
+
+
 class WorkerPoolPort(Protocol):
     def run(
         self,
@@ -35,5 +43,5 @@ class WorkerPoolPort(Protocol):
         logger: LoggerPort,
         on_result: Optional[Callable[[R], None]] = None,
         post_callback: Optional[Callable[[List[R]], None]] = None,
-    ) -> Tuple[List[R], Metrics]:
+    ) -> ExecutionResult[R]:
         raise NotImplementedError

--- a/infrastructure/helpers/__init__.py
+++ b/infrastructure/helpers/__init__.py
@@ -1,6 +1,7 @@
-from .fetch_utils import FetchUtils
-from .time_utils import TimeUtils
 from .data_cleaner import DataCleaner
+from .fetch_utils import FetchUtils
+from .metrics_collector import MetricsCollector
+from .time_utils import TimeUtils
 from .worker_pool import WorkerPool
 
-__all__ = ["FetchUtils", "TimeUtils", "DataCleaner", "WorkerPool"]
+__all__ = ["FetchUtils", "TimeUtils", "DataCleaner", "WorkerPool", "MetricsCollector"]

--- a/infrastructure/helpers/__init__.py
+++ b/infrastructure/helpers/__init__.py
@@ -1,7 +1,15 @@
 from .data_cleaner import DataCleaner
 from .fetch_utils import FetchUtils
 from .metrics_collector import MetricsCollector
+from .save_strategy import SaveStrategy
 from .time_utils import TimeUtils
 from .worker_pool import WorkerPool
 
-__all__ = ["FetchUtils", "TimeUtils", "DataCleaner", "WorkerPool", "MetricsCollector"]
+__all__ = [
+    "FetchUtils",
+    "TimeUtils",
+    "DataCleaner",
+    "WorkerPool",
+    "MetricsCollector",
+    "SaveStrategy",
+]

--- a/infrastructure/helpers/metrics_collector.py
+++ b/infrastructure/helpers/metrics_collector.py
@@ -1,0 +1,29 @@
+class MetricsCollector:
+    """Collects network and processing byte counts."""
+
+    def __init__(self) -> None:
+        self._network_bytes = 0
+        self._processing_bytes = 0
+
+    def record_network_bytes(self, n: int) -> None:
+        self._network_bytes += n
+
+    def record_processing_bytes(self, n: int) -> None:
+        self._processing_bytes += n
+
+    @property
+    def network_bytes(self) -> int:
+        return self._network_bytes
+
+    @property
+    def processing_bytes(self) -> int:
+        return self._processing_bytes
+
+    def get_metrics(self, elapsed_time: float):
+        from domain.ports.worker_pool_port import Metrics
+
+        return Metrics(
+            elapsed_time=elapsed_time,
+            network_bytes=self._network_bytes,
+            processing_bytes=self._processing_bytes,
+        )

--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Callable, Generic, List, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class SaveStrategy(Generic[T]):
+    """Buffers items and flushes them via a callback."""
+
+    def __init__(
+        self,
+        save_callback: Optional[Callable[[List[T]], None]] = None,
+        threshold: int = 50,
+    ) -> None:
+        self.save_callback = save_callback or (lambda buffer: None)
+        self.threshold = threshold
+        self.buffer: List[T] = []
+
+    def handle(self, item: Optional[T]) -> None:
+        if item is None:
+            return
+
+        self.buffer.append(item)
+        if len(self.buffer) >= self.threshold:
+            self.flush()
+
+    def flush(self) -> None:
+        if self.buffer:
+            self.save_callback(self.buffer)
+            self.buffer.clear()
+
+    def finalize(self) -> None:
+        self.flush()

--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -6,9 +6,13 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
-from typing import Callable, Iterable, List, Optional, Tuple, TypeVar
+from typing import Callable, Iterable, List, Optional, TypeVar
 
-from domain.ports.worker_pool_port import LoggerPort, Metrics, WorkerPoolPort
+from domain.ports.worker_pool_port import (
+    ExecutionResult,
+    LoggerPort,
+    WorkerPoolPort,
+)
 from infrastructure.config import Config
 from infrastructure.helpers.byte_formatter import ByteFormatter
 from infrastructure.helpers.metrics_collector import MetricsCollector
@@ -36,7 +40,7 @@ class WorkerPool(WorkerPoolPort):
         logger: LoggerPort,
         on_result: Optional[Callable[[R], None]] = None,
         post_callback: Optional[Callable[[List[R]], None]] = None,
-    ) -> Tuple[List[R], Metrics]:
+    ) -> ExecutionResult[R]:
         logger.log(f"worker pool start {processor.__qualname__}", level="info")
 
         results: List[R] = []
@@ -108,4 +112,4 @@ class WorkerPool(WorkerPoolPort):
             level="info",
         )
 
-        return results, metrics
+        return ExecutionResult(items=results, metrics=metrics)

--- a/infrastructure/logging/progress_formatter.py
+++ b/infrastructure/logging/progress_formatter.py
@@ -8,7 +8,7 @@ class ProgressFormatter:
 
     def format(self, progress: dict) -> str:
         """
-        Gera uma string como: "15/100 | 15.00% | 0h00m10s + 0h01m00s = 0h01m10s e extra_info" 
+        Gera uma string como: "15/100 | 15.00% | 0h00m10s + 0h01m00s = 0h01m10s e extra_info"
         """
         try:
             index = progress.get("index", 0)

--- a/infrastructure/models/company_model.py
+++ b/infrastructure/models/company_model.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import List, Optional
-import json
 
 from sqlalchemy import Boolean, DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
+from domain.dto.company_dto import CompanyDTO
 from domain.dto.raw_company_dto import CodeDTO, RawCompanyDTO
 
 
@@ -62,50 +63,57 @@ class CompanyModel(Base):
     listing_date: Mapped[Optional[datetime]] = mapped_column(DateTime)
 
     @staticmethod
-    def from_dto(dto: RawCompanyDTO) -> "CompanyModel":
-        """Convert a :class:`RawCompanyDTO` into ``CompanyModel``."""
+    def from_dto(dto: RawCompanyDTO | CompanyDTO) -> "CompanyModel":
+        """Convert a ``RawCompanyDTO`` or ``CompanyDTO`` into ``CompanyModel``."""
+
+        def attr(name: str):
+            return getattr(dto, name, None)
+
+        ticker_codes = attr("ticker_codes") or (
+            [] if attr("ticker") is None else [attr("ticker")]
+        )
+        isin_codes = attr("isin_codes") or []
+        other_codes = attr("other_codes") or []
 
         return CompanyModel(
-            cvm_code=dto.cvm_code or "",
-            issuing_company=dto.issuing_company,
-            trading_name=dto.trading_name,
-            company_name=dto.company_name,
-            cnpj=dto.cnpj,
-            ticker_codes=",".join(dto.ticker_codes) if dto.ticker_codes else None,
-            isin_codes=",".join(dto.isin_codes) if dto.isin_codes else None,
+            cvm_code=attr("cvm_code") or attr("ticker") or "",
+            issuing_company=attr("issuing_company"),
+            trading_name=attr("trading_name"),
+            company_name=attr("company_name"),
+            cnpj=attr("cnpj"),
+            ticker_codes=",".join(ticker_codes) if ticker_codes else None,
+            isin_codes=",".join(isin_codes) if isin_codes else None,
             other_codes=(
-                json.dumps(
-                    [{"code": code.code, "isin": code.isin} for code in dto.other_codes]
-                )
-                if dto.other_codes
+                json.dumps([{"code": c.code, "isin": c.isin} for c in other_codes])
+                if other_codes
                 else None
             ),
-            industry_sector=dto.industry_sector,
-            industry_subsector=dto.industry_subsector,
-            industry_segment=dto.industry_segment,
-            industry_classification=dto.industry_classification,
-            industry_classification_eng=dto.industry_classification_eng,
-            activity=dto.activity,
-            company_segment=dto.company_segment,
-            company_segment_eng=dto.company_segment_eng,
-            company_category=dto.company_category,
-            company_type=dto.company_type,
-            listing_segment=dto.listing_segment,
-            registrar=dto.registrar,
-            website=dto.website,
-            institution_common=dto.institution_common,
-            institution_preferred=dto.institution_preferred,
-            market=dto.market,
-            status=dto.status,
-            market_indicator=dto.market_indicator,
-            code=dto.code,
-            has_bdr=dto.has_bdr,
-            type_bdr=dto.type_bdr,
-            has_quotation=dto.has_quotation,
-            has_emissions=dto.has_emissions,
-            date_quotation=dto.date_quotation,
-            last_date=dto.last_date,
-            listing_date=dto.listing_date,
+            industry_sector=attr("industry_sector"),
+            industry_subsector=attr("industry_subsector"),
+            industry_segment=attr("industry_segment"),
+            industry_classification=attr("industry_classification"),
+            industry_classification_eng=attr("industry_classification_eng"),
+            activity=attr("activity"),
+            company_segment=attr("company_segment"),
+            company_segment_eng=attr("company_segment_eng"),
+            company_category=attr("company_category"),
+            company_type=attr("company_type"),
+            listing_segment=attr("listing_segment"),
+            registrar=attr("registrar"),
+            website=attr("website"),
+            institution_common=attr("institution_common"),
+            institution_preferred=attr("institution_preferred"),
+            market=attr("market"),
+            status=attr("status"),
+            market_indicator=attr("market_indicator"),
+            code=attr("code"),
+            has_bdr=attr("has_bdr"),
+            type_bdr=attr("type_bdr"),
+            has_quotation=attr("has_quotation"),
+            has_emissions=attr("has_emissions"),
+            date_quotation=attr("date_quotation"),
+            last_date=attr("last_date"),
+            listing_date=attr("listing_date"),
         )
 
     def to_dto(self) -> RawCompanyDTO:

--- a/infrastructure/scrapers/__init__.py
+++ b/infrastructure/scrapers/__init__.py
@@ -1,4 +1,17 @@
 from .company_b3_scraper import CompanyB3Scraper
+from .company_processors import (
+    CompanyDetailProcessor,
+    CompanyMerger,
+    DetailFetcher,
+    EntryCleaner,
+)
 from .nsd_scraper import NsdScraper
 
-__all__ = ["CompanyB3Scraper", "NsdScraper"]
+__all__ = [
+    "CompanyB3Scraper",
+    "NsdScraper",
+    "EntryCleaner",
+    "DetailFetcher",
+    "CompanyMerger",
+    "CompanyDetailProcessor",
+]

--- a/infrastructure/scrapers/company_b3_scraper.py
+++ b/infrastructure/scrapers/company_b3_scraper.py
@@ -151,7 +151,7 @@ class CompanyB3Scraper:
                 )
                 return fetch
 
-            page_results, _ = self.executor.run(
+            page_exec = self.executor.run(
                 tasks=pages,
                 processor=processor,
                 logger=self.logger,
@@ -161,7 +161,7 @@ class CompanyB3Scraper:
                 level="info",
             )
 
-            for page_data in page_results:
+            for page_data in page_exec.items:
                 page_items, _, _ = page_data
                 results.extend(page_items)
 
@@ -250,7 +250,7 @@ class CompanyB3Scraper:
                 buffer, processed_results, save_callback, threshold, remaining
             )
 
-        results_out, _ = self.executor.run(
+        detail_exec = self.executor.run(
             tasks=tasks,
             processor=processor,
             logger=self.logger,
@@ -261,7 +261,7 @@ class CompanyB3Scraper:
         if buffer:
             self._handle_save(buffer, processed_results, save_callback, threshold, 0)
 
-        return results_out
+        return detail_exec.items
 
     def _fetch_detail(self, cvm_code: str) -> DetailCompanyDTO:
         """

--- a/infrastructure/scrapers/company_processors.py
+++ b/infrastructure/scrapers/company_processors.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Dict, Optional
+
+from application import CompanyMapper
+from domain.dto import BseCompanyDTO, DetailCompanyDTO, RawCompanyDTO
+from infrastructure.helpers import FetchUtils, MetricsCollector
+from infrastructure.helpers.data_cleaner import DataCleaner
+from infrastructure.logging import Logger
+
+
+class EntryCleaner:
+    """Clean raw company listing entries."""
+
+    def __init__(self, data_cleaner: DataCleaner) -> None:
+        self.data_cleaner = data_cleaner
+
+    def run(self, entry: Dict) -> BseCompanyDTO:
+        entry["companyName"] = self.data_cleaner.clean_text(entry.get("companyName"))
+        entry["issuingCompany"] = self.data_cleaner.clean_text(
+            entry.get("issuingCompany")
+        )
+        entry["tradingName"] = self.data_cleaner.clean_text(entry.get("tradingName"))
+        entry["dateListing"] = self.data_cleaner.clean_date(entry.get("dateListing"))
+        return BseCompanyDTO.from_dict(entry)
+
+
+class DetailFetcher:
+    """Fetch and clean detailed company information."""
+
+    def __init__(
+        self,
+        fetch_utils: FetchUtils,
+        session,
+        endpoint_detail: str,
+        language: str,
+        metrics_collector: MetricsCollector,
+        data_cleaner: DataCleaner,
+    ) -> None:
+        self.fetch_utils = fetch_utils
+        self.session = session
+        self.endpoint_detail = endpoint_detail
+        self.language = language
+        self.metrics_collector = metrics_collector
+        self.data_cleaner = data_cleaner
+
+    def run(self, cvm_code: str) -> DetailCompanyDTO:
+        payload = {"codeCVM": cvm_code, "language": self.language}
+        token = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+        url = self.endpoint_detail + token
+        response = self.fetch_utils.fetch_with_retry(self.session, url)
+        self.metrics_collector.record_network_bytes(len(response.content))
+        raw = response.json()
+        raw["issuingCompany"] = self.data_cleaner.clean_text(raw.get("issuingCompany"))
+        raw["companyName"] = self.data_cleaner.clean_text(raw.get("companyName"))
+        raw["tradingName"] = self.data_cleaner.clean_text(raw.get("tradingName"))
+        raw["cnpj"] = raw.get("cnpj")
+        raw["industryClassification"] = raw.get("industryClassification")
+        raw["industryClassificationEng"] = raw.get("industryClassificationEng")
+        raw["activity"] = raw.get("activity")
+        raw["website"] = raw.get("website")
+        raw["hasQuotation"] = raw.get("hasQuotation")
+        raw["status"] = raw.get("status")
+        raw["marketIndicator"] = raw.get("marketIndicator")
+        raw["market"] = self.data_cleaner.clean_text(raw.get("market"))
+        raw["institutionCommon"] = self.data_cleaner.clean_text(
+            raw.get("institutionCommon")
+        )
+        raw["institutionPreferred"] = self.data_cleaner.clean_text(
+            raw.get("institutionPreferred")
+        )
+        raw["code"] = raw.get("code")
+        raw["codeCVM"] = raw.get("codeCVM")
+        raw["lastDate"] = self.data_cleaner.clean_date(raw.get("lastDate"))
+        raw["otherCodes"] = raw.get("otherCodes")
+        raw["hasEmissions"] = raw.get("hasEmissions")
+        raw["hasBDR"] = raw.get("hasBDR")
+        raw["typeBDR"] = raw.get("typeBDR")
+        raw["describleCategoryBVMF"] = raw.get("describleCategoryBVMF")
+        raw["dateQuotation"] = raw.get("dateQuotation")
+        return DetailCompanyDTO.from_dict(raw)
+
+
+class CompanyMerger:
+    """Merge base and detail DTOs."""
+
+    def __init__(self, mapper: CompanyMapper, logger: Logger) -> None:
+        self.mapper = mapper
+        self.logger = logger
+
+    def run(
+        self, base: BseCompanyDTO, detail: DetailCompanyDTO
+    ) -> Optional[RawCompanyDTO]:
+        try:
+            return self.mapper.merge_company_dtos(base, detail)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.log(f"erro {exc}", level="debug")
+            return None
+
+
+class CompanyDetailProcessor:
+    """Pipeline to process a single company entry."""
+
+    def __init__(
+        self, cleaner: EntryCleaner, fetcher: DetailFetcher, merger: CompanyMerger
+    ) -> None:
+        self.cleaner = cleaner
+        self.fetcher = fetcher
+        self.merger = merger
+
+    def run(self, entry: Dict) -> Optional[RawCompanyDTO]:
+        base = self.cleaner.run(entry)
+        detail = self.fetcher.run(str(base.cvm_code))
+        return self.merger.run(base, detail)

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -1,22 +1,29 @@
 from __future__ import annotations
 
-from datetime import datetime
+import re
 import time
-from typing import List, Dict, Optional, Callable
+from datetime import datetime
+from typing import Callable, Dict, List, Optional
 
 from bs4 import BeautifulSoup
-import re
 
 from infrastructure.config import Config
-from infrastructure.logging import Logger
 from infrastructure.helpers import FetchUtils
 from infrastructure.helpers.data_cleaner import DataCleaner
+from infrastructure.helpers.metrics_collector import MetricsCollector
+from infrastructure.logging import Logger
 
 
 class NsdScraper:
     """Scraper adapter responsible for fetching raw NSD documents."""
 
-    def __init__(self, config: Config, logger: Logger, data_cleaner: DataCleaner):
+    def __init__(
+        self,
+        config: Config,
+        logger: Logger,
+        data_cleaner: DataCleaner,
+        metrics_collector: MetricsCollector,
+    ):
         self.config = config
         self.logger = logger
         self.data_cleaner = data_cleaner
@@ -25,7 +32,7 @@ class NsdScraper:
 
         self.nsd_endpoint = self.config.b3.nsd_endpoint
 
-        self.total_bytes_downloaded = 0
+        self.metrics_collector = metrics_collector
 
         self.logger.log("Start NsdScraper", level="info")
 
@@ -79,7 +86,7 @@ class NsdScraper:
 
             try:
                 response = self.fetch_utils.fetch_with_retry(self.session, url)
-                self.total_bytes_downloaded += len(response.content)
+                self.metrics_collector.record_network_bytes(len(response.content))
                 parsed = self._parse_html(nsd, response.text)
             except Exception as e:
                 self.logger.log(
@@ -124,7 +131,7 @@ class NsdScraper:
             index += 1
 
         self.logger.log(
-            f"Downloaded {self.total_bytes_downloaded} bytes",
+            f"Downloaded {self.metrics_collector.network_bytes} bytes",
             level="info",
         )
         return results

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -1,14 +1,14 @@
-from infrastructure.config import Config
-from infrastructure.logging import Logger
-
-from infrastructure.repositories import SQLiteCompanyRepository
-from infrastructure.scrapers.company_b3_scraper import CompanyB3Scraper
-from infrastructure.helpers import WorkerPool
-from infrastructure.scrapers.nsd_scraper import NsdScraper
 from application import CompanyMapper
 from application.services.company_services import CompanyService
 from application.services.nsd_service import NsdService
+from infrastructure.config import Config
+from infrastructure.helpers import WorkerPool
+from infrastructure.helpers.metrics_collector import MetricsCollector
+from infrastructure.logging import Logger
+from infrastructure.repositories import SQLiteCompanyRepository
 from infrastructure.repositories.nsd_repository import SQLiteNSDRepository
+from infrastructure.scrapers.company_b3_scraper import CompanyB3Scraper
+from infrastructure.scrapers.nsd_scraper import NsdScraper
 
 
 class CLIController:
@@ -43,13 +43,15 @@ class CLIController:
 
         company_repo = SQLiteCompanyRepository(config=self.config, logger=self.logger)
         mapper = CompanyMapper(self.data_cleaner)
-        executor = WorkerPool(self.config)
+        collector = MetricsCollector()
+        executor = WorkerPool(self.config, metrics_collector=collector)
         company_scraper = CompanyB3Scraper(
             config=self.config,
             logger=self.logger,
             data_cleaner=self.data_cleaner,
             mapper=mapper,
             executor=executor,
+            metrics_collector=collector,
         )
         company_service = CompanyService(
             config=self.config,
@@ -67,8 +69,12 @@ class CLIController:
         self.logger.log("Start NSD Sync Use Case", level="info")
 
         nsd_repo = SQLiteNSDRepository(config=self.config, logger=self.logger)
+        collector = MetricsCollector()
         nsd_scraper = NsdScraper(
-            config=self.config, logger=self.logger, data_cleaner=self.data_cleaner
+            config=self.config,
+            logger=self.logger,
+            data_cleaner=self.data_cleaner,
+            metrics_collector=collector,
         )
         nsd_service = NsdService(
             logger=self.logger, repository=nsd_repo, scraper=nsd_scraper


### PR DESCRIPTION
## Summary
- add `MetricsCollector` helper to aggregate byte counts
- extend `Metrics` dataclass with network and processing bytes
- refactor `WorkerPool` and scrapers to use the new collector
- adapt services, use cases and CLI wiring
- allow repository to accept both raw and parsed DTOs

## Testing
- `ruff format infrastructure/helpers/metrics_collector.py domain/ports/worker_pool_port.py infrastructure/helpers/worker_pool.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py application/usecases/sync_companies.py application/usecases/sync_nsd.py presentation/cli.py infrastructure/helpers/__init__.py infrastructure/models/company_model.py`
- `ruff check infrastructure/helpers/metrics_collector.py domain/ports/worker_pool_port.py infrastructure/helpers/worker_pool.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py application/usecases/sync_companies.py application/usecases/sync_nsd.py presentation/cli.py infrastructure/helpers/__init__.py infrastructure/models/company_model.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685efe1c93e8832e835be61a273e0807