### PR TITLE
Ensure DTO dates are datetime

### DIFF
--- a/application/mappers/company_mapper.py
+++ b/application/mappers/company_mapper.py
@@ -69,5 +69,5 @@ class CompanyMapper:
 
             date_quotation = detail.date_quotation or None, 
             last_date = detail.last_date, 
-            listing_date = base.listing_date or "", 
+            listing_date = base.listing_date,
         )

--- a/domain/dto/company_dto.py
+++ b/domain/dto/company_dto.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 from .raw_company_dto import CompanyRawDTO
@@ -49,9 +50,9 @@ class CompanyDTO:
     has_quotation: Optional[bool]
     has_emissions: Optional[bool]
 
-    date_quotation: Optional[str]
-    last_date: Optional[str]
-    listing_date: Optional[str]
+    date_quotation: Optional[datetime]
+    last_date: Optional[datetime]
+    listing_date: Optional[datetime]
 
     @staticmethod
     def from_dict(raw: dict) -> "CompanyDTO":
@@ -136,11 +137,7 @@ class CompanyDTO:
             type_bdr=raw.type_bdr,
             has_quotation=raw.has_quotation,
             has_emissions=raw.has_emissions,
-            date_quotation=(
-                raw.date_quotation.strftime("%Y-%m-%d") if raw.date_quotation else None
-            ),
-            last_date=(raw.last_date.strftime("%Y-%m-%d") if raw.last_date else None),
-            listing_date=(
-                raw.listing_date.strftime("%Y-%m-%d") if raw.listing_date else None
-            ),
+            date_quotation=raw.date_quotation,
+            last_date=raw.last_date,
+            listing_date=raw.listing_date,
         )

--- a/domain/dto/raw_company_dto.py
+++ b/domain/dto/raw_company_dto.py
@@ -25,7 +25,7 @@ class CompanyListingDTO:
     cnpj: Optional[str]
     market_indicator: Optional[str]
     type_bdr: Optional[str]
-    listing_date: Optional[str]
+    listing_date: Optional[datetime]
     status: Optional[str]
     segment: Optional[str]
     segment_eng: Optional[str]


### PR DESCRIPTION
## Summary
- update `CompanyDTO` and `CompanyListingDTO` date fields to use `datetime`
- pass raw datetime values when mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686190ce3cd0832e90ef45f124a91044