### PR TITLE
Add RawStatementDTO

### DIFF
--- a/domain/dto/__init__.py
+++ b/domain/dto/__init__.py
@@ -11,6 +11,7 @@ from .raw_company_dto import (
     CompanyListingDTO,
     CompanyRawDTO,
 )
+from .raw_statement_dto import RawStatementDTO
 from .statement_dto import StatementDTO
 from .sync_companies_result_dto import SyncCompaniesResultDTO
 from .worker_class_dto import WorkerTaskDTO
@@ -19,6 +20,7 @@ __all__ = [
     "CompanyDTO",
     "NsdDTO",
     "StatementDTO",
+    "RawStatementDTO",
     "CompanyRawDTO",
     "CompanyListingDTO",
     "CompanyDetailDTO",

--- a/domain/dto/raw_statement_dto.py
+++ b/domain/dto/raw_statement_dto.py
@@ -1,0 +1,36 @@
+"""DTO for raw statement rows returned by the scraper."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class RawStatementDTO:
+    """Raw statement row scraped from the exchange."""
+
+    account: str
+    description: str
+    value: float
+    grupo: str
+    quadro: str
+    company_name: str
+    nsd: int
+    quarter: Optional[str]
+    version: str
+
+    @staticmethod
+    def from_dict(raw: dict) -> "RawStatementDTO":
+        """Create ``RawStatementDTO`` from a raw dictionary."""
+        return RawStatementDTO(
+            account=str(raw.get("account", "")),
+            description=str(raw.get("description", "")),
+            value=float(raw.get("value", 0.0)),
+            grupo=str(raw.get("grupo", "")),
+            quadro=str(raw.get("quadro", "")),
+            company_name=str(raw.get("company_name", "")),
+            nsd=int(raw.get("nsd", 0)),
+            quarter=raw.get("quarter"),
+            version=str(raw.get("version", "")),
+        )

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -2,6 +2,7 @@ import pytest
 
 from domain.dto.company_dto import CompanyDTO
 from domain.dto.nsd_dto import NsdDTO
+from domain.dto.raw_statement_dto import RawStatementDTO
 
 
 def test_company_dto_from_dict():
@@ -14,3 +15,21 @@ def test_company_dto_from_dict():
 def test_nsd_dto_invalid_nsd():
     with pytest.raises(ValueError):
         NsdDTO.from_dict({"nsd": "not_a_number"})
+
+
+def test_raw_statement_dto_from_dict():
+    raw = {
+        "account": "00.01.01",
+        "description": "A\u00e7\u00f5es ON Circulacao",
+        "value": 0.0,
+        "grupo": "Dados da Empresa",
+        "quadro": "Composi\u00e7\u00e3o do Capital",
+        "company_name": "Test Corp",
+        "nsd": 123,
+        "quarter": "2019-12-31",
+        "version": "V1",
+    }
+    dto = RawStatementDTO.from_dict(raw)
+    assert dto.account == "00.01.01"
+    assert dto.company_name == "Test Corp"
+    assert dto.nsd == 123


### PR DESCRIPTION
## Summary
- include RawStatementDTO to capture statement rows
- expose new DTO from domain
- test RawStatementDTO.from_dict

## Testing
- `ruff format domain/dto/raw_statement_dto.py tests/domain/test_dtos.py domain/dto/__init__.py`
- `ruff check domain/dto/raw_statement_dto.py tests/domain/test_dtos.py domain/dto/__init__.py --fix`
- `docformatter --in-place domain/dto/raw_statement_dto.py tests/domain/test_dtos.py domain/dto/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869761ee900832e915350d6e46b01c8