### PR TITLE
Introduce StatementRowsDTO for statement parsing

### DIFF
--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Iterable, List
 
+from domain.dto.nsd_dto import NsdDTO
+from domain.dto.statement_rows_dto import StatementRowsDTO
 from domain.ports import LoggerPort, StatementSourcePort
 
 
@@ -13,9 +15,11 @@ class FetchStatementsUseCase:
         self.source = source
         self.logger.log("Start FetchStatementsUseCase", level="info")
 
-    def run(self, batch_ids: Iterable[str]) -> List[str]:
-        html_chunks: List[str] = []
-        for batch_id in batch_ids:
-            self.logger.log(f"Fetch {batch_id}", level="info")
-            html_chunks.append(self.source.fetch(batch_id))
-        return html_chunks
+    def run(
+        self, batch_rows: Iterable[NsdDTO]
+    ) -> List[tuple[NsdDTO, list[StatementRowsDTO]]]:
+        results: List[tuple[NsdDTO, list[StatementRowsDTO]]] = []
+        for row in batch_rows:
+            self.logger.log(f"Fetch {row.nsd}", level="info")
+            results.append(self.source.fetch(row))
+        return results

--- a/application/usecases/parse_and_classify_statements.py
+++ b/application/usecases/parse_and_classify_statements.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from typing import List
-
-from bs4 import BeautifulSoup
-
 from domain.dto import StatementDTO
+from domain.dto.statement_rows_dto import StatementRowsDTO
 from domain.ports import LoggerPort
-from domain.utils.statement_processing import classify_section, normalize_value
+from domain.utils.statement_processing import classify_section
 
 
 class ParseAndClassifyStatementsUseCase:
@@ -16,19 +13,13 @@ class ParseAndClassifyStatementsUseCase:
         self.logger = logger
         self.logger.log("Start ParseAndClassifyStatementsUseCase", level="info")
 
-    def run(self, batch_id: str, html: str) -> List[StatementDTO]:
-        soup = BeautifulSoup(html, "html.parser")
-        dtos: List[StatementDTO] = []
-        for row in soup.select("tr"):
-            cells = [c.get_text(strip=True) for c in row.find_all("td")]
-            if len(cells) < 2:
-                continue
-            account, value_raw = cells[0], cells[1]
-            dto = StatementDTO(
-                batch_id=batch_id,
-                account=account,
-                section=classify_section(account),
-                value=normalize_value(value_raw),
-            )
-            dtos.append(dto)
-        return dtos
+    def run(self, row: StatementRowsDTO) -> StatementDTO:
+        """Build a :class:`StatementDTO` from a statement row."""
+        return StatementDTO(
+            batch_id=str(row.nsd),
+            account=row.account,
+            section=classify_section(row.account),
+            value=float(row.value),
+            company=row.company_name,
+            period=row.quarter,
+        )

--- a/domain/dto/__init__.py
+++ b/domain/dto/__init__.py
@@ -12,6 +12,7 @@ from .raw_company_dto import (
     CompanyRawDTO,
 )
 from .statement_dto import StatementDTO
+from .statement_rows_dto import StatementRowsDTO
 from .sync_companies_result_dto import SyncCompaniesResultDTO
 from .worker_class_dto import WorkerTaskDTO
 
@@ -19,6 +20,7 @@ __all__ = [
     "CompanyDTO",
     "NsdDTO",
     "StatementDTO",
+    "StatementRowsDTO",
     "CompanyRawDTO",
     "CompanyListingDTO",
     "CompanyDetailDTO",

--- a/domain/dto/statement_rows_dto.py
+++ b/domain/dto/statement_rows_dto.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class StatementRowsDTO:
+    """Immutable DTO for parsed statement rows."""
+
+    account: str
+    description: str
+    value: float
+    grupo: str
+    quadro: str
+    company_name: Optional[str]
+    nsd: int
+    quarter: Optional[str]
+    version: Optional[str]
+
+    @staticmethod
+    def from_tuple(values: Tuple) -> "StatementRowsDTO":
+        """Create a ``StatementRowsDTO`` from an ordered tuple."""
+        keys = [
+            "account",
+            "description",
+            "value",
+            "grupo",
+            "quadro",
+            "company_name",
+            "nsd",
+            "quarter",
+            "version",
+        ]
+
+        mapping = dict(zip(keys, values))
+
+        mapping["account"] = str(mapping.get("account"))
+        mapping["description"] = str(mapping.get("description"))
+        mapping["value"] = float(mapping.get("value"))
+        mapping["grupo"] = str(mapping.get("grupo"))
+        mapping["quadro"] = str(mapping.get("quadro"))
+        company_name = mapping.get("company_name")
+        mapping["company_name"] = (
+            str(company_name) if company_name is not None else None
+        )
+        mapping["nsd"] = int(mapping.get("nsd"))
+        quarter = mapping.get("quarter")
+        mapping["quarter"] = str(quarter) if quarter is not None else None
+        version = mapping.get("version")
+        mapping["version"] = str(version) if version is not None else None
+
+        return StatementRowsDTO(**mapping)

--- a/domain/ports/statement_source_port.py
+++ b/domain/ports/statement_source_port.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from domain.dto.nsd_dto import NsdDTO
+from domain.dto.statement_rows_dto import StatementRowsDTO
 
 
 class StatementSourcePort(ABC):
     """Port for fetching raw statement HTML."""
 
     @abstractmethod
-    def fetch(self, row: NsdDTO) -> list:
-        """Return raw HTML for the given batch identifier."""
+    def fetch(self, row: NsdDTO) -> tuple[NsdDTO, list[StatementRowsDTO]]:
+        """Return statement rows for the given NSD."""
         raise NotImplementedError

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -2,6 +2,7 @@ import pytest
 
 from domain.dto.company_dto import CompanyDTO
 from domain.dto.nsd_dto import NsdDTO
+from domain.dto.statement_rows_dto import StatementRowsDTO
 
 
 def test_company_dto_from_dict():
@@ -14,3 +15,20 @@ def test_company_dto_from_dict():
 def test_nsd_dto_invalid_nsd():
     with pytest.raises(ValueError):
         NsdDTO.from_dict({"nsd": "not_a_number"})
+
+
+def test_statement_rows_dto_from_tuple():
+    tpl = (
+        "00.01.01",
+        "A\u00e7\u00f5es ON Circulacao",
+        113548407.0,
+        "Dados da Empresa",
+        "Composi\u00e7\u00e3o do Capital",
+        "2W ECOBANK SA",
+        102395,
+        "2020-12-31",
+        "V1",
+    )
+    dto = StatementRowsDTO.from_tuple(tpl)
+    assert dto.account == "00.01.01"
+    assert dto.nsd == 102395


### PR DESCRIPTION
## Summary
- add StatementRowsDTO dataclass for parsed statement rows
- return StatementRowsDTO objects from statement source
- parse StatementRowsDTO into StatementDTO
- wire up StatementRowsDTO through StatementProcessingService
- test StatementRowsDTO.from_tuple
- use a dict in `StatementRowsDTO.from_tuple`

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686a54d7afa0832e8a61f39f768931b1