### PR TITLE
Fix nsd_scraper type handling

### DIFF
--- a/.ruffignore
+++ b/.ruffignore
@@ -1,0 +1,2 @@
+legacy/backend/utils_original/playground.ipynb
+legacy/*


### PR DESCRIPTION
## Summary
- adjust NSD scraper to return `NsdDTO`
- add `.ruffignore` to skip legacy files during formatting

## Testing
- `ruff format infrastructure/scrapers/nsd_scraper.py`
- `ruff check infrastructure/scrapers/nsd_scraper.py --fix`
- `pydocstyle infrastructure/scrapers/nsd_scraper.py --convention=google`
- `docformatter --in-place infrastructure/scrapers/nsd_scraper.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645fc144dc832ea41986a7221eaa2e