### PR TITLE
Avoid re-fetching already processed NSDs

### DIFF
--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -42,6 +42,7 @@ class StatementFetchService:
             logger=self.logger,
             source=source,
             repository=rows_repository,
+            statement_repository=statement_repo,
             config=self.config,
             max_workers=self.max_workers,
         )
@@ -121,7 +122,6 @@ class StatementFetchService:
         if not targets:
             self.logger.log("No statements to fetch", level="info")
             return []
-
 
         self.logger.log(
             "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run(save_callback, threshold)",

--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -7,6 +7,7 @@ from domain.dto.statement_rows_dto import StatementRowsDTO
 from domain.dto.worker_class_dto import WorkerTaskDTO
 from domain.ports import (
     LoggerPort,
+    StatementRepositoryPort,
     StatementRowsRepositoryPort,
     StatementSourcePort,
 )
@@ -22,6 +23,7 @@ class FetchStatementsUseCase:
         logger: LoggerPort,
         source: StatementSourcePort,
         repository: StatementRowsRepositoryPort,
+        statement_repository: StatementRepositoryPort,
         config: Config,
         max_workers: int = 1,
     ) -> None:
@@ -30,6 +32,7 @@ class FetchStatementsUseCase:
         self.logger = logger
         self.source = source
         self.repository = repository
+        self.statement_repository = statement_repository
         self.config = config
         self.max_workers = max_workers
 
@@ -141,12 +144,17 @@ class FetchStatementsUseCase:
         if not targets:
             return []
 
+        existing = self.statement_repository.get_all_primary_keys()
+        to_fetch = [t for t in targets if str(t.nsd) not in existing]
+        if not to_fetch:
+            return []
+
         self.logger.log(
             "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all(save_callback, threshold)",
             level="info",
         )
         results = self.fetch_all(
-            targets=targets,
+            targets=to_fetch,
             save_callback=save_callback,
             threshold=threshold,
         )

--- a/tests/application/test_fetch_statements_use_case.py
+++ b/tests/application/test_fetch_statements_use_case.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock
+
+from application.usecases.fetch_statements import FetchStatementsUseCase
+from domain.dto.nsd_dto import NsdDTO
+from domain.ports import (
+    StatementRepositoryPort,
+    StatementRowsRepositoryPort,
+    StatementSourcePort,
+)
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def _make_nsd(nsd: int) -> NsdDTO:
+    return NsdDTO(
+        nsd=nsd,
+        company_name=None,
+        quarter=None,
+        version=None,
+        nsd_type=None,
+        dri=None,
+        auditor=None,
+        responsible_auditor=None,
+        protocol=None,
+        sent_date=None,
+        reason=None,
+    )
+
+
+def test_run_skips_existing(monkeypatch):
+    source = MagicMock(spec=StatementSourcePort)
+    rows_repo = MagicMock(spec=StatementRowsRepositoryPort)
+    stmt_repo = MagicMock(spec=StatementRepositoryPort)
+    stmt_repo.get_all_primary_keys.return_value = {"1"}
+
+    usecase = FetchStatementsUseCase(
+        logger=DummyLogger(),
+        source=source,
+        repository=rows_repo,
+        statement_repository=stmt_repo,
+        config=DummyConfig(),
+        max_workers=2,
+    )
+
+    mock_fetch_all = MagicMock(return_value=[("result", [])])
+    monkeypatch.setattr(usecase, "fetch_all", mock_fetch_all)
+
+    targets = [_make_nsd(1), _make_nsd(2)]
+    result = usecase.run(targets, save_callback="cb", threshold=5)
+
+    stmt_repo.get_all_primary_keys.assert_called_once()
+    mock_fetch_all.assert_called_once_with(
+        targets=[targets[1]], save_callback="cb", threshold=5
+    )
+    assert result == mock_fetch_all.return_value

--- a/tests/application/test_statement_fetch_service.py
+++ b/tests/application/test_statement_fetch_service.py
@@ -45,6 +45,7 @@ def test_run_calls_usecase(monkeypatch):
         logger=service.logger,
         source=source,
         repository=rows_repo,
+        statement_repository=stmt_repo,
         config=dummy_config,
         max_workers=3,
     )


### PR DESCRIPTION
## Summary
- inject `StatementRepositoryPort` into `FetchStatementsUseCase`
- skip NSDs that already have statements saved before fetching
- pass repository to the use case from `StatementFetchService`
- adjust existing test and add new test for the use case

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b12de15b4832e87b3ad6313a54061