### PR TITLE
Add remaining-items flush option

### DIFF
--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -23,14 +23,26 @@ class SaveStrategy(Generic[T]):
         self.threshold = threshold
         self.buffer: List[T] = []
 
-    def handle(self, item: Optional[T]) -> None:
-        """Add ``item`` to the buffer and flush when ``threshold`` is reached."""
+    def handle(self, item: Optional[T], remaining: Optional[int] = None) -> None:
+        """Add ``item`` to the buffer and flush when ``threshold`` is reached.
+
+        Args:
+            item: Item to add to the buffer.
+            remaining: Number of items left to process. If provided, the buffer
+                flushes when this value is a multiple of ``threshold`` or zero.
+        """
 
         if item is None:
             return
 
         self.buffer.append(item)
-        if len(self.buffer) >= self.threshold:
+
+        should_flush = len(self.buffer) >= self.threshold
+
+        if remaining is not None:
+            should_flush = should_flush or remaining % self.threshold == 0
+
+        if remaining == 0 or should_flush:
             self.flush()
 
     def flush(self) -> None:

--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Iterable, List, Optional, TypeVar
@@ -60,7 +59,7 @@ class WorkerPool(WorkerPoolPort):
 
             # Collect results as tasks complete
             for index, future in enumerate(as_completed(future_to_task)):
-                task = future_to_task[future]  # keep a reference for debugging
+                _ = future_to_task[future]  # keep a reference for debugging
                 try:
                     # Retrieve result from worker thread
                     result = future.result()

--- a/tests/infrastructure/test_save_strategy.py
+++ b/tests/infrastructure/test_save_strategy.py
@@ -1,0 +1,31 @@
+from infrastructure.helpers.save_strategy import SaveStrategy
+
+
+def test_handle_flushes_on_threshold():
+    collected = []
+
+    def cb(buffer):
+        collected.append(list(buffer))
+
+    strategy = SaveStrategy(cb, threshold=2)
+    strategy.handle(1)
+    strategy.handle(2)
+
+    assert collected == [[1, 2]]
+    assert strategy.buffer == []
+
+
+def test_handle_flushes_on_remaining():
+    collected = []
+
+    def cb(buffer):
+        collected.append(list(buffer))
+
+    strategy = SaveStrategy(cb, threshold=3)
+    items = [1, 2, 3, 4, 5]
+    for i, item in enumerate(items):
+        remaining = len(items) - i - 1
+        strategy.handle(item, remaining)
+
+    assert collected == [[1, 2], [3, 4, 5]]
+    assert strategy.buffer == []


### PR DESCRIPTION
## Summary
- support remaining item tracking in SaveStrategy
- use underscore variable for unused task reference in WorkerPool
- test SaveStrategy with new remaining parameter

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861fc3e3e40832e9e2379fbb7871ede