### PR TITLE
Refactor repository ports

### DIFF
--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -60,7 +60,7 @@ class SyncCompaniesUseCase:
         )
 
         return SyncCompaniesResultDTO(
-            processed_count=len(results.items),
+            processed_count=len(results),
             skipped_count=len(existing_codes),
             bytes_downloaded=bytes_downloaded,
             elapsed_time=elapsed,

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -1,4 +1,6 @@
 """Exports for domain port interfaces."""
+
+from .base_repository_port import BaseRepositoryPort
 from .company_repository_port import CompanyRepositoryPort
 from .company_source_port import CompanySourcePort
 from .metrics_collector_port import MetricsCollectorPort
@@ -11,6 +13,7 @@ __all__ = [
     "MetricsDTO",
     "LoggerPort",
     "ExecutionResultDTO",
+    "BaseRepositoryPort",
     "CompanyRepositoryPort",
     "CompanySourcePort",
     "MetricsCollectorPort",

--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Generic, List, TypeVar
+
+T = TypeVar("T")
+
+
+class BaseRepositoryPort(ABC, Generic[T]):
+    """Generic repository port for persistence operations."""
+
+    @abstractmethod
+    def save_all(self, items: List[T]) -> None:
+        """Persist a batch of DTOs."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_by_id(self, id: str) -> T:
+        """Retrieve an item by its identifier."""
+        raise NotImplementedError

--- a/domain/ports/company_repository_port.py
+++ b/domain/ports/company_repository_port.py
@@ -2,26 +2,18 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import List, Set
+from abc import abstractmethod
+from typing import Set
 
 from domain.dto.company_dto import CompanyDTO
 
+from .base_repository_port import BaseRepositoryPort
 
-class CompanyRepositoryPort(ABC):
+
+class CompanyRepositoryPort(BaseRepositoryPort[CompanyDTO]):
     """Port for company persistence operations."""
-
-    @abstractmethod
-    def save_all(self, items: List[CompanyDTO]) -> None:
-        """Persist a batch of companies."""
-        raise NotImplementedError
 
     @abstractmethod
     def get_all_primary_keys(self) -> Set[str]:
         """Return all stored CVM codes."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_by_id(self, id: str) -> CompanyDTO:
-        """Retrieve a company by its CVM code."""
         raise NotImplementedError

--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -51,8 +51,8 @@ class SaveStrategy(Generic[T]):
 
         should_flush = len(self.buffer) >= self.threshold
 
-        # if remaining is not None:
-        #     should_flush = should_flush or remaining % self.threshold == 0
+        if remaining is not None:
+            should_flush = should_flush or remaining % self.threshold == 0
 
         if remaining == 0 or should_flush:
             self.flush()

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Set
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
@@ -11,10 +11,9 @@ from infrastructure.config import Config
 from infrastructure.logging import Logger
 from infrastructure.models.base import Base
 from infrastructure.models.company_model import CompanyModel
-from infrastructure.repositories.base_repository import BaseRepository
 
 
-class SQLiteCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryPort):
+class SQLiteCompanyRepository(CompanyRepositoryPort):
     """Concrete implementation of the company repository using SQLite."""
 
     def __init__(self, config: Config, logger: Logger):
@@ -55,26 +54,6 @@ class SQLiteCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryPort)
         finally:
             session.close()
 
-    def get_all(self) -> List[CompanyDTO]:
-        """Return all companies stored in the database."""
-        session = self.Session()
-        try:
-            results = session.query(CompanyModel).all()
-            return [obj.to_dto() for obj in results]
-        finally:
-            session.close()
-
-    def has_item(self, identifier: str) -> bool:
-        """Return ``True`` if a company with ``identifier`` exists."""
-        session = self.Session()
-        try:
-            return (
-                session.query(CompanyModel).filter_by(cvm_code=identifier).first()
-                is not None
-            )
-        finally:
-            session.close()
-
     def get_by_id(self, id: str) -> CompanyDTO:
         """Retrieve a company by CVM code or raise ``ValueError`` if
         missing."""
@@ -88,7 +67,7 @@ class SQLiteCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryPort)
         finally:
             session.close()
 
-    def get_all_primary_keys(self) -> set[str]:
+    def get_all_primary_keys(self) -> Set[str]:
         """Return a set of all CVM codes already persisted."""
         session = self.Session()
         try:


### PR DESCRIPTION
## Summary
- define generic `BaseRepositoryPort` in the domain layer
- derive `CompanyRepositoryPort` from the base port
- refactor `SQLiteCompanyRepository` to implement the single interface
- fix `SaveStrategy` logic and update `SyncCompaniesUseCase`

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6862f96d2d14832eab0beb14f745104a