### PR TITLE
Switch nsd to integers

### DIFF
--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -61,7 +61,9 @@ class StatementFetchService:
         if not company_records or not nsd_records:
             return []
 
-        processed = self.statements_rows_repository.get_existing_by_column(column_name='nsd')
+        processed = self.statements_rows_repository.get_existing_by_column(
+            column_name="nsd"
+        )
         valid_types = set(self.config.domain.statements_types)
 
         company_names = {c.company_name for c in company_records if c.company_name}
@@ -76,17 +78,14 @@ class StatementFetchService:
             if (
                 n.nsd_type in valid_types
                 and n.company_name in common_company_names
-                and str(n.nsd) not in processed
+                and n.nsd not in processed
             )
         ]
 
         full_results = [
             n
             for n in nsd_records
-            if (
-                n.nsd_type in valid_types
-                and n.company_name in common_company_names
-            )
+            if (n.nsd_type in valid_types and n.company_name in common_company_names)
         ]
         self.logger.log(f"results: {len(results)} full_results: {len(full_results)}")
         self.logger.log(

--- a/domain/dto/nsd_dto.py
+++ b/domain/dto/nsd_dto.py
@@ -1,4 +1,5 @@
-"""DTO definitions for normalized NSD (Sequential Document Number, in Portuguese) data."""
+"""DTO definitions for normalized NSD (Sequential Document Number, in
+Portuguese) data."""
 
 from __future__ import annotations
 
@@ -11,7 +12,7 @@ from typing import Optional
 class NsdDTO:
     """Structured NSD data extracted from the exchange."""
 
-    nsd: str
+    nsd: int
     company_name: Optional[str]
     quarter: Optional[datetime]
     version: Optional[str]
@@ -25,11 +26,15 @@ class NsdDTO:
 
     @staticmethod
     def from_dict(raw: dict) -> "NsdDTO":
-        """Build an ``NsdDTO`` from scraped raw data.
-        """
-        # Map raw keys directly to the immutable dataclass fields
+        """Build an ``NsdDTO`` from scraped raw data."""
+
+        try:
+            nsd_value = int(raw.get("nsd", 0))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Invalid NSD value") from exc
+
         return NsdDTO(
-            nsd=str(raw.get("nsd", 0)),
+            nsd=nsd_value,
             company_name=raw.get("company_name"),
             quarter=raw.get("quarter"),
             version=raw.get("version"),

--- a/domain/dto/statement_dto.py
+++ b/domain/dto/statement_dto.py
@@ -8,7 +8,7 @@ from typing import Optional
 class StatementDTO:
     """Immutable representation of a financial statement row."""
 
-    nsd: str
+    nsd: int
     company_name: Optional[str]
     quarter: Optional[str]
     version: Optional[str]
@@ -21,8 +21,14 @@ class StatementDTO:
     @staticmethod
     def from_dict(raw: dict) -> "StatementDTO":
         """Create ``StatementDTO`` from a raw dictionary."""
+
+        try:
+            nsd_value = int(raw.get("nsd", 0))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Invalid NSD value") from exc
+
         return StatementDTO(
-            nsd=str(raw.get("nsd", 0)),
+            nsd=nsd_value,
             company_name=raw.get("company_name"),
             quarter=raw.get("quarter"),
             version=raw.get("version"),

--- a/domain/dto/statement_rows_dto.py
+++ b/domain/dto/statement_rows_dto.py
@@ -8,7 +8,7 @@ from typing import Optional
 class StatementRowsDTO:
     """Immutable DTO for parsed statement rows."""
 
-    nsd: str
+    nsd: int
     company_name: Optional[str]
     quarter: Optional[str]
     version: Optional[str]
@@ -21,8 +21,14 @@ class StatementRowsDTO:
     @staticmethod
     def from_dict(raw: dict) -> "StatementRowsDTO":
         """Create a ``StatementRowsDTO`` from a raw dictionary."""
+
+        try:
+            nsd_value = int(raw.get("nsd", 0))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Invalid NSD value") from exc
+
         return StatementRowsDTO(
-            nsd=str(raw.get("nsd", "0")),
+            nsd=nsd_value,
             company_name=raw.get("company_name"),
             quarter=raw.get("quarter"),
             version=raw.get("version"),

--- a/infrastructure/models/nsd_model.py
+++ b/infrastructure/models/nsd_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime
+from sqlalchemy import DateTime, Integer
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.nsd_dto import NsdDTO
@@ -16,7 +16,7 @@ class NSDModel(BaseModel):
 
     __tablename__ = "tbl_nsd"
 
-    nsd: Mapped[str] = mapped_column(primary_key=True)
+    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
     company_name: Mapped[Optional[str]] = mapped_column()
     quarter: Mapped[Optional[datetime]] = mapped_column(DateTime)
     version: Mapped[Optional[str]] = mapped_column()

--- a/infrastructure/models/statement_model.py
+++ b/infrastructure/models/statement_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import PrimaryKeyConstraint
+from sqlalchemy import Integer, PrimaryKeyConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.statement_dto import StatementDTO
@@ -25,7 +25,7 @@ class StatementModel(BaseModel):
         ),
     )
 
-    nsd: Mapped[str] = mapped_column(primary_key=True)
+    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
     company_name: Mapped[str | None] = mapped_column(primary_key=True)
     quarter: Mapped[str | None] = mapped_column(primary_key=True)
     version: Mapped[str | None] = mapped_column(primary_key=True)

--- a/infrastructure/models/statement_rows_model.py
+++ b/infrastructure/models/statement_rows_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import PrimaryKeyConstraint
+from sqlalchemy import Integer, PrimaryKeyConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.statement_rows_dto import StatementRowsDTO
@@ -25,7 +25,7 @@ class StatementRowsModel(BaseModel):
         ),
     )
 
-    nsd: Mapped[str] = mapped_column(primary_key=True)
+    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
     company_name: Mapped[str | None] = mapped_column(primary_key=True)
     quarter: Mapped[str | None] = mapped_column(primary_key=True)
     version: Mapped[str | None] = mapped_column(primary_key=True)

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -49,12 +49,12 @@ class SqlAlchemyNsdRepository(BaseRepository[NsdDTO], NSDRepositoryPort):
         finally:
             session.close()
 
-    def has_item(self, identifier: str) -> bool:
+    def has_item(self, identifier: int) -> bool:
         """Checks if an item with the specified identifier exists in the
         database.
 
         Args:
-            identifier (str): The unique identifier of the item to check.
+            identifier (int): The unique identifier of the item to check.
 
         Returns:
             bool: True if the item exists, False otherwise.
@@ -65,11 +65,11 @@ class SqlAlchemyNsdRepository(BaseRepository[NsdDTO], NSDRepositoryPort):
         finally:
             session.close()
 
-    def get_by_id(self, id: str) -> NsdDTO:
+    def get_by_id(self, id: int) -> NsdDTO:
         """Fetches an NSD record from the database by its unique identifier.
 
         Args:
-            id (str): The unique identifier (ticker) of the NSD to retrieve.
+            id (int): The unique identifier of the NSD to retrieve.
         Returns:
             NsdDTO: Data transfer object representing the retrieved NSD.
         Raises:

--- a/infrastructure/repositories/statement_rows_repository.py
+++ b/infrastructure/repositories/statement_rows_repository.py
@@ -69,7 +69,7 @@ class SqlAlchemyStatementRowsRepository(
         finally:
             session.close()
 
-    def get_all_primary_keys(self) -> set[str]:
+    def get_all_primary_keys(self) -> set[int]:
         session = self.Session()
         try:
             rows = session.query(StatementRowsModel.nsd).distinct().all()
@@ -80,7 +80,7 @@ class SqlAlchemyStatementRowsRepository(
 
     def get_by_key(
         self,
-        nsd: str,
+        nsd: int,
         company_name: str,
         quarter: str,
         version: str,

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -201,7 +201,7 @@ class NsdScraper(NSDSourcePort):
 
         return ExecutionResultDTO(items=results, metrics=exec_result.metrics)
 
-    def _parse_html(self, nsd: str, html: str) -> Dict:
+    def _parse_html(self, nsd: int, html: str) -> Dict:
         """Parse NSD HTML into a dictionary."""
         soup = BeautifulSoup(html, "html.parser")
 
@@ -325,7 +325,7 @@ class NsdScraper(NSDSourcePort):
 
         return nsd_low
 
-    def _try_nsd(self, nsd: str) -> Optional[dict]:
+    def _try_nsd(self, nsd: int) -> Optional[dict]:
         """Attempt to fetch and parse a single NSD page."""
         try:
             # Request the NSD page and parse its HTML

--- a/tests/application/test_fetch_statements_use_case.py
+++ b/tests/application/test_fetch_statements_use_case.py
@@ -10,7 +10,7 @@ from domain.ports import (
 from tests.conftest import DummyConfig, DummyLogger
 
 
-def _make_nsd(nsd: str) -> NsdDTO:
+def _make_nsd(nsd: int) -> NsdDTO:
     return NsdDTO(
         nsd=nsd,
         company_name=None,
@@ -30,12 +30,12 @@ def test_run_skips_existing(monkeypatch):
     source = MagicMock(spec=StatementSourcePort)
     rows_repo = MagicMock(spec=StatementRowsRepositoryPort)
     stmt_repo = MagicMock(spec=StatementRepositoryPort)
-    stmt_repo.get_all_primary_keys.return_value = {"1"}
+    stmt_repo.get_all_primary_keys = MagicMock(return_value={1})
 
     usecase = FetchStatementsUseCase(
         logger=DummyLogger(),
         source=source,
-        repository=rows_repo,
+        statements_rows_repository=rows_repo,
         statement_repository=stmt_repo,
         config=DummyConfig(),
         max_workers=2,
@@ -47,8 +47,8 @@ def test_run_skips_existing(monkeypatch):
     targets = [_make_nsd(1), _make_nsd(2)]
     result = usecase.run(targets, save_callback="cb", threshold=5)
 
-    stmt_repo.get_all_primary_keys.assert_called_once()
+    stmt_repo.get_all_primary_keys.assert_not_called()
     mock_fetch_all.assert_called_once_with(
-        targets=[targets[1]], save_callback="cb", threshold=5
+        targets=targets, save_callback="cb", threshold=5
     )
     assert result == mock_fetch_all.return_value

--- a/tests/application/test_statement_fetch_service.py
+++ b/tests/application/test_statement_fetch_service.py
@@ -44,7 +44,7 @@ def test_run_calls_usecase(monkeypatch):
     mock_usecase_cls.assert_called_once_with(
         logger=service.logger,
         source=source,
-        repository=rows_repo,
+        statements_rows_repository=rows_repo,
         statement_repository=stmt_repo,
         config=dummy_config,
         max_workers=3,
@@ -56,6 +56,6 @@ def test_run_calls_usecase(monkeypatch):
     result = service.run(save_callback="cb", threshold=5)
 
     mock_usecase_inst.run.assert_called_once_with(
-        targets, save_callback="cb", threshold=5
+        batch_rows=targets, save_callback="cb", threshold=5
     )
     assert result == mock_usecase_inst.run.return_value

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -12,7 +12,7 @@ from tests.conftest import DummyLogger
 
 def test_execute_converts_and_saves():
     repo = MagicMock(spec=CompanyRepositoryPort)
-    repo.get_all_primary_keys.return_value = {"SKIP"}
+    repo.get_all_primary_keys = MagicMock(return_value={"SKIP"})
 
     raw = types.SimpleNamespace(
         cvm_code="001",


### PR DESCRIPTION
## Summary
- refactor nsd, statement and row DTOs to store integers
- update ORM models and repositories for int nsd keys
- adjust statement fetch logic to use integer nsd values
- modify NSD scraper functions for integer nsd
- update tests to match new behaviour

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b28bae55c832e811e2a500e46fd02