### PR TITLE
Fix CompanyDTO fields and cleaning

### DIFF
--- a/domain/dto/company_dto.py
+++ b/domain/dto/company_dto.py
@@ -1,6 +1,6 @@
+import json
 from dataclasses import dataclass
 from typing import Optional
-import json
 
 from .raw_company_dto import CompanyRawDTO
 
@@ -10,95 +10,135 @@ class CompanyDTO:
     """Representa os dados estruturados de uma empresa listada na B3."""
 
     cvm_code: Optional[str]
+    issuing_company: Optional[str]
+    trading_name: Optional[str]
     company_name: Optional[str]
-    ticker: Optional[str]  # Ticker é o código de negociação da ação na B3
+    cnpj: Optional[str]
+
     ticker_codes: Optional[str]
     isin_codes: Optional[str]
-    trading_name: Optional[str]
-    sector: Optional[str]
-    subsector: Optional[str]
-    segment: Optional[str]
-    listing: Optional[str]
-    activity: Optional[str]
-    registrar: Optional[str]
-    cnpj: Optional[str]
-    website: Optional[str]
+    other_codes: Optional[str]
 
-    company_type: Optional[str]
-    status: Optional[str]
+    industry_sector: Optional[str]
+    industry_subsector: Optional[str]
+    industry_segment: Optional[str]
+    industry_classification: Optional[str]
+    industry_classification_eng: Optional[str]
+    activity: Optional[str]
+
+    company_segment: Optional[str]
+    company_segment_eng: Optional[str]
     company_category: Optional[str]
-    corporate_name: Optional[str]
+    company_type: Optional[str]
+
+    listing_segment: Optional[str]
+    registrar: Optional[str]
+    website: Optional[str]
+    institution_common: Optional[str]
+    institution_preferred: Optional[str]
+
+    market: Optional[str]
+    status: Optional[str]
+    market_indicator: Optional[str]
+
+    code: Optional[str]
+    has_bdr: Optional[bool]
+    type_bdr: Optional[str]
+    has_quotation: Optional[bool]
+    has_emissions: Optional[bool]
+
+    date_quotation: Optional[str]
+    last_date: Optional[str]
     listing_date: Optional[str]
-    start_situation_date: Optional[str]
-    situation: Optional[str]
-    situation_date: Optional[str]
-    country: Optional[str]
-    state: Optional[str]
-    city: Optional[str]
 
     @staticmethod
     def from_dict(raw: dict) -> "CompanyDTO":
-        """
-        Constrói um DTO imutável a partir de um dicionário bruto (normalmente vindo do scraper).
-        """
+        """Constrói um DTO imutável a partir de um dicionário bruto."""
+
         return CompanyDTO(
             cvm_code=raw.get("cvm_code") or raw.get("codeCVM"),
+            issuing_company=raw.get("issuing_company") or raw.get("issuingCompany"),
+            trading_name=raw.get("trading_name") or raw.get("tradingName"),
             company_name=raw.get("company_name") or raw.get("companyName"),
-            ticker=raw.get("ticker") or raw.get("issuingCompany"),
+            cnpj=raw.get("cnpj"),
             ticker_codes=raw.get("ticker_codes"),
             isin_codes=raw.get("isin_codes"),
-            trading_name=raw.get("trading_name") or raw.get("tradingName"),
-            sector=raw.get("sector"),
-            subsector=raw.get("subsector"),
-            segment=raw.get("segment"),
-            listing=raw.get("listing"),
+            other_codes=raw.get("other_codes"),
+            industry_sector=raw.get("industry_sector"),
+            industry_subsector=raw.get("industry_subsector"),
+            industry_segment=raw.get("industry_segment"),
+            industry_classification=raw.get("industry_classification"),
+            industry_classification_eng=raw.get("industry_classification_eng"),
             activity=raw.get("activity"),
-            registrar=raw.get("registrar"),
-            cnpj=raw.get("cnpj"),
-            website=raw.get("website"),
-            company_type=raw.get("company_type"),
-            status=raw.get("status"),
+            company_segment=raw.get("company_segment"),
+            company_segment_eng=raw.get("company_segment_eng"),
             company_category=raw.get("company_category"),
-            corporate_name=raw.get("corporate_name"),
+            company_type=raw.get("company_type"),
+            listing_segment=raw.get("listing_segment"),
+            registrar=raw.get("registrar"),
+            website=raw.get("website"),
+            institution_common=raw.get("institution_common"),
+            institution_preferred=raw.get("institution_preferred"),
+            market=raw.get("market"),
+            status=raw.get("status"),
+            market_indicator=raw.get("market_indicator"),
+            code=raw.get("code"),
+            has_bdr=raw.get("has_bdr"),
+            type_bdr=raw.get("type_bdr"),
+            has_quotation=raw.get("has_quotation"),
+            has_emissions=raw.get("has_emissions"),
+            date_quotation=raw.get("date_quotation"),
+            last_date=raw.get("last_date"),
             listing_date=raw.get("listing_date"),
-            start_situation_date=raw.get("start_situation_date"),
-            situation=raw.get("situation"),
-            situation_date=raw.get("situation_date"),
-            country=raw.get("country"),
-            state=raw.get("state"),
-            city=raw.get("city"),
         )
 
     @staticmethod
     def from_raw(raw: CompanyRawDTO) -> "CompanyDTO":
-        """Builds a CompanyDTO from a CompanyDTO instance."""
+        """Build a ``CompanyDTO`` from a ``CompanyRawDTO`` instance."""
+
+        other_codes = (
+            json.dumps([{"code": c.code, "isin": c.isin} for c in raw.other_codes])
+            if raw.other_codes
+            else None
+        )
 
         return CompanyDTO(
             cvm_code=raw.cvm_code,
+            issuing_company=raw.issuing_company,
+            trading_name=raw.trading_name,
             company_name=raw.company_name,
-            ticker=raw.ticker,
+            cnpj=raw.cnpj,
             ticker_codes=json.dumps(raw.ticker_codes) if raw.ticker_codes else None,
             isin_codes=json.dumps(raw.isin_codes) if raw.isin_codes else None,
-            trading_name=raw.trading_name,
-            sector=raw.sector,
-            subsector=raw.subsector,
-            segment=raw.industry_segment,
-            listing=raw.listing,
+            other_codes=other_codes,
+            industry_sector=raw.industry_sector,
+            industry_subsector=raw.industry_subsector,
+            industry_segment=raw.industry_segment,
+            industry_classification=raw.industry_classification,
+            industry_classification_eng=raw.industry_classification_eng,
             activity=raw.activity,
-            registrar=raw.registrar,
-            cnpj=raw.cnpj,
-            website=raw.website,
+            company_segment=raw.company_segment,
+            company_segment_eng=raw.company_segment_eng,
+            company_category=raw.company_category,
             company_type=raw.company_type,
+            listing_segment=raw.listing_segment,
+            registrar=raw.registrar,
+            website=raw.website,
+            institution_common=raw.institution_common,
+            institution_preferred=raw.institution_preferred,
+            market=raw.market,
             status=raw.status,
-            company_category=None,
-            corporate_name=None,
+            market_indicator=raw.market_indicator,
+            code=raw.code,
+            has_bdr=raw.has_bdr,
+            type_bdr=raw.type_bdr,
+            has_quotation=raw.has_quotation,
+            has_emissions=raw.has_emissions,
+            date_quotation=(
+                raw.date_quotation.strftime("%Y-%m-%d") if raw.date_quotation else None
+            ),
+            last_date=(raw.last_date.strftime("%Y-%m-%d") if raw.last_date else None),
             listing_date=(
                 raw.listing_date.strftime("%Y-%m-%d") if raw.listing_date else None
             ),
-            start_situation_date=None,
-            situation=None,
-            situation_date=None,
-            country=None,
-            state=None,
-            city=None,
         )

--- a/infrastructure/models/company_model.py
+++ b/infrastructure/models/company_model.py
@@ -70,13 +70,13 @@ class CompanyModel(Base):
             return getattr(dto, name, None)
 
         ticker_codes = attr("ticker_codes") or (
-            [] if attr("ticker") is None else [attr("ticker")]
+            [] if attr("issuing_company") is None else [attr("issuing_company")]
         )
         isin_codes = attr("isin_codes") or []
         other_codes = attr("other_codes") or []
 
         return CompanyModel(
-            cvm_code=attr("cvm_code") or attr("ticker") or "",
+            cvm_code=attr("cvm_code") or attr("issuing_company") or "",
             issuing_company=attr("issuing_company"),
             trading_name=attr("trading_name"),
             company_name=attr("company_name"),

--- a/infrastructure/scrapers/company_processors.py
+++ b/infrastructure/scrapers/company_processors.py
@@ -5,7 +5,7 @@ import json
 from typing import Dict, Optional
 
 from application import CompanyMapper
-from domain.dto import CompanyListingDTO, CompanyDetailDTO, CompanyRawDTO
+from domain.dto import CompanyDetailDTO, CompanyListingDTO, CompanyRawDTO
 from infrastructure.helpers import FetchUtils, MetricsCollector
 from infrastructure.helpers.data_cleaner import DataCleaner
 from infrastructure.logging import Logger
@@ -20,6 +20,8 @@ class EntryCleaner:
     def run(self, entry: Dict) -> CompanyListingDTO:
         cleaned = self.data_cleaner.clean_company_entry(entry)
         return CompanyListingDTO.from_dict(cleaned)
+
+
 #         entry["companyName"] = self.data_cleaner.clean_text(entry.get("companyName"))
 #         entry["issuingCompany"] = self.data_cleaner.clean_text(
 #             entry.get("issuingCompany")
@@ -81,7 +83,7 @@ class DetailFetcher:
         raw["hasBDR"] = raw.get("hasBDR")
         raw["typeBDR"] = raw.get("typeBDR")
         raw["describleCategoryBVMF"] = raw.get("describleCategoryBVMF")
-        raw["dateQuotation"] = raw.get("dateQuotation")
+        raw["dateQuotation"] = self.data_cleaner.clean_date(raw.get("dateQuotation"))
         return CompanyDetailDTO.from_dict(raw)
 
 

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -2,7 +2,6 @@ import types
 from unittest.mock import MagicMock
 
 from application.usecases.sync_companies import SyncCompaniesUseCase
-# from domain.dto import CompanyDTO, SyncCompaniesResultDTO
 from domain.dto.company_dto import CompanyDTO
 from domain.ports import CompanyRepositoryPort, CompanySourcePort
 from tests.conftest import DummyLogger
@@ -15,14 +14,14 @@ def test_execute_converts_and_saves():
     raw = types.SimpleNamespace(
         cvm_code="001",
         company_name="Acme",
-        ticker="ACM",
+        issuing_company="ACM",
         ticker_codes=["ACM"],
         isin_codes=["BRACM"],
         trading_name="Acme",
-        sector="Tech",
-        subsector="Software",
+        industry_sector="Tech",
+        industry_subsector="Software",
         industry_segment="IT",
-        listing="Novo Mercado",
+        listing_segment="Novo Mercado",
         activity="Development",
         registrar="B3",
         cnpj="00.000.000/0001-91",
@@ -30,6 +29,23 @@ def test_execute_converts_and_saves():
         company_type="SA",
         status="active",
         listing_date=None,
+        other_codes=[],
+        industry_classification=None,
+        industry_classification_eng=None,
+        company_segment=None,
+        company_segment_eng=None,
+        company_category=None,
+        institution_common=None,
+        institution_preferred=None,
+        market=None,
+        market_indicator=None,
+        code=None,
+        has_bdr=None,
+        type_bdr=None,
+        has_quotation=None,
+        has_emissions=None,
+        date_quotation=None,
+        last_date=None,
     )
 
     def fake_fetch_all(
@@ -51,7 +67,7 @@ def test_execute_converts_and_saves():
         max_workers=2,
     )
 
-#     result = usecase.execute()
+    #     result = usecase.execute()
     usecase.execute()
 
     repo.get_all_primary_keys.assert_called_once()
@@ -60,6 +76,7 @@ def test_execute_converts_and_saves():
     saved = repo.save_all.call_args.args[0]
     assert isinstance(saved[0], CompanyDTO)
     assert saved[0].cvm_code == "001"
+
 
 #     assert isinstance(result, SyncCompaniesResultDTO)
 #     assert result.processed_count == 1

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -5,9 +5,9 @@ from domain.dto.nsd_dto import NSDDTO
 
 
 def test_company_dto_from_dict():
-    raw = {"ticker": "XYZ", "company_name": "Xyz Corp"}
+    raw = {"issuing_company": "XYZ", "company_name": "Xyz Corp"}
     dto = CompanyDTO.from_dict(raw)
-    assert dto.ticker == "XYZ"
+    assert dto.issuing_company == "XYZ"
     assert dto.company_name == "Xyz Corp"
 
 

--- a/tests/infrastructure/test_company_repository.py
+++ b/tests/infrastructure/test_company_repository.py
@@ -14,8 +14,8 @@ def test_save_all(SessionLocal, engine):
     Base.metadata.create_all(engine)
 
     companies = [
-        CompanyDTO.from_dict({"ticker": "AAA", "company_name": "Alpha"}),
-        CompanyDTO.from_dict({"ticker": "BBB", "company_name": "Beta"}),
+        CompanyDTO.from_dict({"issuing_company": "AAA", "company_name": "Alpha"}),
+        CompanyDTO.from_dict({"issuing_company": "BBB", "company_name": "Beta"}),
     ]
     repo.save_all(companies)
 


### PR DESCRIPTION
## Summary
- sync CompanyDTO with the current RawCompanyDTO structure
- clean `dateQuotation` in CompanyDetailFetcher
- update CompanyModel adapter to use new `issuing_company` field
- update tests to the new DTO API

## Testing
- `pre-commit run --files domain/dto/company_dto.py infrastructure/models/company_model.py infrastructure/scrapers/company_processors.py tests/domain/test_dtos.py tests/infrastructure/test_company_repository.py tests/application/test_sync_companies_use_case.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68605a5d4528832e9f2ccb8e0ba34f6f