### PR TITLE
Avoid redundant statement downloads

### DIFF
--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -122,7 +122,6 @@ class StatementFetchService:
             self.logger.log("No statements to fetch", level="info")
             return []
 
-
         self.logger.log(
             "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run(save_callback, threshold)",
             level="info",

--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -141,12 +141,17 @@ class FetchStatementsUseCase:
         if not targets:
             return []
 
+        existing = self.repository.get_all_primary_keys()
+        to_fetch = [t for t in targets if str(t.nsd) not in existing]
+        if not to_fetch:
+            return []
+
         self.logger.log(
             "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all(save_callback, threshold)",
             level="info",
         )
         results = self.fetch_all(
-            targets=targets,
+            targets=to_fetch,
             save_callback=save_callback,
             threshold=threshold,
         )

--- a/infrastructure/repositories/statement_rows_repository.py
+++ b/infrastructure/repositories/statement_rows_repository.py
@@ -53,7 +53,7 @@ class SqlAlchemyStatementRowsRepository(
         session = self.Session()
         try:
             return (
-                session.query(StatementRowsModel).filter_by(id=int(identifier)).first()
+                session.query(StatementRowsModel).filter_by(nsd=int(identifier)).first()
                 is not None
             )
         finally:
@@ -62,7 +62,7 @@ class SqlAlchemyStatementRowsRepository(
     def get_by_id(self, id: str) -> StatementRowsDTO:
         session = self.Session()
         try:
-            obj = session.query(StatementRowsModel).filter_by(id=int(id)).first()
+            obj = session.query(StatementRowsModel).filter_by(nsd=int(id)).first()
             if not obj:
                 raise ValueError(f"Raw statement not found: {id}")
             return obj.to_dto()
@@ -72,7 +72,7 @@ class SqlAlchemyStatementRowsRepository(
     def get_all_primary_keys(self) -> set[str]:
         session = self.Session()
         try:
-            ids = session.query(StatementRowsModel.id).distinct().all()
+            ids = session.query(StatementRowsModel.nsd).distinct().all()
             return {str(row[0]) for row in ids if row[0] is not None}
         finally:
             session.close()

--- a/tests/application/test_fetch_statements_use_case.py
+++ b/tests/application/test_fetch_statements_use_case.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+from application.usecases.fetch_statements import FetchStatementsUseCase
+from domain.dto.nsd_dto import NsdDTO
+from domain.ports import (
+    StatementRowsRepositoryPort,
+    StatementSourcePort,
+)
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def _make_nsd(nsd: int) -> NsdDTO:
+    return NsdDTO(
+        nsd=nsd,
+        company_name=None,
+        quarter=None,
+        version=None,
+        nsd_type=None,
+        dri=None,
+        auditor=None,
+        responsible_auditor=None,
+        protocol=None,
+        sent_date=None,
+        reason=None,
+    )
+
+
+def test_run_skips_existing(monkeypatch):
+    source = MagicMock(spec=StatementSourcePort)
+    rows_repo = MagicMock(spec=StatementRowsRepositoryPort)
+    rows_repo.get_all_primary_keys.return_value = {"1"}
+
+    usecase = FetchStatementsUseCase(
+        logger=DummyLogger(),
+        source=source,
+        repository=rows_repo,
+        config=DummyConfig(),
+        max_workers=2,
+    )
+
+    mock_fetch_all = MagicMock(return_value=[("result", [])])
+    monkeypatch.setattr(usecase, "fetch_all", mock_fetch_all)
+
+    targets = [_make_nsd(1), _make_nsd(2)]
+    result = usecase.run(targets, save_callback="cb", threshold=5)
+
+    rows_repo.get_all_primary_keys.assert_called_once()
+    mock_fetch_all.assert_called_once_with(
+        targets=[targets[1]], save_callback="cb", threshold=5
+    )
+    assert result == mock_fetch_all.return_value


### PR DESCRIPTION
## Summary
- fetch statements only for NSDs not already in raw statement rows
- remove unused statement repo dependency from FetchStatementsUseCase
- update statement rows repository queries
- adjust tests for new behavior

## Testing
- `ruff format application/services/statement_fetch_service.py application/usecases/fetch_statements.py infrastructure/repositories/statement_rows_repository.py tests/application/test_fetch_statements_use_case.py tests/application/test_statement_fetch_service.py`
- `ruff check application/services/statement_fetch_service.py application/usecases/fetch_statements.py infrastructure/repositories/statement_rows_repository.py tests/application/test_fetch_statements_use_case.py tests/application/test_statement_fetch_service.py --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive application/services/statement_fetch_service.py application/usecases/fetch_statements.py infrastructure/repositories/statement_rows_repository.py tests/application/test_fetch_statements_use_case.py tests/application/test_statement_fetch_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b12de15b4832e87b3ad6313a54061