### PR TITLE
04 Refactor PersistStatementsUseCase and services

### DIFF
--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -9,6 +9,7 @@ from domain.ports import (
     LoggerPort,
     NSDRepositoryPort,
     StatementRepositoryPort,
+    StatementSourcePort,
 )
 from infrastructure.config import Config
 
@@ -19,7 +20,7 @@ class StatementFetchService:
     def __init__(
         self,
         logger: LoggerPort,
-        fetch_usecase: FetchStatementsUseCase,
+        source: StatementSourcePort,
         company_repo: CompanyRepositoryPort,
         nsd_repo: NSDRepositoryPort,
         statement_repo: StatementRepositoryPort,
@@ -28,7 +29,12 @@ class StatementFetchService:
     ) -> None:
         """Store dependencies for the service."""
         self.logger = logger
-        self.fetch_usecase = fetch_usecase
+        self.fetch_usecase = FetchStatementsUseCase(
+            logger=self.logger,
+            source=source,
+            config=config,
+            max_workers=max_workers,
+        )
         self.company_repo = company_repo
         self.nsd_repo = nsd_repo
         self.statement_repo = statement_repo

--- a/application/services/statement_parse_service.py
+++ b/application/services/statement_parse_service.py
@@ -7,7 +7,7 @@ from application.usecases.parse_and_classify_statements import (
 )
 from application.usecases.persist_statements import PersistStatementsUseCase
 from domain.dto import NsdDTO, StatementDTO, StatementRowsDTO, WorkerTaskDTO
-from domain.ports import LoggerPort
+from domain.ports import LoggerPort, StatementRepositoryPort
 from infrastructure.config import Config
 from infrastructure.helpers import MetricsCollector, WorkerPool
 
@@ -19,14 +19,16 @@ class StatementParseService:
         self,
         logger: LoggerPort,
         parse_usecase: ParseAndClassifyStatementsUseCase,
-        persist_usecase: PersistStatementsUseCase,
+        statement_repo: StatementRepositoryPort,
         config: Config,
         max_workers: int = 1,
     ) -> None:
         """Store dependencies for the service."""
         self.logger = logger
         self.parse_usecase = parse_usecase
-        self.persist_usecase = persist_usecase
+        self.persist_usecase = PersistStatementsUseCase(
+            logger=self.logger, repository=statement_repo
+        )
         self.config = config
         self.max_workers = max_workers
 

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -5,11 +5,7 @@ from application.services.company_service import CompanyService
 from application.services.nsd_service import NsdService
 from application.services.statement_fetch_service import StatementFetchService
 from application.services.statement_parse_service import StatementParseService
-from application.usecases import (
-    FetchStatementsUseCase,
-    ParseAndClassifyStatementsUseCase,
-    PersistStatementsUseCase,
-)
+from application.usecases import ParseAndClassifyStatementsUseCase
 from domain.ports import LoggerPort
 from infrastructure.config import Config
 from infrastructure.helpers import WorkerPool
@@ -226,33 +222,18 @@ class CLIController:
         )
         self.logger.log("End Instance source", level="info")
 
-        self.logger.log("Instantiate fetch_uc (source)", level="info")
-        fetch_uc = FetchStatementsUseCase(
-            logger=self.logger,
-            source=source,
-            config=self.config,
-            max_workers=self.config.global_settings.max_workers,
-        )
-        self.logger.log("End Instance fetch_uc (source)", level="info")
-
         self.logger.log("Instantiate parse_uc", level="info")
         parse_uc = ParseAndClassifyStatementsUseCase(logger=self.logger)
         self.logger.log("End Instance parse_uc", level="info")
 
-        self.logger.log("Instantiate persist_uc", level="info")
-        persist_uc = PersistStatementsUseCase(
-            logger=self.logger, repository=statement_repo
-        )
-        self.logger.log("End Instance persist_uc", level="info")
-
         # UseCase 1: Fetch
         self.logger.log(
-            "Instantiate statements_fetch_service (fetch_uc, company_repo, nsd_repo, statement_repo)",
+            "Instantiate statements_fetch_service (source, company_repo, nsd_repo, statement_repo)",
             level="info",
         )
         statements_fetch_service = StatementFetchService(
             logger=self.logger,
-            fetch_usecase=fetch_uc,
+            source=source,
             company_repo=company_repo,
             nsd_repo=nsd_repo,
             statement_repo=statement_repo,
@@ -270,18 +251,16 @@ class CLIController:
         )
 
         self.logger.log(
-            "End Instance statements_fetch_service (fetch_uc, company_repo, nsd_repo, statement_repo)",
+            "End Instance statements_fetch_service (source, company_repo, nsd_repo, statement_repo)",
             level="info",
         )
 
         # UseCase 2: Parse
-        self.logger.log(
-            "Instantiate parse_service (parce_uc, persist_uc)", level="info"
-        )
+        self.logger.log("Instantiate parse_service (parse_uc)", level="info")
         parse_service = StatementParseService(
             logger=self.logger,
             parse_usecase=parse_uc,
-            persist_usecase=persist_uc,
+            statement_repo=statement_repo,
             config=self.config,
             max_workers=self.config.global_settings.max_workers,
         )
@@ -296,9 +275,7 @@ class CLIController:
             level="info",
         )
 
-        self.logger.log(
-            "End Instance parse_service (parce_uc, persist_uc)", level="info"
-        )
+        self.logger.log("End Instance parse_service (parse_uc)", level="info")
 
         self.logger.log(
             "End  Method controller.run()._statement_service()", level="info"

--- a/tests/application/test_statement_parse_service.py
+++ b/tests/application/test_statement_parse_service.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+from application.services.statement_parse_service import StatementParseService
+from application.usecases.parse_and_classify_statements import (
+    ParseAndClassifyStatementsUseCase,
+)
+from application.usecases.persist_statements import PersistStatementsUseCase
+from domain.ports import StatementRepositoryPort
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def test_init_creates_persist_usecase(monkeypatch):
+    repo = MagicMock(spec=StatementRepositoryPort)
+    parse_usecase = MagicMock(spec=ParseAndClassifyStatementsUseCase)
+
+    persist_cls = MagicMock(spec=PersistStatementsUseCase)
+    persist_inst = MagicMock()
+    persist_cls.return_value = persist_inst
+    monkeypatch.setattr(
+        "application.services.statement_parse_service.PersistStatementsUseCase",
+        persist_cls,
+    )
+
+    service = StatementParseService(
+        logger=DummyLogger(),
+        parse_usecase=parse_usecase,
+        statement_repo=repo,
+        config=DummyConfig(),
+    )
+
+    persist_cls.assert_called_once_with(logger=service.logger, repository=repo)
+
+
+def test_run_parses_and_persists(monkeypatch):
+    repo = MagicMock(spec=StatementRepositoryPort)
+    parse_usecase = MagicMock(spec=ParseAndClassifyStatementsUseCase)
+    persist_cls = MagicMock(spec=PersistStatementsUseCase)
+    persist_inst = MagicMock()
+    persist_cls.return_value = persist_inst
+    monkeypatch.setattr(
+        "application.services.statement_parse_service.PersistStatementsUseCase",
+        persist_cls,
+    )
+
+    service = StatementParseService(
+        logger=DummyLogger(),
+        parse_usecase=parse_usecase,
+        statement_repo=repo,
+        config=DummyConfig(),
+    )
+
+    parse_all = MagicMock(return_value=[[MagicMock()]])
+    persist_all = MagicMock()
+    monkeypatch.setattr(service, "_parse_all", parse_all)
+    monkeypatch.setattr(service, "_persist_all", persist_all)
+
+    fetched = [
+        (
+            MagicMock(),
+            [MagicMock()],
+        )
+    ]
+
+    service.run(fetched)
+
+    parse_all.assert_called_once_with(fetched)
+    persist_all.assert_called_once_with(parse_all.return_value)


### PR DESCRIPTION
## Summary
- stop constructing PersistStatementsUseCase in CLI
- let StatementParseService create PersistStatementsUseCase
- instantiate FetchStatementsUseCase inside StatementFetchService
- update CLI for new service APIs
- expand tests for statement services

## Testing
- `ruff format presentation/cli.py application/services/statement_parse_service.py application/services/statement_fetch_service.py tests/application/test_statement_fetch_service.py tests/application/test_statement_parse_service.py`
- `ruff check presentation/cli.py application/services/statement_parse_service.py application/services/statement_fetch_service.py tests/application/test_statement_fetch_service.py tests/application/test_statement_parse_service.py --fix`
- `pydocstyle --convention=google presentation/cli.py application/services/statement_parse_service.py application/services/statement_fetch_service.py tests/application/test_statement_fetch_service.py tests/application/test_statement_parse_service.py`
- `docformatter --in-place --recursive presentation/cli.py application/services/statement_parse_service.py application/services/statement_fetch_service.py tests/application/test_statement_fetch_service.py tests/application/test_statement_parse_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af71b0330832ea7620128f96630cd