### PR TITLE
Fix circular import by moving ExecutionResultDTO

### DIFF
--- a/domain/dto/__init__.py
+++ b/domain/dto/__init__.py
@@ -1,7 +1,14 @@
 from .company_dto import CompanyDTO
+from .execution_result_dto import ExecutionResultDTO
+from .metrics_dto import MetricsDTO
 from .nsd_dto import NSDDTO
 from .page_result_dto import PageResultDTO
-from .raw_company_dto import CodeDTO, CompanyDetailDTO, CompanyListingDTO, CompanyRawDTO
+from .raw_company_dto import (
+    CodeDTO,
+    CompanyDetailDTO,
+    CompanyListingDTO,
+    CompanyRawDTO,
+)
 from .sync_companies_result_dto import SyncCompaniesResultDTO
 
 __all__ = [
@@ -11,6 +18,8 @@ __all__ = [
     "CompanyListingDTO",
     "CompanyDetailDTO",
     "CodeDTO",
+    "ExecutionResultDTO",
+    "MetricsDTO",
     "PageResultDTO",
     "SyncCompaniesResultDTO",
 ]

--- a/domain/dto/execution_result_dto.py
+++ b/domain/dto/execution_result_dto.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, List, TypeVar
+
+from .metrics_dto import MetricsDTO
+
+R = TypeVar("R")
+
+
+@dataclass(frozen=True)
+class ExecutionResultDTO(Generic[R]):
+    """Results and metrics returned by a worker pool run."""
+
+    items: List[R]
+    metrics: MetricsDTO

--- a/domain/dto/metrics_dto.py
+++ b/domain/dto/metrics_dto.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MetricsDTO:
+    """Execution metrics for worker pools."""
+
+    elapsed_time: float
+    network_bytes: int = 0
+    processing_bytes: int = 0
+    failures: int = 0

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -1,14 +1,11 @@
+from domain.dto import ExecutionResultDTO, MetricsDTO
+
 from .company_repository_port import CompanyRepositoryPort
 from .company_source_port import CompanySourcePort
 from .metrics_collector_port import MetricsCollectorPort
 from .nsd_repository_port import NSDRepositoryPort
 from .nsd_source_port import NSDSourcePort
-from .worker_pool_port import (
-    ExecutionResultDTO,
-    LoggerPort,
-    MetricsDTO,
-    WorkerPoolPort,
-)
+from .worker_pool_port import LoggerPort, WorkerPoolPort
 
 __all__ = [
     "WorkerPoolPort",

--- a/domain/ports/company_source_port.py
+++ b/domain/ports/company_source_port.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Callable, List, Optional, Set
 
+from domain.dto import ExecutionResultDTO
 from domain.dto.raw_company_dto import CompanyRawDTO
-from domain.ports import (
-    ExecutionResultDTO,
-    MetricsCollectorPort,
-)
+
+from .metrics_collector_port import MetricsCollectorPort
 
 
 class CompanySourcePort(ABC):

--- a/domain/ports/metrics_collector_port.py
+++ b/domain/ports/metrics_collector_port.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from domain.ports.worker_pool_port import MetricsDTO
+from domain.dto import MetricsDTO
 
 
 class MetricsCollectorPort(Protocol):

--- a/domain/ports/worker_pool_port.py
+++ b/domain/ports/worker_pool_port.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Callable, Generic, Iterable, List, Optional, Protocol, TypeVar
+from typing import Callable, Iterable, List, Optional, Protocol, TypeVar
+
+from domain.dto import ExecutionResultDTO
 
 T = TypeVar("T")
 R = TypeVar("R")
 
 
 class LoggerPort(Protocol):
-
     def log(
         self,
         message: str,
@@ -20,25 +20,7 @@ class LoggerPort(Protocol):
         raise NotImplementedError
 
 
-@dataclass(frozen=True)
-class MetricsDTO:
-
-    elapsed_time: float
-    network_bytes: int = 0
-    processing_bytes: int = 0
-    failures: int = 0
-
-
-@dataclass(frozen=True)
-class ExecutionResultDTO(Generic[R]):
-    """Results and metrics returned by :class:`WorkerPoolPort.run`."""
-
-    items: List[R]
-    metrics: MetricsDTO
-
-
 class WorkerPoolPort(Protocol):
-
     def run(
         self,
         tasks: Iterable[T],

--- a/infrastructure/helpers/metrics_collector.py
+++ b/infrastructure/helpers/metrics_collector.py
@@ -1,5 +1,5 @@
+from domain.dto import MetricsDTO
 from domain.ports import MetricsCollectorPort
-from domain.ports.worker_pool_port import MetricsDTO
 
 
 class MetricsCollector(MetricsCollectorPort):
@@ -34,7 +34,6 @@ class MetricsCollector(MetricsCollectorPort):
         return self._processing_bytes
 
     def get_metrics(self, elapsed_time: float):
-
         """Create a :class:`MetricsDTO` instance from the collected values."""
 
         return MetricsDTO(

--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -5,9 +5,9 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Iterable, List, Optional, TypeVar
 
+from domain.dto import ExecutionResultDTO
 from domain.ports import MetricsCollectorPort
 from domain.ports.worker_pool_port import (
-    ExecutionResultDTO,
     LoggerPort,
     WorkerPoolPort,
 )
@@ -19,7 +19,8 @@ R = TypeVar("R")
 
 
 class WorkerPool(WorkerPoolPort):
-    """Simple thread pool implementation tied to the domain ``WorkerPoolPort``."""
+    """Simple thread pool implementation tied to the domain
+    ``WorkerPoolPort``."""
 
     def __init__(
         self,

--- a/infrastructure/scrapers/company_b3_scraper.py
+++ b/infrastructure/scrapers/company_b3_scraper.py
@@ -5,10 +5,9 @@ import json
 from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from application import CompanyMapper
-from domain.dto import CompanyRawDTO, PageResultDTO
+from domain.dto import CompanyRawDTO, ExecutionResultDTO, PageResultDTO
 from domain.ports import (
     CompanySourcePort,
-    ExecutionResultDTO,
     MetricsCollectorPort,
     WorkerPoolPort,
 )


### PR DESCRIPTION
## Summary
- relocate `ExecutionResultDTO` and new `MetricsDTO` to `domain.dto`
- update ports and helpers to import from new locations
- fix circular imports during module initialization

## Testing
- `ruff format domain infrastructure`
- `ruff check domain infrastructure --fix`
- `docformatter --in-place --recursive domain infrastructure`
- `pydocstyle --convention=google domain infrastructure`
- `pytest -o addopts=''`

------
https://chatgpt.com/codex/tasks/task_e_6861e464a2c8832ea3ffca9fe9ad19a7