### PR TITLE
01 Clean up merge markers in code

### DIFF
--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -71,36 +71,21 @@ class FetchStatementsUseCase:
                 "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all().processor().source.fetch()",
                 level="info",
             )
-# <<<<<<< codex/double-check-result-handling-in-strategy-and-save-method
             fetched = self.source.fetch(task.data)
-# =======
-#             results = self.source.fetch(task.data)
-# >>>>>>> 2025-07-03-Statements-Round-1
             self.logger.log(
                 "End  Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all().processor().source.fetch()",
                 level="info",
             )
 
-# <<<<<<< codex/double-check-result-handling-in-strategy-and-save-method
             return fetched["nsd"], fetched["statements"]
 
         def handle_batch(item: Tuple[NsdDTO, List[StatementRowsDTO]]) -> None:
             if item[1]:
-# =======
-#             return results
-
-#         def handle_batch(item: Tuple[NsdDTO, List[StatementRowsDTO]]) -> None:
-#             if item["statements"]:
-# >>>>>>> 2025-07-03-Statements-Round-1
                 self.logger.log(
                     "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all().strategy.handle()",
                     level="info",
                 )
-# <<<<<<< codex/double-check-result-handling-in-strategy-and-save-method
                 strategy.handle(item)
-# =======
-#                 strategy.handle(item["statements"])
-# >>>>>>> 2025-07-03-Statements-Round-1
                 self.logger.log(
                     "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all().strategy.handle()",
                     level="info",

--- a/domain/dto/statement_rows_dto.py
+++ b/domain/dto/statement_rows_dto.py
@@ -19,33 +19,9 @@ class StatementRowsDTO:
     value: float
 
     @staticmethod
-# <<<<<<< HEAD
-#     def from_tuple(values: Tuple) -> "StatementRowsDTO":
-#         """Create a ``StatementRowsDTO`` from an ordered tuple."""
-#         (
-#             nsd,
-#             company_name,
-#             quarter,
-#             version,
-#             grupo,
-#             quadro,
-#             account,
-#             description,
-#             value,
-#         ) = values
-#         return StatementRowsDTO(
-#             nsd=int(nsd),
-#             company_name=str(company_name) if company_name is not None else None,
-#             quarter=str(quarter) if quarter is not None else None,
-#             version=str(version) if version is not None else None,
-#             grupo=str(grupo),
-#             quadro=str(quadro),
-#             account=str(account),
-#             description=str(description),
-#             value=float(value),
-# =======
     def from_dict(raw: dict) -> "StatementRowsDTO":
         """Create a ``StatementRowsDTO`` from a raw dictionary."""
+
         return StatementRowsDTO(
             nsd=int(raw.get("nsd", 0)),
             company_name=raw.get("company_name"),
@@ -56,5 +32,4 @@ class StatementRowsDTO:
             account=str(raw.get("account", "")),
             description=str(raw.get("description", "")),
             value=float(raw.get("value", 0.0)),
-# >>>>>>> 12ae6caf4c160196a7670d81e7ef87d8a80cd61f
         )


### PR DESCRIPTION
## Summary
- clear merge artifacts from `fetch_statements` use case
- clean up `StatementRowsDTO.from_dict` implementation

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af70c7a34832ea9290e258db63047