### PR TITLE
Enable threaded NSD scraping

### DIFF
--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -1,7 +1,9 @@
+"""Base repository interface for persistence operations."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, List, TypeVar
+from typing import Generic, List, Set, TypeVar
 
 T = TypeVar("T")
 

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -93,6 +93,7 @@ class CLIController:
             config=self.config,
             logger=self.logger,
             data_cleaner=self.data_cleaner,
+            executor=executor,
             metrics_collector=collector,
         )
 


### PR DESCRIPTION
## Summary
- refactor `NsdScraper` to process NSD pages using `WorkerPool`
- add missing module documentation and Set import
- update CLI to pass the executor when creating `NsdScraper`

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google infrastructure/scrapers/nsd_scraper.py presentation/cli.py domain/ports/base_repository_port.py`
- `docformatter --in-place infrastructure/scrapers/nsd_scraper.py presentation/cli.py domain/ports/base_repository_port.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863591fc50c832e830de6bafa90faa3