### PR TITLE
Translate Portuguese comments and docstrings

### DIFF
--- a/application/services/company_service.py
+++ b/application/services/company_service.py
@@ -7,9 +7,7 @@ from infrastructure.logging import Logger
 
 
 class CompanyService:
-    """
-    Application Service que coordena os casos de uso relacionados a Company.
-    """
+    """Coordinate company-related use cases within the application."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("company_service.CompanyService")
 
     def __init__(
@@ -19,7 +17,7 @@ class CompanyService:
         repository: CompanyRepositoryPort,
         scraper: CompanySourcePort,
     ):
-        """Initialize the service with injected repository and scraper."""
+        """Initialize dependencies for company synchronization."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("company_service.CompanyService.__init__")
         self.logger = logger
         self.config = config
@@ -33,13 +31,9 @@ class CompanyService:
         )
 
 #     def run(self) -> SyncCompaniesResultDTO:
-#         """
-#         Executa a sincronização de empresas usando o caso de uso apropriado.
-#         """
+#         """Run company synchronization and return a result summary."""
 #         return self.sync_usecase.execute()
     def run(self) -> None:
-        """
-        Executa a sincronização de empresas usando o caso de uso apropriado.
-        """
+        """Execute company synchronization using the injected use case."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("company_service.CompanyService.run()")
         self.sync_usecase.execute()

--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -10,9 +10,7 @@ from infrastructure.logging import Logger
 
 
 class SyncCompaniesUseCase:
-    """
-    UseCase responsável por sincronizar os dados das empresas da fonte externa com o repositório local.
-    """
+    """Use case for synchronizing company data from the scraper to the repository."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("sync_companies.SyncCompaniesUseCase")
     def __init__(
         self,
@@ -22,6 +20,7 @@ class SyncCompaniesUseCase:
         max_workers: int,
     ):
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("sync_companies.SyncCompaniesUseCase.__init__")
+        """Store dependencies and configure use case execution."""
         self.logger = logger
         self.logger.log("Start SyncCompaniesUseCase", level="info")
 
@@ -30,11 +29,12 @@ class SyncCompaniesUseCase:
         self.max_workers = max_workers
 
     def execute(self) -> SyncCompaniesResultDTO:
-        """
-        Executa a sincronização:
-        - Carrega dados do scraper (fonte externa)
-        - Converte para CompanyDTO
-        - Persiste no repositório
+        """Run the full synchronization pipeline.
+
+        Steps:
+            1. Fetch data from the scraper.
+            2. Convert results into ``CompanyDTO`` objects.
+            3. Persist them using the repository.
         """
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("sync_companies.SyncCompaniesUseCase.execute()")
         self.logger.log("SyncCompaniesUseCase Execute", level="info")

--- a/domain/dto/company_dto.py
+++ b/domain/dto/company_dto.py
@@ -8,7 +8,7 @@ from .raw_company_dto import CompanyRawDTO
 
 @dataclass(frozen=True)
 class CompanyDTO:
-    """Representa os dados estruturados de uma empresa listada na B3."""
+    """Structured company data extracted from B3."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("company_dto.CompanyDTO")
 
     cvm_code: Optional[str]
@@ -55,7 +55,7 @@ class CompanyDTO:
 
     @staticmethod
     def from_dict(raw: dict) -> "CompanyDTO":
-        """Constrói um DTO imutável a partir de um dicionário bruto."""
+        """Build an immutable DTO from a raw dictionary."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("company_dto CompanyDTO.from_dict()")
 
         return CompanyDTO(
@@ -94,6 +94,7 @@ class CompanyDTO:
             last_date=raw.get("last_date"),
             listing_date=raw.get("listing_date"),
         )
+
 
     @staticmethod
     def from_raw(raw: CompanyRawDTO) -> "CompanyDTO":

--- a/domain/dto/nsd_dto.py
+++ b/domain/dto/nsd_dto.py
@@ -19,14 +19,14 @@ class NSDDTO:
     sent_date: Optional[datetime]
     reason: Optional[str]
 
+
     @staticmethod
     def from_dict(raw: dict) -> "NSDDTO":
-        """
-        Constrói um NSDDTO a partir de um dicionário bruto vindo do scraping.
+        """Build an ``NSDDTO`` from scraped raw data.
 
-        Converte valores de datas para string no formato 'YYYY-MM-DD' ou 'YYYY-MM-DD HH:MM:SS',
-        caso já estejam como datetime. Não realiza parsing — espera-se que o HTML já tenha
-        sido transformado em tipos Python apropriados.
+        Date values are converted to ``YYYY-MM-DD`` or ``YYYY-MM-DD HH:MM:SS`` strings
+        if already ``datetime`` objects. Parsing is not performed; the HTML is expected
+        to be preprocessed into proper Python types.
         """
         def format_date(val: Optional[datetime]) -> Optional[str]:
             if isinstance(val, datetime):

--- a/infrastructure/config/database.py
+++ b/infrastructure/config/database.py
@@ -16,13 +16,13 @@ TABLES = {
 
 @dataclass(frozen=True)
 class DatabaseConfig:
-    """
-    Configuração do banco de dados SQLite.
+    """SQLite database configuration.
+
     Attributes:
-        data_dir: Diretório onde o arquivo de banco será armazenado.
-        db_file_name: Nome do arquivo SQLite.
-        db_path: Caminho completo para o arquivo de banco.
-        connection_string: URI de conexão SQLAlchemy.
+        data_dir: Directory where the database file is stored.
+        db_file_name: SQLite file name.
+        db_path: Full path to the database file.
+        connection_string: SQLAlchemy connection URI.
     """
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("database.DatabaseConfig")
 
@@ -34,14 +34,16 @@ class DatabaseConfig:
     def __post_init__(self):
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("DatabaseConfig.__post_init__")
 
-        # Calcula dinamicamente a URI de conexão
+        # Dynamically compute the connection URI
         object.__setattr__(
             self,
             "connection_string",
             f"sqlite:///{self.data_dir / self.db_filename}"
         )
 
+
 def load_database_config() -> DatabaseConfig:
+    """Load the database configuration using project paths."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("database.load_database_config()")
 
     paths = load_paths()

--- a/infrastructure/config/paths.py
+++ b/infrastructure/config/paths.py
@@ -9,13 +9,13 @@ DATA_DIR = "data"
 
 @dataclass(frozen=True)
 class PathConfig:
-    """
-    Configura os caminhos principais do sistema.
+    """Configuration for important filesystem paths.
+
     Attributes:
-        root_dir: Diretório raiz absoluto do projeto (calculado automaticamente).
-        temp_dir: Subpasta para arquivos temporários.
-        log_dir: Subpasta para arquivos de log.
-        data_dir: Subpasta para bancos de dados.
+        root_dir: Absolute project root directory (computed automatically).
+        temp_dir: Subfolder for temporary files.
+        log_dir: Subfolder for log files.
+        data_dir: Subfolder for databases.
     """
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("config.paths.PathConfig")
     temp_dir: Path = field(init=False)
@@ -25,23 +25,22 @@ class PathConfig:
 
     def __post_init__(self):
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("config.paths.PathConfig.__post_init__")
-        # Define o root_dir como o diretório do projeto
+        # Set root_dir to the project directory
         root = Path(__file__).resolve().parent.parent.parent
         object.__setattr__(self, "root_dir", root)
         object.__setattr__(self, "temp_dir", root / TEMP_DIR)
         object.__setattr__(self, "log_dir", root / LOG_DIR)
         object.__setattr__(self, "data_dir", root / DATA_DIR)
 
-        # Cria as pastas se ainda não existirem
+        # Create folders if they do not already exist
         for fld in fields(self):
             p = getattr(self, fld.name)
             if isinstance(p, Path) and fld.name != "root_dir":
                 p.mkdir(parents=True, exist_ok=True)
 
+
 def load_paths() -> PathConfig:
-    """
-    Cria e retorna uma instância de PathConfig com os diretórios garantidos.
-    """
+    """Create and return a ``PathConfig`` instance with ensured directories."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("config.paths.load_paths")
 
     return PathConfig()

--- a/infrastructure/config/scraping.py
+++ b/infrastructure/config/scraping.py
@@ -14,15 +14,15 @@ LANGUAGES_JSON = "languages.json"  # Arquivo JSON com Accept-Language
 
 @dataclass(frozen=True)
 class ScrapingConfig:
-    """
-    Configurações gerais para web-scraping.
+    """General settings for web scraping.
+
     Attributes:
-        test_internet: URL usada para verificar conectividade.
-        timeout: Tempo máximo de espera em cada requisição.
-        max_attempts: Número máximo de tentativas em caso de falha.
-        user_agents: Lista de User-Agent, carregada de user_agents.json.
-        referers: Lista de Referer, carregada de referers.json.
-        languages: Lista de Accept-Language, carregada de languages.json.
+        test_internet: URL used to check connectivity.
+        timeout: Maximum wait time for each request.
+        max_attempts: Maximum retry attempts if a request fails.
+        user_agents: List of user-agent strings loaded from ``user_agents.json``.
+        referers: List of referer strings loaded from ``referers.json``.
+        languages: List of Accept-Language headers from ``languages.json``.
     """
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("scraping.ScrapingConfig")
 
@@ -33,12 +33,9 @@ class ScrapingConfig:
     timeout: int = field(default=TIMEOUT)
     max_attempts: int = field(default=MAX_ATTEMPTS)
 
+
 def load_scraping_config() -> ScrapingConfig:
-    """
-    Cria e retorna uma instância de ScrapingConfig.
-    Os valores de test_internet, timeout e max_attempts ficam aqui,
-    enquanto user_agents, referers e languages vêm de arquivos JSON separados.
-    """
+    """Create a :class:`ScrapingConfig` from bundled JSON files."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("scraping load_scraping_config")
 
     base = Path(__file__).parent

--- a/infrastructure/factories.py
+++ b/infrastructure/factories.py
@@ -2,10 +2,8 @@ from infrastructure.helpers.data_cleaner import DataCleaner
 from infrastructure.config import Config
 from infrastructure.logging import Logger
 
+
 def create_data_cleaner(config: Config, logger: Logger) -> DataCleaner:
-    """
-    Fábrica parametrizada: recebe config e logger,
-    devolve um DataCleaner pronto para uso.
-    """
+    """Factory that builds a ready-to-use ``DataCleaner`` instance."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("factories.create_data_cleaner() WHERE IS THIS?")
     return DataCleaner(config, logger)

--- a/infrastructure/helpers/data_cleaner.py
+++ b/infrastructure/helpers/data_cleaner.py
@@ -11,9 +11,9 @@ from infrastructure.logging import Logger
 
 
 class DataCleaner:
-    """
-    Classe utilitária para normalização de dados brutos (textos, datas, números).
-    Depende de configuração externa (ex: palavras a remover) e logger.
+    """Utility class for normalizing raw text, dates and numbers.
+
+    Requires external configuration (e.g. words to remove) and a logger.
     """
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("data_cleaner.DataCleaner")
 
@@ -25,7 +25,7 @@ class DataCleaner:
     def clean_text(
         self, text: Optional[str], words_to_remove: Optional[List[str]] = None
     ) -> Optional[str]:
-        """Normaliza texto: remove pontuação, acentos, palavras específicas."""
+        """Normalize a text string by removing punctuation, accents and stop words."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("DataCleaner.clean_text()")
         try:
             if not text:
@@ -45,11 +45,11 @@ class DataCleaner:
 
             return text
         except Exception as e:
-            self.logger.log(f"Erro ao limpar texto: {e}", level="warning")
+            self.logger.log(f"Failed to clean text: {e}", level="warning")
             return None
 
     def clean_number(self, text: str) -> Optional[float]:
-        """Converte número textual (BR/US) para float."""
+        """Convert a stringified number (BR/US formats) to ``float``."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("DataCleaner.clean_number()")
         if not text:
             return None
@@ -57,11 +57,11 @@ class DataCleaner:
             text = text.replace(".", "").replace(",", ".")
             return float(text)
         except Exception as e:
-            self.logger.log(f"Erro ao limpar número: {e}", level="warning")
+            self.logger.log(f"Failed to clean number: {e}", level="warning")
             return None
 
     def clean_date(self, text: Optional[str]) -> Optional[datetime]:
-        """Tenta converter string em datetime a partir de padrões comuns."""
+        """Attempt to parse a date string using several common formats."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("DataCleaner.clean_date()")
         if isinstance(text, datetime):
             return text
@@ -84,7 +84,8 @@ class DataCleaner:
                 continue
 
         self.logger.log(
-            f"Erro ao limpar data: formato não reconhecido: '{text}'", level="debug"
+            f"Failed to parse date: unsupported format '{text}'",
+            level="debug",
         )
         return None
 

--- a/infrastructure/helpers/thread_utils.py
+++ b/infrastructure/helpers/thread_utils.py
@@ -4,19 +4,17 @@ from infrastructure.config import Config
 
 
 class WorkerThreadIdentifier:
-    """
-    Gera e mantém identificadores legíveis e exclusivos por thread no pool.
+    """Generate readable, unique identifiers for worker threads.
 
-    Exemplo de identificador: "W1", "W2", ..., até o limite de max_workers definido no Config.
+    Example identifiers: ``"W1"``, ``"W2"``, up to the ``max_workers`` limit from ``Config``.
     """
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("threading.WorkerThreadIdentifier")
 
     def __init__(self, config: Config):
-        """
-        Inicializa o gerador com base no número máximo de workers permitidos.
+        """Initialize the generator using the configured ``max_workers`` value.
 
         Args:
-            config (Config): Configuração global da aplicação.
+            config: Application configuration with ``max_workers``.
         """
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("WorkerThreadIdentifier.__init__")
         self._max_workers = config.global_settings.max_workers or 1
@@ -24,11 +22,10 @@ class WorkerThreadIdentifier:
         self._counter = iter(range(1, self._max_workers + 1))
 
     def get_worker_name(self) -> str:
-        """
-        Retorna um nome exclusivo de worker para a thread atual, reusado enquanto ela viver.
+        """Return a unique worker name for the current thread.
 
         Returns:
-            str: Nome como "W1", "W2", etc.
+            str: A name such as ``"W1"`` or ``"W2"`` reused while the thread lives.
         """
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("WorkerThreadIdentifier.get_worker_name")
         if not hasattr(self._thread_local, "worker_name"):

--- a/infrastructure/helpers/time_utils.py
+++ b/infrastructure/helpers/time_utils.py
@@ -7,26 +7,23 @@ from infrastructure.config import Config
 
 
 class TimeUtils:
-    """
-    Utilitários para controle de tempo adaptado à carga da CPU.
-    """
+    """Helper for dynamic sleep intervals based on CPU usage."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("time_utils.TimeUtils")
     def __init__(self, config: Config):
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("TimeUtils.__init__")
         self.config = config
 
     def sleep_dynamic(self, wait: Optional[float] = None, cpu_interval: Optional[float] = None) -> None:
-        """
-        Aguarda dinamicamente com base no uso de CPU.
+        """Sleep for a dynamically adjusted time based on CPU utilization.
 
-        A lógica ajusta o tempo de espera:
-        - Alta CPU (>80%): aumenta aleatoriamente o delay.
-        - Média CPU (50–80%): delay moderado.
-        - Baixa CPU (<50%): delay curto.
+        The logic adjusts the delay as follows:
+        - High CPU (>80%): randomly increases the wait time.
+        - Medium CPU (50–80%): moderate delay.
+        - Low CPU (<50%): short delay.
 
         Args:
-            wait (float): Tempo base de espera.
-            cpu_interval (float): Intervalo de amostragem da CPU.
+            wait: Base wait time in seconds.
+            cpu_interval: Sampling interval for ``psutil.cpu_percent``.
         """
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("TimeUtils.sleep_dynamic()")
         wait = wait or self.config.global_settings.wait or 2

--- a/infrastructure/logging/context_tracker.py
+++ b/infrastructure/logging/context_tracker.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 
 class ContextTracker:
-    """
-    Extrai a origem da chamada no projeto para logs de depuração.
-    """
+    """Extracts the call origin within the project for debugging logs."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("context_tracker.ContextTracker")
 
     def __init__(self, project_root: Path):
@@ -15,10 +13,7 @@ class ContextTracker:
         self.project_root = project_root
 
     def get_context(self) -> str:
-        """
-        Retorna string no formato:
-        "line X of func() in 'relative/path/file.py' <- ..."
-        """
+        """Return a string like ``"line X of func() in 'path/file.py' <- ..."``."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("ContextTracker.get_context()")
         try:
             stack = inspect.stack()

--- a/infrastructure/logging/logger.py
+++ b/infrastructure/logging/logger.py
@@ -9,11 +9,7 @@ from infrastructure.logging.context_tracker import ContextTracker
 
 
 class Logger:
-    """
-    Logger da aplicação.
-    Encapsula configuração, contexto e formatação de progresso.
-    Usa o sistema de logging nativo do Python.
-    """
+    """Application logger wrapping Python's ``logging`` module."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("logger.Logger")
 
     def __init__(self, config: Config, level: str = "DEBUG", logger_name: Optional[str] = None):
@@ -28,9 +24,7 @@ class Logger:
         self._logger = self._setup_logger(level)
 
     def _setup_logger(self, level: str) -> logging.LoggerAdapter:
-        """
-        Configura o logger nativo do Python com handlers para terminal e arquivo.
-        """
+        """Configure the underlying ``logging`` logger with console and file handlers."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("Logger.setup_logger()")
         log_path = self.config.logging.full_path
         logger = logging.getLogger(self.logger_name)
@@ -57,9 +51,7 @@ class Logger:
         return adapter
 
     def log(self, message: str, level: str = "info", progress: Optional[dict] = None, extra: Optional[dict] = None, worker_id: Optional[str] = None):
-        """
-        Registra uma mensagem com contexto e progresso, se aplicável.
-        """
+        """Log a message with optional progress and context information."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("Logger.log()")
         context_msg = self.context_tracker.get_context() if level.lower() == "debug" else ""
         progress_msg = self.progress_formatter.format(progress) if progress else ""
@@ -91,6 +83,7 @@ class Logger:
 
 
 class SafeFormatter(logging.Formatter):
+    """Formatter that injects default values for missing log attributes."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("logger.SafeFormatter")
     def format(self, record):
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("SafeFormatter.format()")
@@ -107,7 +100,9 @@ class SafeFormatter(logging.Formatter):
 
         return super().format(record)
 
+
 class MergedLoggerAdapter(logging.LoggerAdapter):
+    """Logger adapter that merges ``extra`` dictionaries from calls and defaults."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("logger.MergedLoggerAdapter")
     def process(self, msg, kwargs):
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("MergedLoggerAdapter.process()")

--- a/infrastructure/logging/progress_formatter.py
+++ b/infrastructure/logging/progress_formatter.py
@@ -3,15 +3,11 @@ import time
 
 
 class ProgressFormatter:
-    """
-    Responsável por formatar informações de progresso para logs.
-    """
+    """Format progress information for logging."""
     import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("progress_formatter.ProgressFormatter")
 
     def format(self, progress: dict) -> str:
-        """
-        Gera uma string como: "15/100 | 15.00% | 0h00m10s + 0h01m00s = 0h01m10s e extra_info"
-        """
+        """Return a formatted progress string like ``"15/100 | 15.00% | 0h00m10s + 0h01m00s = 0h01m10s"``."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("ProgressFormatter.format()")
         try:
             index = progress.get("index", 0)

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -116,11 +116,7 @@ class SQLiteCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryPort)
             session.close()
 
     def get_all_primary_keys(self) -> set[str]:
-        """
-        Retorna um conjunto com todos os códigos CVM já salvos no banco.
-
-        :return: Conjunto de códigos CVM únicos.
-        """
+        """Return a set of all CVM codes already persisted."""
         import logging; logging.basicConfig(level=logging.DEBUG); logging.debug("SQLiteCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryPort).get_all_primary_keys()")
         session = self.Session()
         try:


### PR DESCRIPTION
## Summary
- translate Portuguese docs in company_service and sync_companies
- update infrastructure helpers and config modules
- add English Google-style docstrings
- enforce two blank lines before top level definitions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861396e7c28832eb7e7c80407ef5594