### PR TITLE
Refactor services to depend on ports

### DIFF
--- a/application/services/company_service.py
+++ b/application/services/company_service.py
@@ -1,8 +1,6 @@
 from application.usecases.sync_companies import SyncCompaniesUseCase
-# from domain.dto import SyncCompaniesResultDTO
-from domain.ports import CompanyRepositoryPort, CompanySourcePort
+from domain.ports import CompanyRepositoryPort, CompanySourcePort, LoggerPort
 from infrastructure.config import Config
-from infrastructure.logging import Logger
 
 
 class CompanyService:
@@ -11,14 +9,14 @@ class CompanyService:
     def __init__(
         self,
         config: Config,
-        logger: Logger,
+        logger: LoggerPort,
         repository: CompanyRepositoryPort,
         scraper: CompanySourcePort,
     ):
         """Initialize dependencies for company synchronization."""
         self.logger = logger
         self.config = config
-        logger.log("Start CompanyService", level="info")
+        self.logger.log("Start CompanyService", level="info")
 
         self.sync_usecase = SyncCompaniesUseCase(
             logger=self.logger,
@@ -27,9 +25,6 @@ class CompanyService:
             max_workers=self.config.global_settings.max_workers,
         )
 
-#     def run(self) -> SyncCompaniesResultDTO:
-#         """Run company synchronization and return a result summary."""
-#         return self.sync_usecase.execute()
     def run(self) -> None:
         """Execute company synchronization using the injected use case."""
         self.sync_usecase.execute()

--- a/application/services/nsd_service.py
+++ b/application/services/nsd_service.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
-from infrastructure.logging import Logger
-from infrastructure.repositories.nsd_repository import SQLiteNSDRepository
-from infrastructure.scrapers.nsd_scraper import NsdScraper
 from application.usecases.sync_nsd import SyncNSDUseCase
+from domain.ports import LoggerPort, NSDRepositoryPort, NSDSourcePort
 
 
 class NsdService:
-    """Application service that orchestrates NSD scraping and persistence."""
+    """Application service that orchestrates NSD synchronization."""
 
     def __init__(
-        self, logger: Logger, repository: SQLiteNSDRepository, scraper: NsdScraper
+        self,
+        logger: LoggerPort,
+        repository: NSDRepositoryPort,
+        scraper: NSDSourcePort,
     ) -> None:
         self.logger = logger
-        logger.log("Start NsdService", level="info")
+        self.logger.log("Start NsdService", level="info")
 
         self.sync_usecase = SyncNSDUseCase(
             logger=self.logger, repository=repository, scraper=scraper

--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -4,16 +4,16 @@ from typing import List
 from domain.dto import SyncCompaniesResultDTO
 from domain.dto.company_dto import CompanyDTO
 from domain.dto.raw_company_dto import CompanyRawDTO
-from domain.ports import CompanyRepositoryPort, CompanySourcePort
-from infrastructure.logging import Logger
+from domain.ports import CompanyRepositoryPort, CompanySourcePort, LoggerPort
 
 
 class SyncCompaniesUseCase:
-    """Use case for synchronizing company data from the scraper to the repository."""
+    """Use case for synchronizing company data from the scraper to the
+    repository."""
 
     def __init__(
         self,
-        logger: Logger,
+        logger: LoggerPort,
         repository: CompanyRepositoryPort,
         scraper: CompanySourcePort,
         max_workers: int,

--- a/application/usecases/sync_nsd.py
+++ b/application/usecases/sync_nsd.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 from domain.dto.nsd_dto import NSDDTO
-from infrastructure.logging import Logger
-from infrastructure.repositories.nsd_repository import SQLiteNSDRepository
-from infrastructure.scrapers.nsd_scraper import NsdScraper
+from domain.ports import LoggerPort, NSDRepositoryPort, NSDSourcePort
 
 
 class SyncNSDUseCase:
     """Use case responsible for synchronizing NSD documents."""
 
     def __init__(
-        self, logger: Logger, repository: SQLiteNSDRepository, scraper: NsdScraper
-    ):
+        self,
+        logger: LoggerPort,
+        repository: NSDRepositoryPort,
+        scraper: NSDSourcePort,
+    ) -> None:
         self.logger = logger
         self.logger.log("Start SyncNSDUseCase", level="info")
 

--- a/domain/dto/company_dto.py
+++ b/domain/dto/company_dto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 from typing import Optional
@@ -91,7 +93,6 @@ class CompanyDTO:
             last_date=raw.get("last_date"),
             listing_date=raw.get("listing_date"),
         )
-
 
     @staticmethod
     def from_raw(raw: CompanyRawDTO) -> "CompanyDTO":

--- a/domain/dto/nsd_dto.py
+++ b/domain/dto/nsd_dto.py
@@ -1,8 +1,10 @@
 # domain/models/nsd_dto.py
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
 from datetime import datetime
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -19,7 +21,6 @@ class NSDDTO:
     sent_date: Optional[datetime]
     reason: Optional[str]
 
-
     @staticmethod
     def from_dict(raw: dict) -> "NSDDTO":
         """Build an ``NSDDTO`` from scraped raw data.
@@ -28,6 +29,7 @@ class NSDDTO:
         if already ``datetime`` objects. Parsing is not performed; the HTML is expected
         to be preprocessed into proper Python types.
         """
+
         def format_date(val: Optional[datetime]) -> Optional[str]:
             if isinstance(val, datetime):
                 return val.strftime("%Y-%m-%d %H:%M:%S")
@@ -46,5 +48,5 @@ class NSDDTO:
             responsible_auditor=raw.get("responsible_auditor"),
             protocol=raw.get("protocol"),
             sent_date=raw.get("sent_date"),
-            reason=raw.get("reason")
+            reason=raw.get("reason"),
         )

--- a/domain/dto/page_result_dto.py
+++ b/domain/dto/page_result_dto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Dict, List
 

--- a/domain/dto/raw_company_dto.py
+++ b/domain/dto/raw_company_dto.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from typing import List, Optional
-import json
 
 
 @dataclass(frozen=True)
@@ -32,13 +34,12 @@ class CompanyListingDTO:
 
     @staticmethod
     def from_dict(raw: dict) -> "CompanyListingDTO":
-
         return CompanyListingDTO(
             cvm_code=raw.get("codeCVM"),
             issuing_company=raw.get("issuingCompany"),
             company_name=raw.get("companyName"),
             trading_name=raw.get("tradingName"),
-            cnpj=raw.get("cnpj"), 
+            cnpj=raw.get("cnpj"),
             market_indicator=raw.get("marketIndicator"),
             type_bdr=raw.get("typeBDR"),
             listing_date=raw.get("dateListing"),
@@ -86,7 +87,9 @@ class CompanyDetailDTO:
         other_codes = raw.get("otherCodes") or []
         if isinstance(other_codes, str):
             other_codes = json.loads(other_codes)
-        code_dtos = [CodeDTO(code=c.get("code"), isin=c.get("isin")) for c in other_codes]
+        code_dtos = [
+            CodeDTO(code=c.get("code"), isin=c.get("isin")) for c in other_codes
+        ]
         company_detail_dto = CompanyDetailDTO(
             issuing_company=raw.get("issuingCompany"),
             company_name=raw.get("companyName"),
@@ -111,7 +114,6 @@ class CompanyDetailDTO:
             type_bdr=raw.get("typeBDR"),
             company_category=raw.get("describleCategoryBVMF"),
             date_quotation=raw.get("dateQuotation"),
-
             listing_segment=raw.get("listingSegment"),
             registrar=raw.get("registrar"),
         )
@@ -131,7 +133,7 @@ class CompanyRawDTO:
     ticker_codes: List[str]
     isin_codes: List[str]
     other_codes: List[CodeDTO]
-    
+
     industry_sector: Optional[str]
     industry_subsector: Optional[str]
     industry_segment: Optional[str]
@@ -149,7 +151,7 @@ class CompanyRawDTO:
     website: Optional[str]
     institution_common: Optional[str]
     institution_preferred: Optional[str]
-    
+
     market: Optional[str]
     status: Optional[str]
     market_indicator: Optional[str]
@@ -159,7 +161,7 @@ class CompanyRawDTO:
     type_bdr: Optional[str]
     has_quotation: Optional[bool]
     has_emissions: Optional[bool]
-    
+
     date_quotation: Optional[datetime]
     last_date: Optional[datetime]
     listing_date: Optional[datetime]

--- a/domain/dto/sync_companies_result_dto.py
+++ b/domain/dto/sync_companies_result_dto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import List, Optional
 

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -1,8 +1,8 @@
 from .company_repository_port import CompanyRepositoryPort
 from .company_source_port import CompanySourcePort
+from .nsd_repository_port import NSDRepositoryPort
+from .nsd_source_port import NSDSourcePort
 from .worker_pool_port import ExecutionResult, LoggerPort, Metrics, WorkerPoolPort
-from .company_repository_port import CompanyRepositoryPort
-from .company_source_port import CompanySourcePort
 
 __all__ = [
     "WorkerPoolPort",
@@ -11,4 +11,6 @@ __all__ = [
     "ExecutionResult",
     "CompanyRepositoryPort",
     "CompanySourcePort",
+    "NSDRepositoryPort",
+    "NSDSourcePort",
 ]

--- a/domain/ports/nsd_repository_port.py
+++ b/domain/ports/nsd_repository_port.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Set
+
+from domain.dto.nsd_dto import NSDDTO
+
+
+class NSDRepositoryPort(ABC):
+    """Port for NSD persistence operations."""
+
+    @abstractmethod
+    def save_all(self, items: List[NSDDTO]) -> None:
+        """Persist a batch of NSD records."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_all_primary_keys(self) -> Set[int]:
+        """Return all stored NSD identifiers."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_by_id(self, id: int) -> NSDDTO:
+        """Retrieve an NSD record by its ID."""
+        raise NotImplementedError

--- a/domain/ports/nsd_source_port.py
+++ b/domain/ports/nsd_source_port.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, List, Optional, Set
+
+
+class NSDSourcePort(ABC):
+    """Port for external NSD data providers."""
+
+    @abstractmethod
+    def fetch_all(
+        self,
+        start: int = 1,
+        max_nsd: Optional[int] = None,
+        skip_codes: Optional[Set[int]] = None,
+        save_callback: Optional[Callable[[List[Dict]], None]] = None,
+        threshold: Optional[int] = None,
+    ) -> List[Dict]:
+        """Fetch all available NSD records."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- add NSD ports and use them across services
- update services to log via the LoggerPort interface
- add `from __future__ import annotations` to DTO modules

## Testing
- `ruff format application/services/company_service.py application/services/nsd_service.py application/usecases/sync_companies.py application/usecases/sync_nsd.py domain/dto/company_dto.py domain/dto/nsd_dto.py domain/dto/page_result_dto.py domain/dto/raw_company_dto.py domain/dto/sync_companies_result_dto.py domain/ports/__init__.py domain/ports/nsd_repository_port.py domain/ports/nsd_source_port.py`
- `ruff check application/services/company_service.py application/services/nsd_service.py application/usecases/sync_companies.py application/usecases/sync_nsd.py domain/dto/company_dto.py domain/dto/nsd_dto.py domain/dto/page_result_dto.py domain/dto/raw_company_dto.py domain/dto/sync_companies_result_dto.py domain/ports/__init__.py domain/ports/nsd_repository_port.py domain/ports/nsd_source_port.py --fix`
- `docformatter --in-place application/services/company_service.py application/services/nsd_service.py application/usecases/sync_companies.py application/usecases/sync_nsd.py domain/dto/company_dto.py domain/dto/nsd_dto.py domain/dto/page_result_dto.py domain/dto/raw_company_dto.py domain/dto/sync_companies_result_dto.py domain/ports/__init__.py domain/ports/nsd_repository_port.py domain/ports/nsd_source_port.py`
- `pydocstyle --convention=google application/services/company_service.py application/services/nsd_service.py application/usecases/sync_companies.py application/usecases/sync_nsd.py domain/dto/company_dto.py domain/dto/nsd_dto.py domain/dto/page_result_dto.py domain/dto/raw_company_dto.py domain/dto/sync_companies_result_dto.py domain/ports/__init__.py domain/ports/nsd_repository_port.py domain/ports/nsd_source_port.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861816f88b4832eb2861fca6ccd50d6