### PR TITLE
Add metrics collector port

### DIFF
--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -1,5 +1,6 @@
 from .company_repository_port import CompanyRepositoryPort
 from .company_source_port import CompanySourcePort
+from .metrics_collector_port import MetricsCollectorPort
 from .nsd_repository_port import NSDRepositoryPort
 from .nsd_source_port import NSDSourcePort
 from .worker_pool_port import (
@@ -16,6 +17,7 @@ __all__ = [
     "ExecutionResultDTO",
     "CompanyRepositoryPort",
     "CompanySourcePort",
+    "MetricsCollectorPort",
     "NSDRepositoryPort",
     "NSDSourcePort",
 ]

--- a/domain/ports/company_source_port.py
+++ b/domain/ports/company_source_port.py
@@ -5,6 +5,8 @@ from typing import Callable, List, Optional, Set
 
 from domain.dto.raw_company_dto import CompanyRawDTO
 
+from .metrics_collector_port import MetricsCollectorPort
+
 
 class CompanySourcePort(ABC):
     """Port for external company data providers."""
@@ -18,4 +20,10 @@ class CompanySourcePort(ABC):
         max_workers: int | None = None,
     ) -> List[CompanyRawDTO]:
         """Fetch all available companies."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def metrics_collector(self) -> MetricsCollectorPort:
+        """Metrics collector used by the scraper."""
         raise NotImplementedError

--- a/domain/ports/metrics_collector_port.py
+++ b/domain/ports/metrics_collector_port.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class MetricsCollectorPort(Protocol):
+    """Collects and exposes metrics for network and processing byte counts."""
+
+    def record_network_bytes(self, n: int) -> None:
+        """Accumulate ``n`` bytes transferred over the network."""
+        raise NotImplementedError
+
+    def record_processing_bytes(self, n: int) -> None:
+        """Accumulate ``n`` bytes processed locally."""
+        raise NotImplementedError
+
+    @property
+    def network_bytes(self) -> int:
+        """Total bytes transferred over the network."""
+        raise NotImplementedError
+
+    @property
+    def processing_bytes(self) -> int:
+        """Total bytes processed locally."""
+        raise NotImplementedError

--- a/domain/ports/nsd_source_port.py
+++ b/domain/ports/nsd_source_port.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Optional, Set
 
+from .metrics_collector_port import MetricsCollectorPort
+
 
 class NSDSourcePort(ABC):
     """Port for external NSD data providers."""
@@ -17,4 +19,10 @@ class NSDSourcePort(ABC):
         threshold: Optional[int] = None,
     ) -> List[Dict]:
         """Fetch all available NSD records."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def metrics_collector(self) -> MetricsCollectorPort:
+        """Metrics collector used by the scraper."""
         raise NotImplementedError

--- a/infrastructure/helpers/metrics_collector.py
+++ b/infrastructure/helpers/metrics_collector.py
@@ -1,4 +1,7 @@
-class MetricsCollector:
+from domain.ports import MetricsCollectorPort
+
+
+class MetricsCollector(MetricsCollectorPort):
     """Collects network and processing byte counts."""
 
     def __init__(self) -> None:

--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Iterable, List, Optional, TypeVar
 
+from domain.ports import MetricsCollectorPort
 from domain.ports.worker_pool_port import (
     ExecutionResultDTO,
     LoggerPort,
@@ -12,7 +13,6 @@ from domain.ports.worker_pool_port import (
 )
 from infrastructure.config import Config
 from infrastructure.helpers.byte_formatter import ByteFormatter
-from infrastructure.helpers.metrics_collector import MetricsCollector
 
 T = TypeVar("T")
 R = TypeVar("R")
@@ -24,7 +24,7 @@ class WorkerPool(WorkerPoolPort):
     def __init__(
         self,
         config: Config,
-        metrics_collector: MetricsCollector,
+        metrics_collector: MetricsCollectorPort,
         max_workers: Optional[int] = None,
     ) -> None:
         """Initialize the worker pool with configuration and metrics."""

--- a/infrastructure/scrapers/company_b3_scraper.py
+++ b/infrastructure/scrapers/company_b3_scraper.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from application import CompanyMapper
 from domain.dto import CompanyRawDTO, PageResultDTO
-from domain.ports import CompanySourcePort, WorkerPoolPort
+from domain.ports import CompanySourcePort, MetricsCollectorPort, WorkerPoolPort
 from infrastructure.config import Config
 from infrastructure.helpers import FetchUtils, SaveStrategy
 from infrastructure.helpers.byte_formatter import ByteFormatter
@@ -33,7 +33,7 @@ class CompanyB3Scraper(CompanySourcePort):
         data_cleaner: DataCleaner,
         mapper: CompanyMapper,
         executor: WorkerPoolPort,
-        metrics_collector,
+        metrics_collector: MetricsCollectorPort,
     ):
         """Set up configuration, logger and helper utilities for the scraper.
 

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -7,10 +7,10 @@ from typing import Callable, Dict, List, Optional
 
 from bs4 import BeautifulSoup
 
+from domain.ports import MetricsCollectorPort
 from infrastructure.config import Config
 from infrastructure.helpers import FetchUtils, SaveStrategy
 from infrastructure.helpers.data_cleaner import DataCleaner
-from infrastructure.helpers.metrics_collector import MetricsCollector
 from infrastructure.logging import Logger
 
 
@@ -22,7 +22,7 @@ class NsdScraper:
         config: Config,
         logger: Logger,
         data_cleaner: DataCleaner,
-        metrics_collector: MetricsCollector,
+        metrics_collector: MetricsCollectorPort,
     ):
         self.config = config
         self.logger = logger


### PR DESCRIPTION
## Summary
- define `MetricsCollectorPort` protocol
- expose the new port in `domain.ports`
- require a metrics collector on `CompanySourcePort` and `NSDSourcePort`
- type `metrics_collector` arguments as `MetricsCollectorPort` in scrapers and worker pool

## Testing
- `ruff check domain/ports/__init__.py domain/ports/company_source_port.py domain/ports/nsd_source_port.py infrastructure/helpers/metrics_collector.py infrastructure/helpers/worker_pool.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py domain/ports/metrics_collector_port.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619bfa7b14832ea30b7e70b3d885ae