### PR TITLE
Add NSD prediction service

### DIFF
--- a/application/services/nsd_prediction_service.py
+++ b/application/services/nsd_prediction_service.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import List
+
+from domain.ports import NSDRepositoryPort
+
+
+def _find_next_probable_nsd(
+    repository: NSDRepositoryPort,
+    window_days: int = 30,
+    safety_factor: float = 1.5,
+) -> List[int]:
+    """Estimate next NSD numbers based on historical submission rate.
+
+    The prediction is calculated from the most recent ``window_days`` worth
+    of stored records. It computes the average number of submissions per
+    day and multiplies by the number of days since the last known NSD. The
+    ``safety_factor`` parameter is applied to avoid underestimation.
+
+    Args:
+        repository: Data source providing access to stored NSDs.
+        window_days: Number of days used to calculate the average rate.
+        safety_factor: Multiplier to account for variations in publishing
+            behaviour.
+
+    Returns:
+        A list of sequential NSD values likely to have been published
+        after the last stored record.
+    """
+    records = [r for r in repository.get_all() if r.sent_date]
+    if not records:
+        return []
+
+    last_nsd = max(r.nsd for r in records)
+    max_date = max(r.sent_date for r in records)
+    window_start = max_date - timedelta(days=window_days)
+
+    recent = [r for r in records if r.sent_date >= window_start]
+    if not recent:
+        recent = records
+
+    min_date = min(r.sent_date for r in recent)
+    days_span = max((max_date - min_date).days, 1)
+    daily_avg = len(recent) / days_span
+
+    days_since_last = max((datetime.utcnow() - max_date).days, 0)
+    estimate = int(daily_avg * days_since_last * safety_factor)
+
+    return [last_nsd + i for i in range(1, estimate + 1)]

--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -50,8 +50,8 @@ class SaveStrategy(Generic[T]):
         self.buffer.append(item)
 
         should_flush = len(self.buffer) >= self.threshold
-        # if remaining is not None:
-        #     should_flush = should_flush or remaining % self.threshold == 0
+        if remaining is not None:
+            should_flush = should_flush or remaining % self.threshold == 0
 
         if remaining == 0 or should_flush:
             self.flush()

--- a/tests/application/test_nsd_prediction_service.py
+++ b/tests/application/test_nsd_prediction_service.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+from application.services.nsd_prediction_service import _find_next_probable_nsd
+from domain.dto.nsd_dto import NsdDTO
+from domain.ports import NSDRepositoryPort
+
+
+def test_find_next_probable_nsd_returns_sequence():
+    repo = MagicMock(spec=NSDRepositoryPort)
+    now = datetime.utcnow()
+    start = now - timedelta(days=15)
+
+    items = []
+    for i in range(10):
+        items.append(
+            NsdDTO(
+                nsd=i + 1,
+                company_name=None,
+                quarter=None,
+                version=None,
+                nsd_type=None,
+                dri=None,
+                auditor=None,
+                responsible_auditor=None,
+                protocol=None,
+                sent_date=start + timedelta(days=i),
+                reason=None,
+            )
+        )
+    repo.get_all.return_value = items
+
+    result = _find_next_probable_nsd(
+        repository=repo,
+        window_days=20,
+        safety_factor=1.0,
+    )
+
+    max_date = start + timedelta(days=9)
+    min_date = start
+    days_span = (max_date - min_date).days
+    daily_avg = len(items) / days_span
+    days_since_last = (now - max_date).days
+    expected_count = int(daily_avg * days_since_last * 1.0)
+    expected = [len(items) + i for i in range(1, expected_count + 1)]
+
+    assert result == expected
+
+
+def test_find_next_probable_nsd_empty():
+    repo = MagicMock(spec=NSDRepositoryPort)
+    repo.get_all.return_value = []
+
+    result = _find_next_probable_nsd(repo)
+    assert result == []


### PR DESCRIPTION
## Summary
- implement `_find_next_probable_nsd` in new `nsd_prediction_service`
- add accompanying tests
- restore logic in `SaveStrategy.handle` for flushing based on remaining items

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c0e46cc4832e9d2b6fb12bc28bbc