### PR TITLE
Add DTO naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,12 +94,16 @@ They are orchestrated by the CLI controller (`CLIController`), which boots the s
 All data passed between layers are **immutable dataclasses** in `domain/dto/`:
 
 - `CompanyDTO`  
-- `NSDDTO`  
+- `NSDDTO`
 
 They provide:
-- Strict field typing  
-- `@staticmethod from_dict(raw: dict) → DTO`  
+- Strict field typing
+- `@staticmethod from_dict(raw: dict) → DTO`
 - No business logic (pure data carriers)
+
+See [DTO Naming Conventions](DTO_NAMING_CONVENTIONS.md) for the standard
+terminology used in all services (`ListingDTO`, `DetailDTO`, `RawDTO`, and
+the final `<Entity>DTO`).
 
 ---
 

--- a/COMPANY_DETAIL_PIPELINE.md
+++ b/COMPANY_DETAIL_PIPELINE.md
@@ -2,9 +2,9 @@
 
 The company detail workflow uses a small pipeline of processors to keep each step focused on a single responsibility:
 
-1. **EntryCleaner** – normalizes raw listing data and converts it to `BseCompanyDTO`.
-2. **DetailFetcher** – retrieves the detail page for a company and converts it to `DetailCompanyDTO` while recording network metrics.
-3. **CompanyMerger** – merges the base and detail DTOs into a single `RawCompanyDTO`.
+1. **EntryCleaner** – normalizes raw listing data and converts it to `CompanyListingDTO`.
+2. **DetailFetcher** – retrieves the detail page for a company and converts it to `CompanyDetailDTO` while recording network metrics.
+3. **CompanyMerger** – merges the listing and detail DTOs into a single `CompanyRawDTO`.
 4. **CompanyDetailProcessor** – orchestrates the three steps above and returns the final DTO.
 
 This pipeline is instantiated in `CompanyB3Scraper` and used inside `_fetch_companies_details`. Each processor is a class with its dependencies injected via the constructor, following the project’s hexagonal architecture guidelines.

--- a/DTO_NAMING_CONVENTIONS.md
+++ b/DTO_NAMING_CONVENTIONS.md
@@ -1,0 +1,14 @@
+# DTO Naming Conventions
+
+This document defines the standard terminology for the various DTOs used across services.
+
+- **`<Entity>ListingDTO`** – Data loaded from the listing endpoint (base information).
+- **`<Entity>DetailDTO`** – Information returned by the detail endpoint for a single entity.
+- **`<Entity>RawDTO`** – Temporary merge of listing + detail data, used only inside infrastructure to prepare the final object.
+- **`<Entity>DTO`** – Immutable domain object created from dicts or a Raw DTO. This is the only DTO propagated to application and domain layers.
+
+### Flow
+
+adapter → `ListingDTO`/`DetailDTO` → `RawDTO` → `EntityDTO` → model/repository
+
+The `RawDTO` should remain an implementation detail. If convenient, the domain `from_dict()` helper may create and discard a `RawDTO` internally, avoiding propagation of intermediate types outside the infrastructure layer.

--- a/application/mappers/company_mapper.py
+++ b/application/mappers/company_mapper.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from infrastructure.helpers.data_cleaner import DataCleaner
 from domain.dto import (
-    BseCompanyDTO,
-    DetailCompanyDTO,
-    RawCompanyDTO,
+    CompanyListingDTO,
+    CompanyDetailDTO,
+    CompanyRawDTO,
 )
 
 
@@ -16,9 +16,9 @@ class CompanyMapper:
 
     def merge_company_dtos(
         self,
-        base: BseCompanyDTO,
-        detail: DetailCompanyDTO,
-    ) -> RawCompanyDTO:
+        base: CompanyListingDTO,
+        detail: CompanyDetailDTO,
+    ) -> CompanyRawDTO:
 
         codes = detail.other_codes or []
         
@@ -28,7 +28,7 @@ class CompanyMapper:
         industry_subsector = self.data_cleaner.clean_text(parts[1]) if len(parts) > 1 else None
         industry_segment = self.data_cleaner.clean_text(parts[2]) if len(parts) > 2 else None
 
-        return RawCompanyDTO(
+        return CompanyRawDTO(
             cvm_code = detail.cvm_code or base.cvm_code,
             issuing_company = detail.issuing_company or base.issuing_company,
             trading_name = detail.trading_name or base.trading_name,

--- a/domain/dto/__init__.py
+++ b/domain/dto/__init__.py
@@ -2,18 +2,18 @@ from .company_dto import CompanyDTO
 from .nsd_dto import NSDDTO
 from .page_result_dto import PageResultDTO
 from .raw_company_dto import (
-    BseCompanyDTO,
+    CompanyListingDTO,
     CodeDTO,
-    DetailCompanyDTO,
-    RawCompanyDTO,
+    CompanyDetailDTO,
+    CompanyRawDTO,
 )
 
 __all__ = [
     "CompanyDTO",
     "NSDDTO",
-    "RawCompanyDTO",
-    "BseCompanyDTO",
-    "DetailCompanyDTO",
+    "CompanyRawDTO",
+    "CompanyListingDTO",
+    "CompanyDetailDTO",
     "CodeDTO",
     "PageResultDTO",
 ]

--- a/domain/dto/company_dto.py
+++ b/domain/dto/company_dto.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Optional
 import json
 
-from .raw_company_dto import RawCompanyDTO
+from .raw_company_dto import CompanyRawDTO
 
 
 @dataclass(frozen=True)
@@ -70,7 +70,7 @@ class CompanyDTO:
         )
 
     @staticmethod
-    def from_raw(raw: RawCompanyDTO) -> "CompanyDTO":
+    def from_raw(raw: CompanyRawDTO) -> "CompanyDTO":
         """Builds a CompanyDTO from a CompanyDTO instance."""
 
         return CompanyDTO(

--- a/domain/dto/raw_company_dto.py
+++ b/domain/dto/raw_company_dto.py
@@ -13,7 +13,7 @@ class CodeDTO:
 
 
 @dataclass(frozen=True)
-class BseCompanyDTO:
+class CompanyListingDTO:
     """DTO for base company data from the list endpoint."""
 
     cvm_code: Optional[str]
@@ -31,8 +31,8 @@ class BseCompanyDTO:
     market: Optional[str]
 
     @staticmethod
-    def from_dict(raw: dict) -> "BseCompanyDTO":
-        return BseCompanyDTO(
+    def from_dict(raw: dict) -> "CompanyListingDTO":
+        return CompanyListingDTO(
             cvm_code=raw.get("codeCVM"),
             issuing_company=raw.get("issuingCompany"),
             company_name=raw.get("companyName"),
@@ -50,7 +50,7 @@ class BseCompanyDTO:
 
 
 @dataclass(frozen=True)
-class DetailCompanyDTO:
+class CompanyDetailDTO:
     """DTO for detailed company data from the detail endpoint."""
 
     issuing_company: Optional[str]
@@ -81,12 +81,12 @@ class DetailCompanyDTO:
     registrar: Optional[str]
 
     @staticmethod
-    def from_dict(raw: dict) -> "DetailCompanyDTO":
+    def from_dict(raw: dict) -> "CompanyDetailDTO":
         other_codes = raw.get("otherCodes") or []
         if isinstance(other_codes, str):
             other_codes = json.loads(other_codes)
         code_dtos = [CodeDTO(code=c.get("code"), isin=c.get("isin")) for c in other_codes]
-        company_detail_dto = DetailCompanyDTO(
+        company_detail_dto = CompanyDetailDTO(
             issuing_company=raw.get("issuingCompany"),
             company_name=raw.get("companyName"),
             trading_name=raw.get("tradingName"),
@@ -118,7 +118,7 @@ class DetailCompanyDTO:
 
 
 @dataclass(frozen=True)
-class RawCompanyDTO:
+class CompanyRawDTO:
     """Raw parsed data returned by the scraper before mapping to the domain."""
 
     cvm_code: Optional[str]

--- a/infrastructure/models/company_model.py
+++ b/infrastructure/models/company_model.py
@@ -8,7 +8,7 @@ from sqlalchemy import Boolean, DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from domain.dto.company_dto import CompanyDTO
-from domain.dto.raw_company_dto import CodeDTO, RawCompanyDTO
+from domain.dto.raw_company_dto import CodeDTO, CompanyRawDTO
 
 
 class Base(DeclarativeBase):
@@ -63,8 +63,8 @@ class CompanyModel(Base):
     listing_date: Mapped[Optional[datetime]] = mapped_column(DateTime)
 
     @staticmethod
-    def from_dto(dto: RawCompanyDTO | CompanyDTO) -> "CompanyModel":
-        """Convert a ``RawCompanyDTO`` or ``CompanyDTO`` into ``CompanyModel``."""
+    def from_dto(dto: CompanyRawDTO | CompanyDTO) -> "CompanyModel":
+        """Convert a ``CompanyRawDTO`` or ``CompanyDTO`` into ``CompanyModel``."""
 
         def attr(name: str):
             return getattr(dto, name, None)
@@ -116,8 +116,8 @@ class CompanyModel(Base):
             listing_date=attr("listing_date"),
         )
 
-    def to_dto(self) -> RawCompanyDTO:
-        """Reconstruct a :class:`RawCompanyDTO` from this model."""
+    def to_dto(self) -> CompanyRawDTO:
+        """Reconstruct a :class:`CompanyRawDTO` from this model."""
 
         ticker_codes: List[str] = (
             self.ticker_codes.split(",") if self.ticker_codes else []
@@ -128,7 +128,7 @@ class CompanyModel(Base):
             CodeDTO(code=item.get("code"), isin=item.get("isin")) for item in raw_other
         ]
 
-        return RawCompanyDTO(
+        return CompanyRawDTO(
             cvm_code=self.cvm_code,
             issuing_company=self.issuing_company,
             trading_name=self.trading_name,

--- a/infrastructure/scrapers/company_b3_scraper.py
+++ b/infrastructure/scrapers/company_b3_scraper.py
@@ -3,7 +3,7 @@ import json
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from application import CompanyMapper
-from domain.dto import PageResultDTO, RawCompanyDTO
+from domain.dto import PageResultDTO, CompanyRawDTO
 from domain.ports import WorkerPoolPort
 from infrastructure.config import Config
 from infrastructure.helpers import FetchUtils, SaveStrategy
@@ -104,9 +104,9 @@ class CompanyB3Scraper:
         self,
         threshold: Optional[int] = None,
         skip_codes: Optional[Set[str]] = None,
-        save_callback: Optional[Callable[[List[RawCompanyDTO]], None]] = None,
+        save_callback: Optional[Callable[[List[CompanyRawDTO]], None]] = None,
         max_workers: int | None = None,
-    ) -> List[RawCompanyDTO]:
+    ) -> List[CompanyRawDTO]:
         """Fetch all companies from B3.
 
         Args:
@@ -240,10 +240,10 @@ class CompanyB3Scraper:
         self,
         companies_list: List[Dict],
         skip_codes: Optional[Set[str]] = None,
-        save_callback: Optional[Callable[[List[RawCompanyDTO]], None]] = None,
+        save_callback: Optional[Callable[[List[CompanyRawDTO]], None]] = None,
         threshold: Optional[int] = None,
         max_workers: int | None = None,
-    ) -> List[RawCompanyDTO]:
+    ) -> List[CompanyRawDTO]:
         """
         Fetches and parses detailed information for a list of companies, with optional skipping and periodic saving.
         Args:
@@ -263,13 +263,13 @@ class CompanyB3Scraper:
 
         threshold = threshold or self.config.global_settings.threshold or 50
         skip_codes = skip_codes or set()
-        strategy: SaveStrategy[RawCompanyDTO] = SaveStrategy(save_callback, threshold)
+        strategy: SaveStrategy[CompanyRawDTO] = SaveStrategy(save_callback, threshold)
 
         self.logger.log("Start CompanyB3Scraper fetch_companies_details", level="info")
 
         tasks = list(enumerate(companies_list))
 
-        def processor(item: Tuple[int, Dict]) -> Optional[RawCompanyDTO]:
+        def processor(item: Tuple[int, Dict]) -> Optional[CompanyRawDTO]:
             index, entry = item
             if entry.get("codeCVM") in skip_codes:
                 return None
@@ -279,7 +279,7 @@ class CompanyB3Scraper:
 
             return processed_entry
 
-        def handle_batch(item: Optional[RawCompanyDTO]) -> None:
+        def handle_batch(item: Optional[CompanyRawDTO]) -> None:
             strategy.handle(item)
 
         detail_exec = self.executor.run(


### PR DESCRIPTION
## Summary
- document DTO naming convention
- link to the new doc in AGENTS
- adjust company detail pipeline doc to use the new naming

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686025302b44832ead07f2fe1f5f91bf