### PR TITLE
01 01 01 01 Refactor use cases and update tests

### DIFF
--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -9,6 +9,8 @@ from domain.ports import (
     LoggerPort,
     NSDRepositoryPort,
     StatementRepositoryPort,
+    StatementRowsRepositoryPort,
+    StatementSourcePort,
 )
 from infrastructure.config import Config
 
@@ -19,7 +21,8 @@ class StatementFetchService:
     def __init__(
         self,
         logger: LoggerPort,
-        fetch_usecase: FetchStatementsUseCase,
+        source: StatementSourcePort,
+        rows_repository: StatementRowsRepositoryPort,
         company_repo: CompanyRepositoryPort,
         nsd_repo: NSDRepositoryPort,
         statement_repo: StatementRepositoryPort,
@@ -28,12 +31,19 @@ class StatementFetchService:
     ) -> None:
         """Store dependencies for the service."""
         self.logger = logger
-        self.fetch_usecase = fetch_usecase
         self.company_repo = company_repo
         self.nsd_repo = nsd_repo
         self.statement_repo = statement_repo
         self.config = config
         self.max_workers = max_workers
+
+        self.fetch_usecase = FetchStatementsUseCase(
+            logger=self.logger,
+            source=source,
+            repository=rows_repository,
+            config=self.config,
+            max_workers=self.max_workers,
+        )
 
         self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 

--- a/application/services/statement_parse_service.py
+++ b/application/services/statement_parse_service.py
@@ -6,7 +6,7 @@ from application.usecases.parse_and_classify_statements import (
     ParseAndClassifyStatementsUseCase,
 )
 from domain.dto import NsdDTO, StatementDTO, StatementRowsDTO, WorkerTaskDTO
-from domain.ports import LoggerPort
+from domain.ports import LoggerPort, StatementRepositoryPort
 from infrastructure.config import Config
 from infrastructure.helpers import MetricsCollector, WorkerPool
 
@@ -17,15 +17,20 @@ class StatementParseService:
     def __init__(
         self,
         logger: LoggerPort,
-        parse_usecase: ParseAndClassifyStatementsUseCase,
+        repository: StatementRepositoryPort,
         config: Config,
         max_workers: int = 1,
     ) -> None:
         """Store dependencies for the service."""
         self.logger = logger
-        self.parse_usecase = parse_usecase
         self.config = config
         self.max_workers = max_workers
+
+        self.parse_usecase = ParseAndClassifyStatementsUseCase(
+            logger=self.logger,
+            repository=repository,
+            config=self.config,
+        )
 
         self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -5,10 +5,6 @@ from application.services.company_service import CompanyService
 from application.services.nsd_service import NsdService
 from application.services.statement_fetch_service import StatementFetchService
 from application.services.statement_parse_service import StatementParseService
-from application.usecases import (
-    FetchStatementsUseCase,
-    ParseAndClassifyStatementsUseCase,
-)
 from domain.ports import LoggerPort
 from infrastructure.config import Config
 from infrastructure.helpers import WorkerPool
@@ -233,32 +229,15 @@ class CLIController:
         )
         self.logger.log("End Instance source", level="info")
 
-        self.logger.log("Instantiate fetch_uc (source)", level="info")
-        fetch_uc = FetchStatementsUseCase(
-            logger=self.logger,
-            source=source,
-            repository=raw_rows_repo,
-            config=self.config,
-            max_workers=self.config.global_settings.max_workers,
-        )
-        self.logger.log("End Instance fetch_uc (source)", level="info")
-
-        self.logger.log("Instantiate parse_uc", level="info")
-        parse_uc = ParseAndClassifyStatementsUseCase(
-            logger=self.logger,
-            repository=statement_repo,
-            config=self.config,
-        )
-        self.logger.log("End Instance parse_uc", level="info")
-
         # UseCase 1: Fetch
         self.logger.log(
-            "Instantiate statements_fetch_service (fetch_uc, company_repo, nsd_repo, statement_repo)",
+            "Instantiate statements_fetch_service (source, raw_rows_repo, company_repo, nsd_repo, statement_repo)",
             level="info",
         )
         statements_fetch_service = StatementFetchService(
             logger=self.logger,
-            fetch_usecase=fetch_uc,
+            source=source,
+            rows_repository=raw_rows_repo,
             company_repo=company_repo,
             nsd_repo=nsd_repo,
             statement_repo=statement_repo,
@@ -276,15 +255,15 @@ class CLIController:
         )
 
         self.logger.log(
-            "End Instance statements_fetch_service (fetch_uc, company_repo, nsd_repo, statement_repo)",
+            "End Instance statements_fetch_service (source, raw_rows_repo, company_repo, nsd_repo, statement_repo)",
             level="info",
         )
 
         # UseCase 2: Parse
-        self.logger.log("Instantiate parse_service (parse_uc)", level="info")
+        self.logger.log("Instantiate parse_service (statement_repo)", level="info")
         parse_service = StatementParseService(
             logger=self.logger,
-            parse_usecase=parse_uc,
+            repository=statement_repo,
             config=self.config,
             max_workers=self.config.global_settings.max_workers,
         )
@@ -299,7 +278,7 @@ class CLIController:
             level="info",
         )
 
-        self.logger.log("End Instance parse_service (parse_uc)", level="info")
+        self.logger.log("End Instance parse_service (statement_repo)", level="info")
 
         self.logger.log(
             "End  Method controller.run()._statement_service()", level="info"

--- a/tests/application/test_statement_parse_service.py
+++ b/tests/application/test_statement_parse_service.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+from application.services.statement_parse_service import StatementParseService
+from application.usecases.parse_and_classify_statements import (
+    ParseAndClassifyStatementsUseCase,
+)
+from domain.dto import NsdDTO, StatementRowsDTO
+from domain.ports import StatementRepositoryPort
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def test_run_invokes_parse_and_finalize(monkeypatch):
+    dummy_config = DummyConfig()
+
+    mock_usecase_cls = MagicMock(spec=ParseAndClassifyStatementsUseCase)
+    mock_usecase_inst = MagicMock()
+    mock_usecase_cls.return_value = mock_usecase_inst
+    monkeypatch.setattr(
+        "application.services.statement_parse_service.ParseAndClassifyStatementsUseCase",
+        mock_usecase_cls,
+    )
+
+    repository = MagicMock(spec=StatementRepositoryPort)
+
+    service = StatementParseService(
+        logger=DummyLogger(),
+        repository=repository,
+        config=dummy_config,
+        max_workers=2,
+    )
+
+    mock_usecase_cls.assert_called_once_with(
+        logger=service.logger, repository=repository, config=dummy_config
+    )
+
+    parse_all = MagicMock()
+    monkeypatch.setattr(service, "_parse_all", parse_all)
+
+    fetched = [(MagicMock(spec=NsdDTO), [MagicMock(spec=StatementRowsDTO)])]
+
+    service.run(fetched)
+
+    parse_all.assert_called_once_with(fetched)
+    mock_usecase_inst.finalize.assert_called_once()


### PR DESCRIPTION
## Summary
- update `StatementParseService` to build its own use case with the provided repository
- update `StatementFetchService` to create `FetchStatementsUseCase`
- wire new constructor arguments in CLI
- adapt existing tests and add new tests for `StatementParseService`

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0101bc84832ea5ae5248c1d580c2