### PR TITLE
Refactor DataCleaner normalization logic

### DIFF
--- a/infrastructure/helpers/data_cleaner.py
+++ b/infrastructure/helpers/data_cleaner.py
@@ -1,12 +1,20 @@
-import re
-import string
 from datetime import datetime
 from typing import List, Optional
 
-import unidecode
-
 from infrastructure.config import Config
 from infrastructure.logging import Logger
+from infrastructure.utils.normalization import (
+    clean_date as util_clean_date,
+)
+from infrastructure.utils.normalization import (
+    clean_dict_fields as util_clean_dict_fields,
+)
+from infrastructure.utils.normalization import (
+    clean_number as util_clean_number,
+)
+from infrastructure.utils.normalization import (
+    clean_text as util_clean_text,
+)
 
 
 class DataCleaner:
@@ -22,86 +30,37 @@ class DataCleaner:
     def clean_text(
         self, text: Optional[str], words_to_remove: Optional[List[str]] = None
     ) -> Optional[str]:
-        """Normalize a text string by removing punctuation, accents and stop words."""
-        try:
-            if not text:
-                return None
+        """Normalize a text string using ``utils.clean_text``."""
 
-            words_to_remove = words_to_remove or self.config.domain.words_to_remove
-
-            text = unidecode.unidecode(text)
-            text = text.translate(str.maketrans("", "", string.punctuation))
-            text = text.upper().strip()
-            text = re.sub(r"\s+", " ", text)
-
-            if words_to_remove:
-                pattern = r"\b(?:" + "|".join(map(re.escape, words_to_remove)) + r")\b"
-                text = re.sub(pattern, "", text)
-                text = re.sub(r"\s+", " ", text).strip()
-
-            return text
-        except Exception as e:
-            self.logger.log(f"Failed to clean text: {e}", level="warning")
-            return None
+        words_to_remove = words_to_remove or self.config.domain.words_to_remove
+        return util_clean_text(
+            text, words_to_remove=words_to_remove, logger=self.logger
+        )
 
     def clean_number(self, text: str) -> Optional[float]:
-        """Convert a stringified number (BR/US formats) to ``float``."""
-        if not text:
-            return None
-        try:
-            text = text.replace(".", "").replace(",", ".")
-            return float(text)
-        except Exception as e:
-            self.logger.log(f"Failed to clean number: {e}", level="warning")
-            return None
+        """Convert a stringified number using ``utils.clean_number``."""
+
+        return util_clean_number(text, logger=self.logger)
 
     def clean_date(self, text: Optional[str]) -> Optional[datetime]:
-        """Attempt to parse a date string using several common formats."""
-        if isinstance(text, datetime):
-            return text
+        """Parse a date string using ``utils.clean_date``."""
 
-        if not text:
-            return None
+        return util_clean_date(text, logger=self.logger)
 
-        patterns = [
-            "%d/%m/%Y %H:%M:%S",
-            "%m/%d/%Y %H:%M:%S",
-            "%Y-%m-%d %H:%M:%S",
-            "%d/%m/%Y",
-            "%m/%d/%Y",
-            "%Y-%m-%d",
-        ]
-        for fmt in patterns:
-            try:
-                return datetime.strptime(text.strip(), fmt)
-            except Exception:
-                continue
+    def clean_dict_fields(
+        self,
+        entry: dict,
+        text_keys: List[str],
+        date_keys: List[str],
+        number_keys: Optional[List[str]] = None,
+    ) -> dict:
+        """Return a cleaned ``entry`` using ``utils.clean_dict_fields``."""
 
-        self.logger.log(
-            f"Failed to parse date: unsupported format '{text}'",
-            level="debug",
+        return util_clean_dict_fields(
+            entry,
+            text_keys,
+            date_keys,
+            number_keys,
+            logger=self.logger,
+            words_to_remove=self.config.domain.words_to_remove,
         )
-        return None
-
-    def clean_company_entry(self, entry: dict) -> dict:
-        """Normalize relevant fields in a raw company listing entry."""
-
-        text_keys = [
-            "companyName",
-            "issuingCompany",
-            "tradingName",
-            "segment",
-            "segmentEng",
-            "market",
-        ]
-        date_keys = ["dateListing"]
-
-        for key in text_keys:
-            if key in entry:
-                entry[key] = self.clean_text(entry.get(key))
-
-        for key in date_keys:
-            if key in entry:
-                entry[key] = self.clean_date(entry.get(key))
-
-        return entry

--- a/infrastructure/scrapers/company_processors.py
+++ b/infrastructure/scrapers/company_processors.py
@@ -19,7 +19,18 @@ class EntryCleaner:
         self.data_cleaner = data_cleaner
 
     def run(self, entry: Dict) -> CompanyListingDTO:
-        cleaned = self.data_cleaner.clean_company_entry(entry)
+        cleaned = self.data_cleaner.clean_dict_fields(
+            entry,
+            text_keys=[
+                "companyName",
+                "issuingCompany",
+                "tradingName",
+                "segment",
+                "segmentEng",
+                "market",
+            ],
+            date_keys=["dateListing"],
+        )
         return CompanyListingDTO.from_dict(cleaned)
 
 

--- a/infrastructure/utils/__init__.py
+++ b/infrastructure/utils/__init__.py
@@ -1,0 +1,8 @@
+from .normalization import clean_date, clean_dict_fields, clean_number, clean_text
+
+__all__ = [
+    "clean_text",
+    "clean_number",
+    "clean_date",
+    "clean_dict_fields",
+]

--- a/infrastructure/utils/normalization.py
+++ b/infrastructure/utils/normalization.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import re
+import string
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import unidecode
+
+from infrastructure.logging import Logger
+
+
+def clean_text(
+    text: Optional[str],
+    words_to_remove: Optional[List[str]] = None,
+    logger: Optional[Logger] = None,
+) -> Optional[str]:
+    """Normalize a text string by removing punctuation, accents and stop
+    words."""
+    try:
+        if not text:
+            return None
+
+        text = unidecode.unidecode(text)
+        text = text.translate(str.maketrans("", "", string.punctuation))
+        text = text.upper().strip()
+        text = re.sub(r"\s+", " ", text)
+
+        if words_to_remove:
+            pattern = r"\b(?:" + "|".join(map(re.escape, words_to_remove)) + r")\b"
+            text = re.sub(pattern, "", text)
+            text = re.sub(r"\s+", " ", text).strip()
+
+        return text
+    except Exception as exc:  # noqa: BLE001
+        if logger:
+            logger.log(f"Failed to clean text: {exc}", level="warning")
+        return None
+
+
+def clean_number(text: str, logger: Optional[Logger] = None) -> Optional[float]:
+    """Convert a stringified number (BR/US formats) to ``float``."""
+    if not text:
+        return None
+    try:
+        text = text.replace(".", "").replace(",", ".")
+        return float(text)
+    except Exception as exc:  # noqa: BLE001
+        if logger:
+            logger.log(f"Failed to clean number: {exc}", level="warning")
+        return None
+
+
+def clean_date(
+    text: Optional[str], logger: Optional[Logger] = None
+) -> Optional[datetime]:
+    """Attempt to parse a date string using several common formats."""
+    if isinstance(text, datetime):
+        return text
+
+    if not text:
+        return None
+
+    patterns = [
+        "%d/%m/%Y %H:%M:%S",
+        "%m/%d/%Y %H:%M:%S",
+        "%Y-%m-%d %H:%M:%S",
+        "%d/%m/%Y",
+        "%m/%d/%Y",
+        "%Y-%m-%d",
+    ]
+    for fmt in patterns:
+        try:
+            return datetime.strptime(text.strip(), fmt)
+        except Exception:
+            continue
+
+    if logger:
+        logger.log(f"Failed to parse date: unsupported format '{text}'", level="debug")
+    return None
+
+
+def clean_dict_fields(
+    entry: Dict,
+    text_keys: List[str],
+    date_keys: List[str],
+    number_keys: Optional[List[str]] = None,
+    *,
+    logger: Optional[Logger] = None,
+    words_to_remove: Optional[List[str]] = None,
+) -> Dict:
+    """Return a cleaned copy of ``entry`` with normalized text, dates and
+    numbers."""
+    number_keys = number_keys or []
+    cleaned = entry.copy()
+
+    for key in text_keys:
+        if key in cleaned:
+            cleaned[key] = clean_text(cleaned.get(key), words_to_remove, logger)
+
+    for key in date_keys:
+        if key in cleaned:
+            cleaned[key] = clean_date(cleaned.get(key), logger)
+
+    for key in number_keys:
+        if key in cleaned:
+            cleaned[key] = clean_number(cleaned.get(key), logger)
+
+    return cleaned

--- a/tests/infrastructure/test_normalization_utils.py
+++ b/tests/infrastructure/test_normalization_utils.py
@@ -1,0 +1,20 @@
+import copy
+
+from infrastructure.utils.normalization import clean_dict_fields
+from tests.conftest import DummyLogger
+
+
+def test_clean_dict_fields_non_mutating():
+    entry = {"name": "Acme!", "listed": "01/02/2020"}
+    original = copy.deepcopy(entry)
+
+    cleaned = clean_dict_fields(
+        entry,
+        text_keys=["name"],
+        date_keys=["listed"],
+        logger=DummyLogger(),
+    )
+
+    assert cleaned["name"] == "ACME"
+    assert hasattr(cleaned["listed"], "year") and cleaned["listed"].year == 2020
+    assert entry == original


### PR DESCRIPTION
## Summary
- introduce `infrastructure.utils.normalization` with generic cleaning helpers
- replace `clean_company_entry` with `clean_dict_fields`
- adjust entry cleaning in company processor to use new method
- add unit test covering utility function

## Testing
- `ruff format infrastructure/helpers/data_cleaner.py infrastructure/scrapers/company_processors.py infrastructure/utils/normalization.py tests/infrastructure/test_normalization_utils.py infrastructure/utils/__init__.py`
- `ruff check infrastructure/helpers/data_cleaner.py infrastructure/scrapers/company_processors.py infrastructure/utils/normalization.py tests/infrastructure/test_normalization_utils.py infrastructure/utils/__init__.py --fix`
- `docformatter --in-place infrastructure/utils/normalization.py tests/infrastructure/test_normalization_utils.py infrastructure/helpers/data_cleaner.py infrastructure/scrapers/company_processors.py infrastructure/utils/__init__.py`
- `pydocstyle --convention=google infrastructure/helpers/data_cleaner.py infrastructure/utils/normalization.py infrastructure/scrapers/company_processors.py tests/infrastructure/test_normalization_utils.py infrastructure/utils/__init__.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d9992ab4832ebefed224c60c32ee