### PR TITLE
Add StatementRowsDTO for parsed statement rows

### DIFF
--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -1,21 +1,26 @@
+"""Use case responsible for fetching statement rows from the source."""
+
 from __future__ import annotations
 
 from typing import Iterable, List
 
+from domain.dto import NsdDTO, StatementRowsDTO
 from domain.ports import LoggerPort, StatementSourcePort
 
 
 class FetchStatementsUseCase:
-    """Retrieve raw HTML statements from the source port."""
+    """Retrieve parsed statement rows from the source port."""
 
     def __init__(self, logger: LoggerPort, source: StatementSourcePort) -> None:
+        """Store dependencies and emit startup log."""
         self.logger = logger
         self.source = source
         self.logger.log("Start FetchStatementsUseCase", level="info")
 
-    def run(self, batch_ids: Iterable[str]) -> List[str]:
-        html_chunks: List[str] = []
-        for batch_id in batch_ids:
-            self.logger.log(f"Fetch {batch_id}", level="info")
-            html_chunks.append(self.source.fetch(batch_id))
-        return html_chunks
+    def run(self, batch: Iterable[NsdDTO]) -> List[StatementRowsDTO]:
+        """Fetch all statements for the provided NSDs."""
+        rows: List[StatementRowsDTO] = []
+        for item in batch:
+            self.logger.log(f"Fetch {item.nsd}", level="info")
+            rows.append(self.source.fetch(item))
+        return rows

--- a/domain/dto/__init__.py
+++ b/domain/dto/__init__.py
@@ -12,6 +12,7 @@ from .raw_company_dto import (
     CompanyRawDTO,
 )
 from .statement_dto import StatementDTO
+from .statement_rows_dto import StatementRowsDTO
 from .sync_companies_result_dto import SyncCompaniesResultDTO
 from .worker_class_dto import WorkerTaskDTO
 
@@ -19,6 +20,7 @@ __all__ = [
     "CompanyDTO",
     "NsdDTO",
     "StatementDTO",
+    "StatementRowsDTO",
     "CompanyRawDTO",
     "CompanyListingDTO",
     "CompanyDetailDTO",

--- a/domain/dto/statement_rows_dto.py
+++ b/domain/dto/statement_rows_dto.py
@@ -1,0 +1,22 @@
+"""DTO representing statement rows associated with a specific NSD."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+from .nsd_dto import NsdDTO
+
+
+@dataclass(frozen=True)
+class StatementRowsDTO:
+    """Container for parsed statement rows associated with an ``NsdDTO``."""
+
+    nsd: NsdDTO
+    rows: List[Dict[str, Any]]
+
+    @staticmethod
+    def from_tuple(data: Tuple[NsdDTO, List[Dict[str, Any]]]) -> "StatementRowsDTO":
+        """Build a ``StatementRowsDTO`` from ``(NsdDTO, rows)`` tuple."""
+        nsd, rows = data
+        return StatementRowsDTO(nsd=nsd, rows=rows)

--- a/domain/ports/statement_source_port.py
+++ b/domain/ports/statement_source_port.py
@@ -1,14 +1,17 @@
+"""Port definition for retrieving statement rows."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
 from domain.dto.nsd_dto import NsdDTO
+from domain.dto.statement_rows_dto import StatementRowsDTO
 
 
 class StatementSourcePort(ABC):
-    """Port for fetching raw statement HTML."""
+    """Port for fetching parsed statement rows."""
 
     @abstractmethod
-    def fetch(self, row: NsdDTO) -> list:
-        """Return raw HTML for the given batch identifier."""
+    def fetch(self, row: NsdDTO) -> StatementRowsDTO:
+        """Return parsed rows for the given NSD."""
         raise NotImplementedError

--- a/infrastructure/scrapers/statements_source_adapter.py
+++ b/infrastructure/scrapers/statements_source_adapter.py
@@ -10,6 +10,7 @@ from urllib.parse import quote_plus
 from bs4 import BeautifulSoup, Tag
 
 from domain.dto.nsd_dto import NsdDTO
+from domain.dto.statement_rows_dto import StatementRowsDTO
 from domain.ports import LoggerPort, StatementSourcePort
 from infrastructure.config import Config
 from infrastructure.helpers.data_cleaner import DataCleaner
@@ -91,7 +92,8 @@ class RequestsStatementSourceAdapter(StatementSourcePort):
                     {
                         "account": account,
                         "description": account_description,
-                        "value": (self.data_cleaner.clean_number(account_value) or 0.0) * thousand,
+                        "value": (self.data_cleaner.clean_number(account_value) or 0.0)
+                        * thousand,
                     }
                 )
 
@@ -165,8 +167,8 @@ class RequestsStatementSourceAdapter(StatementSourcePort):
             print(e)
         return result
 
-    def fetch(self, row: NsdDTO) -> list[dict[str, str]]:
-        """Fetch HTML for the given NSD and return the statement page."""
+    def fetch(self, row: NsdDTO) -> StatementRowsDTO:
+        """Fetch and parse statements for the given NSD."""
         url = self.endpoint.format(nsd=row.nsd)
         start = time.perf_counter()
 
@@ -184,10 +186,16 @@ class RequestsStatementSourceAdapter(StatementSourcePort):
                 response = self.fetch_utils.fetch_with_retry(self.session, item["url"])
                 soup = BeautifulSoup(response.text, "html.parser")
 
-                if "MensagemModal" in response.text or "acesse este conteúdo pela página principal dos documentos" in soup.get_text():
+                if (
+                    "MensagemModal" in response.text
+                    or "acesse este conteúdo pela página principal dos documentos"
+                    in soup.get_text()
+                ):
                     # Tenta regenerar hash, embora neste caso hash_value_retry não seja usado
-                    hash_response_retry = self.fetch_utils.fetch_with_retry(scraper=None, url=url)
-                    hash_value_retry = self._extract_hash(hash_response.text)
+                    hash_response_retry = self.fetch_utils.fetch_with_retry(
+                        scraper=None, url=url
+                    )
+                    self._extract_hash(hash_response_retry.text)
 
                     # self.logger.log(
                     #     f'{row.company_name} {quarter} {row.version} {row.nsd} - {i} {item["grupo"]} {item["quadro"]} - Retry {attempt+1}',
@@ -200,12 +208,14 @@ class RequestsStatementSourceAdapter(StatementSourcePort):
                 # Se todas as tentativas falharem, aborta NSD
                 self.logger.log(
                     f"{row.company_name} {quarter} {row.version} {row.nsd}... Aborted entire company quarter.",
-                    level="warning"
+                    level="warning",
                 )
-                return []
+                return StatementRowsDTO(nsd=row, rows=[])
 
-
-            self.logger.log(f'{row.company_name} {quarter} {row.version} {row.nsd} - {i} {item["grupo"]} {item["quadro"]}', level="info")
+            self.logger.log(
+                f"{row.company_name} {quarter} {row.version} {row.nsd} - {i} {item['grupo']} {item['quadro']}",
+                level="info",
+            )
             rows = self._parse_statement_page(soup, item["grupo"])
             for r in rows:
                 r.update(
@@ -222,5 +232,8 @@ class RequestsStatementSourceAdapter(StatementSourcePort):
 
         elapsed = time.perf_counter() - start
         quarter = row.quarter.strftime("%Y-%m-%d") if row.quarter else None
-        self.logger.log(f'{row.company_name} {quarter} {row.version} {row.nsd} in {elapsed:.2f}s', level="info")
-        return self.parsed_rows
+        self.logger.log(
+            f"{row.company_name} {quarter} {row.version} {row.nsd} in {elapsed:.2f}s",
+            level="info",
+        )
+        return StatementRowsDTO(nsd=row, rows=self.parsed_rows)

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -2,6 +2,7 @@ import pytest
 
 from domain.dto.company_dto import CompanyDTO
 from domain.dto.nsd_dto import NsdDTO
+from domain.dto.statement_rows_dto import StatementRowsDTO
 
 
 def test_company_dto_from_dict():
@@ -14,3 +15,11 @@ def test_company_dto_from_dict():
 def test_nsd_dto_invalid_nsd():
     with pytest.raises(ValueError):
         NsdDTO.from_dict({"nsd": "not_a_number"})
+
+
+def test_statement_rows_dto_from_tuple():
+    nsd = NsdDTO.from_dict({"nsd": 123})
+    rows = [{"account": "1", "value": 10.0}]
+    dto = StatementRowsDTO.from_tuple((nsd, rows))
+    assert dto.nsd == nsd
+    assert dto.rows == rows


### PR DESCRIPTION
## Summary
- introduce `StatementRowsDTO` to encapsulate parsed statement rows
- adapt statement source port and adapter to return the new DTO
- update parse use case and statement processing service to use `StatementRowsDTO`
- revise fetch statements use case to fetch by `NsdDTO`
- add tests for the new DTO

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google application/services/statement_processing_service.py application/usecases/fetch_statements.py application/usecases/parse_and_classify_statements.py domain/ports/statement_source_port.py domain/dto/statement_rows_dto.py`
- `docformatter --in-place application/usecases/fetch_statements.py application/usecases/parse_and_classify_statements.py application/services/statement_processing_service.py domain/ports/statement_source_port.py domain/dto/statement_rows_dto.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4e7bb0b0832e924bca4e4eaeee51