### PR TITLE
Refactor repositories to share base class

### DIFF
--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -15,6 +15,16 @@ class BaseRepositoryPort(ABC, Generic[T]):
         raise NotImplementedError
 
     @abstractmethod
+    def get_all(self) -> List[T]:
+        """Retrieve all items from the repository."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def has_item(self, identifier: str) -> bool:
+        """Check if an item exists in the repository."""
+        raise NotImplementedError
+
+    @abstractmethod
     def get_by_id(self, id: str) -> T:
         """Retrieve an item by its identifier."""
         raise NotImplementedError

--- a/domain/ports/nsd_repository_port.py
+++ b/domain/ports/nsd_repository_port.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import List, Set
+from abc import abstractmethod
+from typing import Set
 
 from domain.dto.nsd_dto import NSDDTO
 
+from .base_repository_port import BaseRepositoryPort
 
-class NSDRepositoryPort(ABC):
+
+class NSDRepositoryPort(BaseRepositoryPort[NSDDTO]):
     """Port for NSD persistence operations."""
-
-    @abstractmethod
-    def save_all(self, items: List[NSDDTO]) -> None:
-        """Persist a batch of NSD records."""
-        raise NotImplementedError
 
     @abstractmethod
     def get_all_primary_keys(self) -> Set[int]:

--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -51,8 +51,8 @@ class SaveStrategy(Generic[T]):
 
         should_flush = len(self.buffer) >= self.threshold
 
-        # if remaining is not None:
-        #     should_flush = should_flush or remaining % self.threshold == 0
+        if remaining is not None:
+            should_flush = should_flush or remaining % self.threshold == 0
 
         if remaining == 0 or should_flush:
             self.flush()

--- a/infrastructure/models/__init__.py
+++ b/infrastructure/models/__init__.py
@@ -4,4 +4,7 @@ from .base_model import BaseModel
 from .company_model import CompanyModel
 from .nsd_model import NSDModel
 
-__all__ = ["Base",  "CompanyModel", "NSDModel"]
+# Provide a common "Base" alias expected by tests
+Base = BaseModel
+
+__all__ = ["Base", "CompanyModel", "NSDModel"]

--- a/infrastructure/models/base_model.py
+++ b/infrastructure/models/base_model.py
@@ -5,3 +5,7 @@ class BaseModel(DeclarativeBase):
     """Base class for all ORM models."""
 
     pass
+
+
+# Historical alias used by tests
+Base = BaseModel

--- a/infrastructure/repositories/base_repository.py
+++ b/infrastructure/repositories/base_repository.py
@@ -1,20 +1,23 @@
 from abc import ABC, abstractmethod
-from typing import Generic, List, TypeVar
+from typing import List, TypeVar
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
+from domain.ports.base_repository_port import BaseRepositoryPort
 from infrastructure.config import Config
 from infrastructure.logging import Logger
 from infrastructure.models.base_model import BaseModel
 
 T = TypeVar("T")  # T pode ser CompanyDTO, StatementDTO, etc.
 
-class BaseRepository(ABC, Generic[T]):
+
+class BaseRepository(BaseRepositoryPort[T], ABC):
     """
     Contract - Interface genérica para repositórios de leitura/escrita.
     Pode ser especializada para qualquer tipo de DTO.
     """
+
     def __init__(self, config: Config, logger: Logger):
         """Initialize the SQLite database connection and ensure tables
         exist."""
@@ -30,33 +33,27 @@ class BaseRepository(ABC, Generic[T]):
         with self.engine.connect() as conn:
             conn.execute(text("PRAGMA journal_mode=WAL"))
 
-        self.Session = sessionmaker(bind=self.engine, autoflush=True, expire_on_commit=True)
+        self.Session = sessionmaker(
+            bind=self.engine, autoflush=True, expire_on_commit=True
+        )
         BaseModel.metadata.create_all(self.engine)
-
 
     @abstractmethod
     def save_all(self, items: List[T]) -> None:
-        """
-        Saves in repository.
-        """
+        """Saves in repository."""
         pass
 
     @abstractmethod
     def get_all(self) -> List[T]:
-        """
-        Get all items from repository.
-        """
+        """Get all items from repository."""
         pass
 
     @abstractmethod
     def has_item(self, identifier: str) -> bool:
-        """
-        Check if it is in repository.
-        """
+        """Check if it is in repository."""
         pass
 
     @abstractmethod
     def get_by_id(self, id: str) -> T:
         """Recupera uma empresa a partir do ticker."""
         pass
-

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -1,32 +1,18 @@
 from typing import List
 
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
-
 from domain.dto.nsd_dto import NSDDTO
+from domain.ports.nsd_repository_port import NSDRepositoryPort
 from infrastructure.config import Config
 from infrastructure.logging import Logger
-from infrastructure.models.base_model import BaseModel
 from infrastructure.models.nsd_model import NSDModel
 from infrastructure.repositories.base_repository import BaseRepository
 
 
-class SQLiteNSDRepository(BaseRepository[NSDDTO]):
+class SQLiteNSDRepository(BaseRepository[NSDDTO], NSDRepositoryPort):
     """Concrete repository for NSDDTO using SQLite via SQLAlchemy."""
 
     def __init__(self, config: Config, logger: Logger):
-        self.config = config
-        self.logger = logger
-        self.logger.log("Start SQLiteNSDRepository", level="info")
-
-        self.engine = create_engine(
-            config.database.connection_string,
-            connect_args={"check_same_thread": False},
-        )
-        with self.engine.connect() as conn:
-            conn.execute(text("PRAGMA journal_mode=WAL"))
-        self.Session = sessionmaker(bind=self.engine)
-        BaseModel.metadata.create_all(self.engine)
+        super().__init__(config, logger)
 
     def save_all(self, items: List[NSDDTO]) -> None:
         session = self.Session()
@@ -57,8 +43,8 @@ class SQLiteNSDRepository(BaseRepository[NSDDTO]):
             session.close()
 
     def has_item(self, identifier: str) -> bool:
-        """
-        Checks if an item with the specified identifier exists in the database.
+        """Checks if an item with the specified identifier exists in the
+        database.
 
         Args:
             identifier (str): The unique identifier of the item to check.
@@ -73,8 +59,8 @@ class SQLiteNSDRepository(BaseRepository[NSDDTO]):
             session.close()
 
     def get_by_id(self, id: str) -> NSDDTO:
-        """
-        Fetches an NSD record from the database by its unique identifier.
+        """Fetches an NSD record from the database by its unique identifier.
+
         Args:
             id (str): The unique identifier (ticker) of the NSD to retrieve.
         Returns:
@@ -92,8 +78,7 @@ class SQLiteNSDRepository(BaseRepository[NSDDTO]):
             session.close()
 
     def get_all_primary_keys(self) -> set[int]:
-        """
-        Retrieve all distinct primary key values from the NSDModel table.
+        """Retrieve all distinct primary key values from the NSDModel table.
 
         Returns: All unique primary key values (nsd) from the NSDModel table.
         """


### PR DESCRIPTION
## Summary
- extend BaseRepositoryPort to include `get_all` and `has_item`
- implement BaseRepository using BaseRepositoryPort
- ensure SQLiteCompanyRepository and SQLiteNSDRepository inherit from BaseRepository
- add `get_all` and `has_item` implementations for companies
- fix SaveStrategy flush logic
- expose `Base` alias for ORM models

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631bdd59cc832e9a15ac14b6ecdd04