### PR TITLE
Hexagonal Architecture Improvements #2

### DIFF
--- a/application/services/company_services.py
+++ b/application/services/company_services.py
@@ -1,9 +1,7 @@
+from application.usecases.sync_companies import SyncCompaniesUseCase
+from domain.ports import CompanyRepositoryPort, CompanySourcePort
 from infrastructure.config import Config
 from infrastructure.logging import Logger
-from infrastructure.repositories import SQLiteCompanyRepository
-from infrastructure.scrapers.company_b3_scraper import CompanyB3Scraper
-
-from application.usecases.sync_companies import SyncCompaniesUseCase
 
 
 class CompanyService:
@@ -15,24 +13,19 @@ class CompanyService:
         self,
         config: Config,
         logger: Logger,
-        repository: SQLiteCompanyRepository,
-        scraper: CompanyB3Scraper,
+        repository: CompanyRepositoryPort,
+        scraper: CompanySourcePort,
     ):
-        """
-        Initializes the CompanyService with the provided repository and scraper.
-        Args:
-            repository (SQLiteCompanyRepository): The repository instance for company data persistence.
-            scraper (CompanyB3Scraper): The scraper instance for fetching company data from B3.
-        """
+        """Initialize the service with injected repository and scraper."""
         self.logger = logger
         self.config = config
         logger.log("Start CompanyService", level="info")
 
         self.sync_usecase = SyncCompaniesUseCase(
-            config=self.config,
             logger=self.logger,
             repository=repository,
             scraper=scraper,
+            max_workers=self.config.global_settings.max_workers,
         )
 
     def run(self) -> None:

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -1,3 +1,12 @@
 from .worker_pool_port import ExecutionResult, LoggerPort, Metrics, WorkerPoolPort
+from .company_repository_port import CompanyRepositoryPort
+from .company_source_port import CompanySourcePort
 
-__all__ = ["WorkerPoolPort", "Metrics", "LoggerPort", "ExecutionResult"]
+__all__ = [
+    "WorkerPoolPort",
+    "Metrics",
+    "LoggerPort",
+    "ExecutionResult",
+    "CompanyRepositoryPort",
+    "CompanySourcePort",
+]

--- a/domain/ports/company_repository_port.py
+++ b/domain/ports/company_repository_port.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Set
+
+from domain.dto.company_dto import CompanyDTO
+
+
+class CompanyRepositoryPort(ABC):
+    """Port for company persistence operations."""
+
+    @abstractmethod
+    def save_all(self, items: List[CompanyDTO]) -> None:
+        """Persist a batch of companies."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_primary_keys(self) -> Set[str]:
+        """Return all stored CVM codes."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_by_id(self, id: str) -> CompanyDTO:
+        """Retrieve a company by its CVM code."""
+        raise NotImplementedError

--- a/domain/ports/company_source_port.py
+++ b/domain/ports/company_source_port.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable, List, Optional, Set
+
+from domain.dto.raw_company_dto import CompanyRawDTO
+
+
+class CompanySourcePort(ABC):
+    """Port for external company data providers."""
+
+    @abstractmethod
+    def fetch_all(
+        self,
+        threshold: Optional[int] = None,
+        skip_codes: Optional[Set[str]] = None,
+        save_callback: Optional[Callable[[List[CompanyRawDTO]], None]] = None,
+        max_workers: int | None = None,
+    ) -> List[CompanyRawDTO]:
+        """Fetch all available companies."""
+        raise NotImplementedError

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
@@ -5,11 +7,12 @@ from sqlalchemy.orm import sessionmaker
 from infrastructure.repositories.base_repository import BaseRepository
 from infrastructure.models.company_model import Base, CompanyModel
 from domain.dto.company_dto import CompanyDTO
+from domain.ports import CompanyRepositoryPort
 from infrastructure.config import Config
 from infrastructure.logging import Logger
 
 
-class SQLiteCompanyRepository(BaseRepository[CompanyDTO]):
+class SQLiteCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryPort):
     """
     Concrete implementation of BaseRepository for CompanyDTO,
     using SQLite and SQLAlchemy for persistence.
@@ -44,6 +47,10 @@ class SQLiteCompanyRepository(BaseRepository[CompanyDTO]):
                 obj = CompanyModel.from_dto(dto)
                 session.merge(obj)  # Upsert operation: insert or update if exists
             session.commit()
+            self.logger.log(
+                f"Saved {len(items)} companies",
+                level="info",
+            )
         except Exception as e:
             self.logger.log(f"erro {e}", level="debug")
         finally:

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -33,6 +33,10 @@ class SQLiteNSDRepository(BaseRepository[NSDDTO]):
                 obj = NSDModel.from_dto(dto)
                 session.merge(obj)
             session.commit()
+            self.logger.log(
+                f"Saved {len(items)} nsd records",
+                level="info",
+            )
         finally:
             session.close()
 

--- a/infrastructure/scrapers/company_b3_scraper.py
+++ b/infrastructure/scrapers/company_b3_scraper.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import base64
 import json
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from application import CompanyMapper
 from domain.dto import PageResultDTO, CompanyRawDTO
-from domain.ports import WorkerPoolPort
+from domain.ports import CompanySourcePort, WorkerPoolPort
 from infrastructure.config import Config
 from infrastructure.helpers import FetchUtils, SaveStrategy
 from infrastructure.helpers.byte_formatter import ByteFormatter
@@ -18,7 +20,7 @@ from infrastructure.scrapers.company_processors import (
 )
 
 
-class CompanyB3Scraper:
+class CompanyB3Scraper(CompanySourcePort):
     """
     Scraper adapter responsible for fetching raw company data.
     In a real implementation, this could use requests, BeautifulSoup, or Selenium.

--- a/tests/application/test_company_service.py
+++ b/tests/application/test_company_service.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+from application.services.company_services import CompanyService
+from application.usecases.sync_companies import SyncCompaniesUseCase
+from domain.ports import CompanyRepositoryPort, CompanySourcePort
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def test_run_calls_usecase_execute(monkeypatch):
+    dummy_config = DummyConfig()
+    dummy_config.global_settings.max_workers = 3
+
+    mock_usecase_cls = MagicMock(spec=SyncCompaniesUseCase)
+    mock_usecase_inst = MagicMock()
+    mock_usecase_cls.return_value = mock_usecase_inst
+    monkeypatch.setattr(
+        "application.services.company_services.SyncCompaniesUseCase",
+        mock_usecase_cls,
+    )
+
+    repo = MagicMock(spec=CompanyRepositoryPort)
+    scraper = MagicMock(spec=CompanySourcePort)
+
+    service = CompanyService(
+        config=dummy_config,
+        logger=DummyLogger(),
+        repository=repo,
+        scraper=scraper,
+    )
+
+    mock_usecase_cls.assert_called_once_with(
+        logger=service.logger,
+        repository=repo,
+        scraper=scraper,
+        max_workers=3,
+    )
+
+    service.run()
+
+    mock_usecase_inst.execute.assert_called_once()

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -1,0 +1,60 @@
+import types
+from unittest.mock import MagicMock
+
+from application.usecases.sync_companies import SyncCompaniesUseCase
+from domain.dto.company_dto import CompanyDTO
+from domain.ports import CompanyRepositoryPort, CompanySourcePort
+from tests.conftest import DummyLogger
+
+
+def test_execute_converts_and_saves():
+    repo = MagicMock(spec=CompanyRepositoryPort)
+    repo.get_all_primary_keys.return_value = {"SKIP"}
+
+    raw = types.SimpleNamespace(
+        cvm_code="001",
+        company_name="Acme",
+        ticker="ACM",
+        ticker_codes=["ACM"],
+        isin_codes=["BRACM"],
+        trading_name="Acme",
+        sector="Tech",
+        subsector="Software",
+        industry_segment="IT",
+        listing="Novo Mercado",
+        activity="Development",
+        registrar="B3",
+        cnpj="00.000.000/0001-91",
+        website="example.com",
+        company_type="SA",
+        status="active",
+        listing_date=None,
+    )
+
+    def fake_fetch_all(
+        threshold=None, skip_codes=None, save_callback=None, max_workers=None
+    ):
+        assert skip_codes == {"SKIP"}
+        if save_callback:
+            save_callback([raw])
+        return [raw]
+
+    scraper = MagicMock(spec=CompanySourcePort)
+    scraper.fetch_all.side_effect = fake_fetch_all
+    scraper.metrics_collector = types.SimpleNamespace(network_bytes=100)
+
+    usecase = SyncCompaniesUseCase(
+        logger=DummyLogger(),
+        repository=repo,
+        scraper=scraper,
+        max_workers=2,
+    )
+
+    usecase.execute()
+
+    repo.get_all_primary_keys.assert_called_once()
+    scraper.fetch_all.assert_called_once()
+    repo.save_all.assert_called_once()
+    saved = repo.save_all.call_args.args[0]
+    assert isinstance(saved[0], CompanyDTO)
+    assert saved[0].cvm_code == "001"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,5 +39,6 @@ class DummyConfig:
 
     class Global:
         app_name = "TEST"
+        max_workers = 1
 
     global_settings = Global()


### PR DESCRIPTION
## Summary
- convert scraped `CompanyRawDTO` values to `CompanyDTO` before saving
- introduce repository and scraper ports to decouple layers
- log saved batch sizes in SQLite repositories
- avoid passing the entire config into the company sync use case
- add unit tests for `CompanyService` and `SyncCompaniesUseCase`

## Testing
- `pre-commit run --files tests/conftest.py tests/application/test_sync_companies_use_case.py tests/application/test_company_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686035e9bf5c832ea040fb98fd6985e7