### PR TITLE
Add remaining-items flush option

### DIFF
--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Iterable, List, Optional, TypeVar
@@ -60,7 +59,7 @@ class WorkerPool(WorkerPoolPort):
 
             # Collect results as tasks complete
             for index, future in enumerate(as_completed(future_to_task)):
-                task = future_to_task[future]  # keep a reference for debugging
+                _ = future_to_task[future]  # keep a reference for debugging
                 try:
                     # Retrieve result from worker thread
                     result = future.result()

--- a/infrastructure/scrapers/company_b3_scraper.py
+++ b/infrastructure/scrapers/company_b3_scraper.py
@@ -180,7 +180,9 @@ class CompanyB3Scraper(CompanySourcePort):
         self.logger.log("Fetch Existing Companies from B3", level="info")
 
         threshold = threshold or self.config.global_settings.threshold or 50
-        strategy: SaveStrategy[Dict] = SaveStrategy(save_callback, threshold)
+        strategy: SaveStrategy[Dict] = SaveStrategy(
+            save_callback, threshold, config=self.config
+        )
         page_exec = ExecutionResultDTO(
             items=[], metrics=self.metrics_collector.get_metrics(0)
         )
@@ -195,20 +197,24 @@ class CompanyB3Scraper(CompanySourcePort):
             strategy.handle(item)
         total_pages = fetch.total_pages
 
-
         extra_info = {
-            "Download": self.byte_formatter.format_bytes(self._metrics_collector.network_bytes - pre),
-            "Total download": self.byte_formatter.format_bytes(self.metrics_collector.network_bytes),
-            }
-        self.logger.log(f"Page {page}/{total_pages}", 
+            "Download": self.byte_formatter.format_bytes(
+                self._metrics_collector.network_bytes - pre
+            ),
+            "Total download": self.byte_formatter.format_bytes(
+                self.metrics_collector.network_bytes
+            ),
+        }
+        self.logger.log(
+            f"Page {page}/{total_pages}",
             level="info",
             progress={
                 "index": 0,
                 "size": total_pages,
                 "start_time": start_time,
-                },
+            },
             extra=extra_info,
-            )
+        )
 
         if total_pages > 1:
             tasks = list(enumerate(range(2, total_pages + 1)))
@@ -218,18 +224,23 @@ class CompanyB3Scraper(CompanySourcePort):
                 pre = self._metrics_collector.network_bytes
                 fetch = self._fetch_page(page)
                 extra_info = {
-                    "Download": self.byte_formatter.format_bytes(self._metrics_collector.network_bytes - pre),
-                    "Total download": self.byte_formatter.format_bytes(self.metrics_collector.network_bytes),
-                    }
-                self.logger.log(f"Page {page}/{total_pages}",
+                    "Download": self.byte_formatter.format_bytes(
+                        self._metrics_collector.network_bytes - pre
+                    ),
+                    "Total download": self.byte_formatter.format_bytes(
+                        self.metrics_collector.network_bytes
+                    ),
+                }
+                self.logger.log(
+                    f"Page {page}/{total_pages}",
                     level="info",
                     progress={
                         "index": index + 1,
                         "size": total_pages,
                         "start_time": start_time,
-                        },
+                    },
                     extra=extra_info,
-                    )
+                )
                 return fetch
 
             page_exec = self.executor.run(
@@ -310,7 +321,9 @@ class CompanyB3Scraper(CompanySourcePort):
 
         threshold = threshold or self.config.global_settings.threshold or 50
         skip_codes = skip_codes or set()
-        strategy: SaveStrategy[CompanyRawDTO] = SaveStrategy(save_callback, threshold)
+        strategy: SaveStrategy[CompanyRawDTO] = SaveStrategy(
+            save_callback, threshold, config=self.config
+        )
         detail_exec: ExecutionResultDTO[Optional[CompanyRawDTO]] = ExecutionResultDTO(
             items=[], metrics=self.metrics_collector.get_metrics(0)
         )
@@ -326,17 +339,17 @@ class CompanyB3Scraper(CompanySourcePort):
             code_cvm = entry.get("codeCVM")
             if code_cvm in skip_codes:
                 # Log and skip already persisted companies
-                extra_info = {
-                    }
-                self.logger.log(f"{code_cvm}",
+                extra_info = {}
+                self.logger.log(
+                    f"{code_cvm}",
                     level="info",
                     progress={
                         "index": index,
                         "size": len(tasks),
                         "start_time": start_time,
-                        },
+                    },
                     extra=extra_info,
-                    )
+                )
 
                 return None
 
@@ -347,18 +360,23 @@ class CompanyB3Scraper(CompanySourcePort):
             extra_info = {
                 "issuingCompany": issuingCompany,
                 "trading_name": tradingName,
-                "Download": self.byte_formatter.format_bytes(self._metrics_collector.network_bytes - pre),
-                "Total download": self.byte_formatter.format_bytes(self.metrics_collector.network_bytes),
-                }
-            self.logger.log(f"{code_cvm}",
+                "Download": self.byte_formatter.format_bytes(
+                    self._metrics_collector.network_bytes - pre
+                ),
+                "Total download": self.byte_formatter.format_bytes(
+                    self.metrics_collector.network_bytes
+                ),
+            }
+            self.logger.log(
+                f"{code_cvm}",
                 level="info",
                 progress={
                     "index": index,
                     "size": len(tasks),
                     "start_time": start_time,
-                    },
+                },
                 extra=extra_info,
-                )
+            )
 
             return result
 

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -66,7 +66,9 @@ class NsdScraper:
         nsd = start
         index = 0
 
-        strategy: SaveStrategy[Dict] = SaveStrategy(save_callback, threshold)
+        strategy: SaveStrategy[Dict] = SaveStrategy(
+            save_callback, threshold, config=self.config
+        )
         results: List[Dict] = []
         start_time = time.perf_counter()
 

--- a/tests/infrastructure/test_save_strategy.py
+++ b/tests/infrastructure/test_save_strategy.py
@@ -1,0 +1,51 @@
+from infrastructure.helpers.save_strategy import SaveStrategy
+
+
+def test_handle_flushes_on_threshold():
+    collected = []
+
+    def cb(buffer):
+        collected.append(list(buffer))
+
+    strategy = SaveStrategy(cb, threshold=2)
+    strategy.handle(1)
+    strategy.handle(2)
+
+    assert collected == [[1, 2]]
+    assert strategy.buffer == []
+
+
+def test_handle_flushes_on_remaining():
+    collected = []
+
+    def cb(buffer):
+        collected.append(list(buffer))
+
+    strategy = SaveStrategy(cb, threshold=3)
+    items = [1, 2, 3, 4, 5]
+    for i, item in enumerate(items):
+        remaining = len(items) - i - 1
+        strategy.handle(item, remaining)
+
+    assert collected == [[1, 2], [3, 4, 5]]
+    assert strategy.buffer == []
+
+
+def test_threshold_loaded_from_config():
+    collected = []
+
+    def cb(buffer):
+        collected.append(list(buffer))
+
+    class DummyConfig:
+        class GlobalSettings:
+            threshold = 2
+
+        global_settings = GlobalSettings()
+
+    strategy = SaveStrategy(cb, config=DummyConfig())
+    strategy.handle(1)
+    strategy.handle(2)
+
+    assert collected == [[1], [2]]
+    assert strategy.buffer == []


### PR DESCRIPTION
## Summary
- support remaining item tracking in SaveStrategy with default from config
- inject config into SaveStrategy usage
- test SaveStrategy with new config-based default

## Testing
- `ruff format infrastructure/helpers/save_strategy.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py tests/infrastructure/test_save_strategy.py`
- `ruff check infrastructure/helpers/save_strategy.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py tests/infrastructure/test_save_strategy.py --fix`
- `docformatter --in-place infrastructure/helpers/save_strategy.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py tests/infrastructure/test_save_strategy.py`
- `pydocstyle --convention=google infrastructure/helpers/save_strategy.py infrastructure/scrapers/company_b3_scraper.py infrastructure/scrapers/nsd_scraper.py tests/infrastructure/test_save_strategy.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6861fc3e3e40832e9e2379fbb7871ede