### PR TITLE
Fix WorkerPool task handling and add test

### DIFF
--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -61,12 +61,16 @@ class WorkerPool(WorkerPoolPort):
             logger.log(f"worker {worker_id} started", level="info", worker_id=worker_id)
             while True:
                 item = queue.get()
-                index, entry = item
-                task = WorkerTaskDTO(index=index, data=entry, worker_id=worker_id)
-                logger.log(f"worker {worker_id} got another task from qeue {queue.unfinished_tasks} tasks", level="info", worker_id=worker_id)
                 if item is sentinel:
                     queue.task_done()
                     break
+                index, entry = item
+                task = WorkerTaskDTO(index=index, data=entry, worker_id=worker_id)
+                logger.log(
+                    f"worker {worker_id} got another task from queue {queue.unfinished_tasks} tasks",
+                    level="info",
+                    worker_id=worker_id,
+                )
                 try:
                     logger.log(f"running {item[1]['codeCVM']}", level="info")
                     result = processor(task)
@@ -86,7 +90,10 @@ class WorkerPool(WorkerPoolPort):
                     queue.task_done()
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            logger.log(f"ThreadPoolExecutor started with {self.max_workers} workers", level="info")
+            logger.log(
+                f"ThreadPoolExecutor started with {self.max_workers} workers",
+                level="info",
+            )
             futures = [
                 executor.submit(worker, uuid.uuid4().hex[:8])
                 for _ in range(self.max_workers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,5 +40,6 @@ class DummyConfig:
     class Global:
         app_name = "TEST"
         max_workers = 1
+        queue_size = 10
 
     global_settings = Global()

--- a/tests/infrastructure/test_worker_pool.py
+++ b/tests/infrastructure/test_worker_pool.py
@@ -1,0 +1,55 @@
+from domain.dto import MetricsDTO, WorkerTaskDTO
+from infrastructure.helpers.worker_pool import WorkerPool
+from tests.conftest import DummyConfig, DummyLogger
+
+
+class DummyMetricsCollector:
+    def __init__(self) -> None:
+        self.network_bytes = 0
+        self.processing_bytes = 0
+
+    def record_network_bytes(self, n: int) -> None:
+        self.network_bytes += n
+
+    def record_processing_bytes(self, n: int) -> None:
+        self.processing_bytes += n
+
+    def get_metrics(self, elapsed_time: float) -> MetricsDTO:
+        return MetricsDTO(
+            elapsed_time=elapsed_time,
+            network_bytes=self.network_bytes,
+            processing_bytes=self.processing_bytes,
+        )
+
+
+def test_worker_pool_passes_task_dto():
+    collector = DummyMetricsCollector()
+    pool = WorkerPool(config=DummyConfig(), metrics_collector=collector)
+
+    tasks = list(
+        enumerate(
+            [
+                {"codeCVM": "A"},
+                {"codeCVM": "B"},
+                {"codeCVM": "C"},
+            ]
+        )
+    )
+    received = []
+
+    def processor(task: WorkerTaskDTO) -> str:
+        assert isinstance(task, WorkerTaskDTO)
+        received.append((task.index, task.data, task.worker_id))
+        return task.data
+
+    result = pool.run(tasks=tasks, processor=processor, logger=DummyLogger())
+
+    assert result.items == [
+        {"codeCVM": "A"},
+        {"codeCVM": "B"},
+        {"codeCVM": "C"},
+    ]
+    assert len(received) == len(tasks)
+    for idx, data, worker_id in received:
+        assert tasks[idx][1] == data
+        assert worker_id


### PR DESCRIPTION
## Summary
- ensure WorkerPool checks for sentinel before unpacking queue items
- expand DummyConfig with `queue_size` for WorkerPool tests
- add test verifying WorkerTaskDTO is passed from WorkerPool to processor

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6862bebbc2a4832ebfbe1de348200eb5