### PR TITLE
Refactor statement fetch flow

### DIFF
--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -1,25 +1,85 @@
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Callable, Iterable, List, Optional, Tuple
 
 from domain.dto.nsd_dto import NsdDTO
 from domain.dto.statement_rows_dto import StatementRowsDTO
+from domain.dto.worker_class_dto import WorkerTaskDTO
 from domain.ports import LoggerPort, StatementSourcePort
+from infrastructure.config import Config
+from infrastructure.helpers import MetricsCollector, SaveStrategy, WorkerPool
 
 
 class FetchStatementsUseCase:
     """Retrieve raw HTML statements from the source port."""
 
-    def __init__(self, logger: LoggerPort, source: StatementSourcePort) -> None:
+    def __init__(
+        self,
+        logger: LoggerPort,
+        source: StatementSourcePort,
+        config: Config,
+        max_workers: int = 1,
+    ) -> None:
         self.logger = logger
         self.source = source
+        self.config = config
+        self.max_workers = max_workers
         self.logger.log("Start FetchStatementsUseCase", level="info")
 
+    def fetch_all(
+        self,
+        targets: List[NsdDTO],
+        save_callback: Optional[
+            Callable[[List[Tuple[NsdDTO, List[StatementRowsDTO]]]], None]
+        ] = None,
+        threshold: Optional[int] = None,
+    ) -> List[Tuple[NsdDTO, List[StatementRowsDTO]]]:
+        """Fetch statements for ``targets`` concurrently."""
+        collector = MetricsCollector()
+        pool = WorkerPool(
+            config=self.config,
+            metrics_collector=collector,
+            max_workers=self.max_workers,
+        )
+
+        strategy: SaveStrategy[Tuple[NsdDTO, List[StatementRowsDTO]]] = SaveStrategy(
+            save_callback, threshold, config=self.config
+        )
+
+        tasks = list(enumerate(targets))
+
+        def processor(task: WorkerTaskDTO) -> Tuple[NsdDTO, List[StatementRowsDTO]]:
+            return self.source.fetch(task.data)
+
+        def handle_batch(item: Tuple[NsdDTO, List[StatementRowsDTO]]) -> None:
+            strategy.handle(item)
+
+        result = pool.run(
+            tasks=tasks,
+            processor=processor,
+            logger=self.logger,
+            on_result=handle_batch,
+        )
+
+        strategy.finalize()
+
+        return result.items
+
     def run(
-        self, batch_rows: Iterable[NsdDTO]
-    ) -> List[tuple[NsdDTO, list[StatementRowsDTO]]]:
-        results: List[tuple[NsdDTO, list[StatementRowsDTO]]] = []
-        for row in batch_rows:
-            self.logger.log(f"Fetch {row.nsd}", level="info")
-            results.append(self.source.fetch(row))
-        return results
+        self,
+        batch_rows: Iterable[NsdDTO],
+        save_callback: Optional[
+            Callable[[List[Tuple[NsdDTO, List[StatementRowsDTO]]]], None]
+        ] = None,
+        threshold: Optional[int] = None,
+    ) -> List[Tuple[NsdDTO, List[StatementRowsDTO]]]:
+        """Execute the use case for ``batch_rows``."""
+        targets = list(batch_rows)
+        if not targets:
+            return []
+
+        return self.fetch_all(
+            targets=targets,
+            save_callback=save_callback,
+            threshold=threshold,
+        )

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -129,7 +129,9 @@ class CLIController:
         """Build and run the statement processing workflow."""
         self.logger.log("Start Statement Sync Use Case", level="info")
 
-        statement_repo = SqlAlchemyStatementRepository(config=self.config, logger=self.logger)
+        statement_repo = SqlAlchemyStatementRepository(
+            config=self.config, logger=self.logger
+        )
         company_repo = SqlAlchemyCompanyRepository(
             config=self.config, logger=self.logger
         )
@@ -139,9 +141,16 @@ class CLIController:
             config=self.config, logger=self.logger, data_cleaner=self.data_cleaner
         )
 
-        fetch_uc = FetchStatementsUseCase(logger=self.logger, source=source)
+        fetch_uc = FetchStatementsUseCase(
+            logger=self.logger,
+            source=source,
+            config=self.config,
+            max_workers=self.config.global_settings.max_workers,
+        )
         parse_uc = ParseAndClassifyStatementsUseCase(logger=self.logger)
-        persist_uc = PersistStatementsUseCase(logger=self.logger, repository=statement_repo)
+        persist_uc = PersistStatementsUseCase(
+            logger=self.logger, repository=statement_repo
+        )
 
         statements_fetch_service = StatementFetchService(
             logger=self.logger,

--- a/tests/application/test_statement_fetch_service.py
+++ b/tests/application/test_statement_fetch_service.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+from application.services.statement_fetch_service import StatementFetchService
+from application.usecases.fetch_statements import FetchStatementsUseCase
+from domain.dto.nsd_dto import NsdDTO
+from domain.ports import (
+    CompanyRepositoryPort,
+    NSDRepositoryPort,
+    StatementRepositoryPort,
+)
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def test_run_calls_usecase(monkeypatch):
+    dummy_config = DummyConfig()
+
+    usecase = MagicMock(spec=FetchStatementsUseCase)
+
+    company_repo = MagicMock(spec=CompanyRepositoryPort)
+    nsd_repo = MagicMock(spec=NSDRepositoryPort)
+    stmt_repo = MagicMock(spec=StatementRepositoryPort)
+
+    service = StatementFetchService(
+        logger=DummyLogger(),
+        fetch_usecase=usecase,
+        company_repo=company_repo,
+        nsd_repo=nsd_repo,
+        statement_repo=stmt_repo,
+        config=dummy_config,
+        max_workers=3,
+    )
+
+    targets = [MagicMock(spec=NsdDTO)]
+    monkeypatch.setattr(service, "_build_targets", lambda: targets)
+
+    result = service.run(save_callback="cb", threshold=5)
+
+    usecase.run.assert_called_once_with(targets, save_callback="cb", threshold=5)
+    assert result == usecase.run.return_value


### PR DESCRIPTION
## Summary
- move worker pool logic from `StatementFetchService` to `FetchStatementsUseCase`
- adjust service `run` to delegate to the use case
- provide configuration when instantiating the use case in CLI
- add a test ensuring the service delegates work to the use case

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest tests/application/test_statement_fetch_service.py -q`
- `pytest -q` *(fails due to long runtime, aborted with KeyboardInterrupt after success)*

------
https://chatgpt.com/codex/tasks/task_e_686aa5066258832ea6921049eb2b2c51