### PR TITLE
Move capital composition values to config

### DIFF
--- a/infrastructure/config/statements.py
+++ b/infrastructure/config/statements.py
@@ -6,6 +6,29 @@ from typing import Dict, List, Mapping, Optional, Tuple
 URL_DF = "https://www.rad.cvm.gov.br/ENET/frmDemonstracaoFinanceiraITR.aspx"
 URL_CAPITAL = "https://www.rad.cvm.gov.br/ENET/frmDadosComposicaoCapitalITR.aspx"
 
+CAPITAL_ITEMS: List[Dict[str, str]] = [
+    {
+        "elem_id": "QtdAordCapiItgz_1",
+        "account": "00.01.01",
+        "description": "Ações ON Circulação",
+    },
+    {
+        "elem_id": "QtdAprfCapiItgz_1",
+        "account": "00.01.02",
+        "description": "Ações PN Circulação",
+    },
+    {
+        "elem_id": "QtdAordTeso_1",
+        "account": "00.02.01",
+        "description": "Ações ON Tesouraria",
+    },
+    {
+        "elem_id": "QtdAprfTeso_1",
+        "account": "00.02.02",
+        "description": "Ações PN Tesouraria",
+    },
+]
+
 NSD_TYPE_MAP: Mapping[str, Tuple[str, int]] = {
     "INFORMACOES TRIMESTRAIS": ("ITR", 3),
     "DEMONSTRACOES FINANCEIRAS PADRONIZADAS": ("DFP", 4),
@@ -116,6 +139,9 @@ class StatementsConfig:
     nsd_type_map: Mapping[str, Tuple[str, int]] = field(
         default_factory=lambda: NSD_TYPE_MAP.copy()
     )
+    capital_items: List[Dict[str, str]] = field(
+        default_factory=lambda: [item.copy() for item in CAPITAL_ITEMS]
+    )
     url_df: str = field(default=URL_DF)
     url_capital: str = field(default=URL_CAPITAL)
 
@@ -125,6 +151,7 @@ def load_statements_config() -> StatementsConfig:
     return StatementsConfig(
         statement_items=[item.copy() for item in STATEMENT_ITEMS],
         nsd_type_map=NSD_TYPE_MAP.copy(),
+        capital_items=[item.copy() for item in CAPITAL_ITEMS],
         url_df=URL_DF,
         url_capital=URL_CAPITAL,
     )

--- a/infrastructure/scrapers/statements_source_adapter.py
+++ b/infrastructure/scrapers/statements_source_adapter.py
@@ -49,34 +49,14 @@ class RequestsStatementSourceAdapter(StatementSourcePort):
                 result = self.data_cleaner.clean_number(el.get_text())
                 return result if result is not None else 0.0
 
-            results.append(
-                {
-                    "account": "00.01.01",
-                    "description": "Ações ON Circulação",
-                    "value": v("QtdAordCapiItgz_1"),
-                }
-            )
-            results.append(
-                {
-                    "account": "00.01.02",
-                    "description": "Ações PN Circulação",
-                    "value": v("QtdAprfCapiItgz_1"),
-                }
-            )
-            results.append(
-                {
-                    "account": "00.02.01",
-                    "description": "Ações ON Tesouraria",
-                    "value": v("QtdAordTeso_1"),
-                }
-            )
-            results.append(
-                {
-                    "account": "00.02.02",
-                    "description": "Ações PN Tesouraria",
-                    "value": v("QtdAprfTeso_1"),
-                }
-            )
+            for item in self.statements_config.capital_items:
+                results.append(
+                    {
+                        "account": item["account"],
+                        "description": item["description"],
+                        "value": v(item["elem_id"]),
+                    }
+                )
             return results
 
         # Default parsing for DFs pages

--- a/tests/infrastructure/test_statements_config.py
+++ b/tests/infrastructure/test_statements_config.py
@@ -5,3 +5,4 @@ def test_statements_config_loads():
     config = Config()
     assert config.statements.statement_items[0]["grupo"] == "Dados da Empresa"
     assert "INFORMACOES TRIMESTRAIS" in config.statements.nsd_type_map
+    assert config.statements.capital_items[0]["account"] == "00.01.01"


### PR DESCRIPTION
## Summary
- move capital composition constants into `statements` config
- read the constants in `RequestsStatementSourceAdapter`
- test that config exposes the capital items

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869610ae128832e80953c1107560bdb