### PR TITLE
Align worker pool data classes with DTO standards

### DIFF
--- a/WORKER_POOL.md
+++ b/WORKER_POOL.md
@@ -3,7 +3,7 @@
 The worker pool in `infrastructure.helpers.worker_pool.WorkerPool` wraps `ThreadPoolExecutor`.
 
 ```
-ExecutionResult = WorkerPool.run(tasks, processor, logger,
+ExecutionResultDTO = WorkerPool.run(tasks, processor, logger,
                                  on_result=None,
                                  post_callback=None)
 ```

--- a/application/services/company_service.py
+++ b/application/services/company_service.py
@@ -25,6 +25,6 @@ class CompanyService:
             max_workers=self.config.global_settings.max_workers,
         )
 
-    def run(self) -> None:
+    def run(self):
         """Execute company synchronization using the injected use case."""
-        self.sync_usecase.execute()
+        return self.sync_usecase.execute()

--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -39,7 +39,7 @@ class SyncCompaniesUseCase:
         start = time.perf_counter()
         existing_codes = self.repository.get_all_primary_keys()
 
-        self.scraper.fetch_all(
+        results = self.scraper.fetch_all(
             skip_codes=existing_codes,
             save_callback=self._save_batch,
             max_workers=self.max_workers,
@@ -51,12 +51,12 @@ class SyncCompaniesUseCase:
             level="info",
         )
 
-    #         return SyncCompaniesResultDTO(
-    #             processed_count=len(results),
-    #             skipped_count=len(existing_codes),
-    #             bytes_downloaded=bytes_downloaded,
-    #             elapsed_time=elapsed,
-    #         )
+        return SyncCompaniesResultDTO(
+            processed_count=len(results),
+            skipped_count=len(existing_codes),
+            bytes_downloaded=bytes_downloaded,
+            elapsed_time=elapsed,
+        )
 
     def _save_batch(self, buffer: List[CompanyRawDTO]) -> None:
         """Convert raw companies to domain DTOs before saving."""

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -2,13 +2,18 @@ from .company_repository_port import CompanyRepositoryPort
 from .company_source_port import CompanySourcePort
 from .nsd_repository_port import NSDRepositoryPort
 from .nsd_source_port import NSDSourcePort
-from .worker_pool_port import ExecutionResult, LoggerPort, Metrics, WorkerPoolPort
+from .worker_pool_port import (
+    ExecutionResultDTO,
+    LoggerPort,
+    MetricsDTO,
+    WorkerPoolPort,
+)
 
 __all__ = [
     "WorkerPoolPort",
-    "Metrics",
+    "MetricsDTO",
     "LoggerPort",
-    "ExecutionResult",
+    "ExecutionResultDTO",
     "CompanyRepositoryPort",
     "CompanySourcePort",
     "NSDRepositoryPort",

--- a/domain/ports/worker_pool_port.py
+++ b/domain/ports/worker_pool_port.py
@@ -20,8 +20,8 @@ class LoggerPort(Protocol):
         raise NotImplementedError
 
 
-@dataclass
-class Metrics:
+@dataclass(frozen=True)
+class MetricsDTO:
 
     elapsed_time: float
     network_bytes: int = 0
@@ -29,12 +29,12 @@ class Metrics:
     failures: int = 0
 
 
-@dataclass
-class ExecutionResult(Generic[R]):
+@dataclass(frozen=True)
+class ExecutionResultDTO(Generic[R]):
     """Results and metrics returned by :class:`WorkerPoolPort.run`."""
 
     items: List[R]
-    metrics: Metrics
+    metrics: MetricsDTO
 
 
 class WorkerPoolPort(Protocol):
@@ -46,5 +46,5 @@ class WorkerPoolPort(Protocol):
         logger: LoggerPort,
         on_result: Optional[Callable[[R], None]] = None,
         post_callback: Optional[Callable[[List[R]], None]] = None,
-    ) -> ExecutionResult[R]:
+    ) -> ExecutionResultDTO[R]:
         raise NotImplementedError

--- a/infrastructure/helpers/metrics_collector.py
+++ b/infrastructure/helpers/metrics_collector.py
@@ -30,11 +30,11 @@ class MetricsCollector:
         return self._processing_bytes
 
     def get_metrics(self, elapsed_time: float):
-        from domain.ports.worker_pool_port import Metrics
+        from domain.ports.worker_pool_port import MetricsDTO
 
-        """Create a :class:`Metrics` instance from the collected values."""
+        """Create a :class:`MetricsDTO` instance from the collected values."""
 
-        return Metrics(
+        return MetricsDTO(
             elapsed_time=elapsed_time,
             network_bytes=self._network_bytes,
             processing_bytes=self._processing_bytes,

--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Iterable, List, Optional, TypeVar
 
 from domain.ports.worker_pool_port import (
-    ExecutionResult,
+    ExecutionResultDTO,
     LoggerPort,
     WorkerPoolPort,
 )
@@ -41,7 +41,7 @@ class WorkerPool(WorkerPoolPort):
         logger: LoggerPort,
         on_result: Optional[Callable[[R], None]] = None,
         post_callback: Optional[Callable[[List[R]], None]] = None,
-    ) -> ExecutionResult[R]:
+    ) -> ExecutionResultDTO[R]:
         """Process ``tasks`` concurrently using ``processor``."""
 
         logger.log(f"worker pool start {processor.__qualname__}", level="info")
@@ -86,4 +86,4 @@ class WorkerPool(WorkerPoolPort):
             level="info",
         )
 
-        return ExecutionResult(items=results, metrics=metrics)
+        return ExecutionResultDTO(items=results, metrics=metrics)

--- a/tests/application/test_company_service.py
+++ b/tests/application/test_company_service.py
@@ -37,10 +37,7 @@ def test_run_calls_usecase_execute(monkeypatch):
         max_workers=3,
     )
 
-#     result = service.run()
-
-#     mock_usecase_inst.execute.assert_called_once()
-#     assert result == mock_usecase_inst.execute.return_value
-    service.run()
+    result = service.run()
 
     mock_usecase_inst.execute.assert_called_once()
+    assert result == mock_usecase_inst.execute.return_value

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 from application.usecases.sync_companies import SyncCompaniesUseCase
 from domain.dto.company_dto import CompanyDTO
+from domain.dto.sync_companies_result_dto import SyncCompaniesResultDTO
 from domain.ports import CompanyRepositoryPort, CompanySourcePort
 from tests.conftest import DummyLogger
 
@@ -67,8 +68,7 @@ def test_execute_converts_and_saves():
         max_workers=2,
     )
 
-    #     result = usecase.execute()
-    usecase.execute()
+    result = usecase.execute()
 
     repo.get_all_primary_keys.assert_called_once()
     scraper.fetch_all.assert_called_once()
@@ -77,8 +77,7 @@ def test_execute_converts_and_saves():
     assert isinstance(saved[0], CompanyDTO)
     assert saved[0].cvm_code == "001"
 
-
-#     assert isinstance(result, SyncCompaniesResultDTO)
-#     assert result.processed_count == 1
-#     assert result.skipped_count == 1
-#     assert result.bytes_downloaded == 100
+    assert isinstance(result, SyncCompaniesResultDTO)
+    assert result.processed_count == 1
+    assert result.skipped_count == 1
+    assert result.bytes_downloaded == 100


### PR DESCRIPTION
## Summary
- rename `Metrics` and `ExecutionResult` to `MetricsDTO` and `ExecutionResultDTO`
- make the DTOs immutable
- return `SyncCompaniesResultDTO` from `SyncCompaniesUseCase`
- propagate return value through `CompanyService`
- update worker pool documentation
- fix unit tests

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686184f7ed34832e91071e0b0a7153e1