### PR TITLE
Add typing annotations

### DIFF
--- a/application/mappers/company_mapper.py
+++ b/application/mappers/company_mapper.py
@@ -11,7 +11,7 @@ from domain.ports import DataCleanerPort
 class CompanyMapper:
     """Merge base and detail company data into a parsed DTO."""
 
-    def __init__(self, data_cleaner: DataCleanerPort):
+    def __init__(self, data_cleaner: DataCleanerPort) -> None:
         """Create a new mapper using the provided data cleaner utility."""
         self.data_cleaner = data_cleaner
 

--- a/application/services/company_service.py
+++ b/application/services/company_service.py
@@ -1,4 +1,5 @@
 from application.usecases.sync_companies import SyncCompaniesUseCase
+from domain.dto import SyncCompaniesResultDTO
 from domain.ports import CompanyRepositoryPort, CompanySourcePort, LoggerPort
 from infrastructure.config import Config
 
@@ -27,7 +28,7 @@ class CompanyService:
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
-    def run(self):
+    def run(self) -> SyncCompaniesResultDTO:
         """Execute company synchronization using the injected use case."""
         # Delegate execution to the underlying use case and return the result.
         # self.logger.log("Call Method sync_companies_usecase.run()", level="info")

--- a/infrastructure/config/config.py
+++ b/infrastructure/config/config.py
@@ -17,7 +17,7 @@ class Config:
     respective domain.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Run all configuration sections."""
         # Run all configurations
         self.paths: PathConfig = load_paths()

--- a/infrastructure/config/database.py
+++ b/infrastructure/config/database.py
@@ -5,7 +5,7 @@ from typing import Mapping
 
 from .paths import load_paths
 
-DB_FILENAME="fly.db"
+DB_FILENAME = "fly.db"
 TABLES = {
     # logic key : SQLite physical name
     "company": "tbl_company",
@@ -30,13 +30,10 @@ class DatabaseConfig:
     tables: Mapping[str, str] = field(default_factory=lambda: TABLES)
     connection_string: str = field(init=False)
 
-    def __post_init__(self):
-
+    def __post_init__(self) -> None:
         # Dynamically compute the connection URI
         object.__setattr__(
-            self,
-            "connection_string",
-            f"sqlite:///{self.data_dir / self.db_filename}"
+            self, "connection_string", f"sqlite:///{self.data_dir / self.db_filename}"
         )
 
 
@@ -46,7 +43,7 @@ def load_database_config() -> DatabaseConfig:
     paths = load_paths()
 
     return DatabaseConfig(
-        data_dir = paths.data_dir,
-        db_filename = DB_FILENAME,
-        tables = TABLES,
+        data_dir=paths.data_dir,
+        db_filename=DB_FILENAME,
+        tables=TABLES,
     )

--- a/infrastructure/config/paths.py
+++ b/infrastructure/config/paths.py
@@ -6,6 +6,7 @@ TEMP_DIR = "temp"
 LOG_DIR = "logs"
 DATA_DIR = "data"
 
+
 @dataclass(frozen=True)
 class PathConfig:
     """Configuration for important filesystem paths.
@@ -16,12 +17,13 @@ class PathConfig:
         log_dir: Subfolder for log files.
         data_dir: Subfolder for databases.
     """
+
     temp_dir: Path = field(init=False)
     log_dir: Path = field(init=False)
     data_dir: Path = field(init=False)
     root_dir: Path = field(init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # Set root_dir to the project directory
         root = Path(__file__).resolve().parent.parent.parent
         object.__setattr__(self, "root_dir", root)

--- a/infrastructure/helpers/data_cleaner.py
+++ b/infrastructure/helpers/data_cleaner.py
@@ -26,7 +26,7 @@ class DataCleaner(DataCleanerPort):
     Requires external configuration (e.g. words to remove) and a logger.
     """
 
-    def __init__(self, config: Config, logger: LoggerPort):
+    def __init__(self, config: Config, logger: LoggerPort) -> None:
         """Store configuration and logger."""
         self.config = config
         self.logger = logger

--- a/infrastructure/helpers/fetch_utils.py
+++ b/infrastructure/helpers/fetch_utils.py
@@ -16,7 +16,7 @@ from infrastructure.helpers.time_utils import TimeUtils
 class FetchUtils:
     """Utility class for HTTP operations with retry and randomized headers."""
 
-    def __init__(self, config: Config, logger: LoggerPort):
+    def __init__(self, config: Config, logger: LoggerPort) -> None:
         self.config = config
         self.logger = logger
 
@@ -30,7 +30,7 @@ class FetchUtils:
                 "Referer": random.choice(self.config.scraping.referers),
                 "Accept-Language": random.choice(self.config.scraping.languages),
             }
-        except Exception as e:
+        except Exception:
             # self.logger.log(f"Header generation failed: {e}", level="warning")
             return {
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -60,7 +60,7 @@ class FetchUtils:
             context.verify_mode = ssl.CERT_NONE
 
             class InsecureAdapter(requests.adapters.HTTPAdapter):
-                def init_poolmanager(self, *args, **kwargs):
+                def init_poolmanager(self, *args, **kwargs) -> None:
                     kwargs["ssl_context"] = context
                     self.poolmanager = (
                         requests.packages.urllib3.poolmanager.PoolManager(

--- a/infrastructure/helpers/metrics_collector.py
+++ b/infrastructure/helpers/metrics_collector.py
@@ -33,7 +33,7 @@ class MetricsCollector(MetricsCollectorPort):
 
         return self._processing_bytes
 
-    def get_metrics(self, elapsed_time: float):
+    def get_metrics(self, elapsed_time: float) -> MetricsDTO:
         """Create a :class:`MetricsDTO` instance from the collected values."""
 
         return MetricsDTO(

--- a/infrastructure/helpers/thread_utils.py
+++ b/infrastructure/helpers/thread_utils.py
@@ -9,7 +9,7 @@ class WorkerThreadIdentifier:
     Example identifiers: ``"W1"``, ``"W2"``, up to the ``max_workers`` limit from ``Config``.
     """
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config) -> None:
         """Initialize the generator using the configured ``max_workers`` value.
 
         Args:

--- a/infrastructure/helpers/time_utils.py
+++ b/infrastructure/helpers/time_utils.py
@@ -9,10 +9,13 @@ from infrastructure.config import Config
 
 class TimeUtils:
     """Helper for dynamic sleep intervals based on CPU usage."""
-    def __init__(self, config: Config):
+
+    def __init__(self, config: Config) -> None:
         self.config = config
 
-    def sleep_dynamic(self, wait: Optional[float] = None, cpu_interval: Optional[float] = None) -> None:
+    def sleep_dynamic(
+        self, wait: Optional[float] = None, cpu_interval: Optional[float] = None
+    ) -> None:
         """Sleep for a dynamically adjusted time based on CPU utilization.
 
         The logic adjusts the delay as follows:

--- a/infrastructure/logging/context_tracker.py
+++ b/infrastructure/logging/context_tracker.py
@@ -5,12 +5,12 @@ from pathlib import Path
 class ContextTracker:
     """Extracts the call origin within the project for debugging logs."""
 
-    def __init__(self, project_root: Path):
-
+    def __init__(self, project_root: Path) -> None:
         self.project_root = project_root
 
     def get_context(self) -> str:
-        """Return a string like ``"line X of func() in 'path/file.py' <- ..."``."""
+        """Return a string like ``"line X of func() in 'path/file.py' <-
+        ..."``."""
         try:
             stack = inspect.stack()
             relevant = []
@@ -19,7 +19,9 @@ class ContextTracker:
                 path = Path(frame.filename).resolve()
                 if self.project_root in path.parents:
                     rel_path = path.relative_to(self.project_root)
-                    relevant.append(f"line {frame.lineno} of {frame.function}() in '{rel_path}'")
+                    relevant.append(
+                        f"line {frame.lineno} of {frame.function}() in '{rel_path}'"
+                    )
 
             return " <- ".join(relevant[3:-1])
         except Exception:

--- a/infrastructure/logging/logger.py
+++ b/infrastructure/logging/logger.py
@@ -13,7 +13,7 @@ class Logger(LoggerPort):
 
     def __init__(
         self, config: Config, level: str = "DEBUG", logger_name: Optional[str] = None
-    ):
+    ) -> None:
         self._run_id = uuid.uuid4().hex[:8]
         self.worker_id = uuid.uuid4().hex[:8]
 
@@ -24,7 +24,8 @@ class Logger(LoggerPort):
         self._logger = self._setup_logger(level)
 
     def _setup_logger(self, level: str) -> logging.LoggerAdapter:
-        """Configure the underlying ``logging`` logger with console and file handlers."""
+        """Configure the underlying ``logging`` logger with console and file
+        handlers."""
         log_path = self.config.logging.full_path
         logger = logging.getLogger(self.logger_name)
         logger.setLevel(logging.DEBUG)
@@ -56,7 +57,7 @@ class Logger(LoggerPort):
         progress: Optional[dict] = None,
         extra: Optional[dict] = None,
         worker_id: Optional[str] = None,
-    ):
+    ) -> None:
         """Log a message with optional progress and context information."""
         context_msg = (
             self.context_tracker.get_context() if level.lower() == "debug" else ""
@@ -89,7 +90,7 @@ class Logger(LoggerPort):
 class SafeFormatter(logging.Formatter):
     """Formatter that injects default values for missing log attributes."""
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         # Define valores padrão
         defaults = {
             "run_id": "0",
@@ -104,9 +105,10 @@ class SafeFormatter(logging.Formatter):
 
 
 class MergedLoggerAdapter(logging.LoggerAdapter):
-    """Logger adapter that merges ``extra`` dictionaries from calls and defaults."""
+    """Logger adapter that merges ``extra`` dictionaries from calls and
+    defaults."""
 
-    def process(self, msg, kwargs):
+    def process(self, msg: str, kwargs: dict) -> tuple[str, dict]:
         base = self.extra if isinstance(self.extra, dict) else {}
         extra = kwargs.get("extra") or {}
         if not isinstance(extra, dict):

--- a/infrastructure/repositories/base_repository.py
+++ b/infrastructure/repositories/base_repository.py
@@ -18,7 +18,7 @@ class BaseRepository(BaseRepositoryPort[T], ABC):
     Pode ser especializada para qualquer tipo de DTO.
     """
 
-    def __init__(self, config: Config, logger: LoggerPort):
+    def __init__(self, config: Config, logger: LoggerPort) -> None:
         """Initialize the SQLite database connection and ensure tables
         exist."""
         self.config = config

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -21,7 +21,7 @@ class SqlAlchemyCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryP
         issues.
     """
 
-    def __init__(self, config: Config, logger: LoggerPort):
+    def __init__(self, config: Config, logger: LoggerPort) -> None:
         super().__init__(config, logger)
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -14,7 +14,7 @@ from infrastructure.repositories import BaseRepository
 class SqlAlchemyNsdRepository(BaseRepository[NsdDTO], NSDRepositoryPort):
     """Concrete repository for NsdDTO using SQLite via SQLAlchemy."""
 
-    def __init__(self, config: Config, logger: LoggerPort):
+    def __init__(self, config: Config, logger: LoggerPort) -> None:
         super().__init__(config, logger)
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")

--- a/infrastructure/repositories/statement_repository.py
+++ b/infrastructure/repositories/statement_repository.py
@@ -14,7 +14,7 @@ class SqlAlchemyStatementRepository(
 ):
     """SQLite-backed repository for ``StatementDTO`` objects."""
 
-    def __init__(self, config: Config, logger: LoggerPort):
+    def __init__(self, config: Config, logger: LoggerPort) -> None:
         super().__init__(config, logger)
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
@@ -60,4 +60,3 @@ class SqlAlchemyStatementRepository(
             return obj.to_dto()
         finally:
             session.close()
-

--- a/infrastructure/scrapers/statements_source_adapter.py
+++ b/infrastructure/scrapers/statements_source_adapter.py
@@ -21,7 +21,9 @@ from infrastructure.helpers.time_utils import TimeUtils
 class RequestsStatementSourceAdapter(StatementSourcePort):
     """Fetch statement HTML using ``requests``."""
 
-    def __init__(self, config: Config, logger: LoggerPort, data_cleaner: DataCleaner):
+    def __init__(
+        self, config: Config, logger: LoggerPort, data_cleaner: DataCleaner
+    ) -> None:
         """Create the adapter with its configuration and logger."""
         self.config = config
         self.logger = logger
@@ -186,7 +188,9 @@ class RequestsStatementSourceAdapter(StatementSourcePort):
         for i, item in enumerate(nsd_items):
             quarter = row.quarter.strftime("%Y-%m-%d") if row.quarter else None
             for attempt in range(self.config.scraping.max_attempts):
-                response, self.session = self.fetch_utils.fetch_with_retry(self.session, item["url"])
+                response, self.session = self.fetch_utils.fetch_with_retry(
+                    self.session, item["url"]
+                )
                 soup = BeautifulSoup(response.text, "html.parser")
 
                 if (
@@ -195,7 +199,9 @@ class RequestsStatementSourceAdapter(StatementSourcePort):
                     in soup.get_text()
                 ):
                     # Tenta regenerar hash, embora neste caso hash_value_retry não seja usado
-                    response, self.session = self.fetch_utils.fetch_with_retry(scraper=None, url=url)
+                    response, self.session = self.fetch_utils.fetch_with_retry(
+                        scraper=None, url=url
+                    )
                     # hash_value_retry = self._extract_hash(hash_response.text)
 
                     # self.logger.log(


### PR DESCRIPTION
## Summary
- annotate CompanyService run method
- annotate CompanyMapper constructor
- enforce type hints for logging and helper utilities
- adjust repository and config constructors for typing

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google application infrastructure`
- `docformatter --in-place application/services/company_service.py application/mappers/company_mapper.py infrastructure/helpers/metrics_collector.py infrastructure/helpers/fetch_utils.py infrastructure/helpers/data_cleaner.py infrastructure/helpers/thread_utils.py infrastructure/helpers/time_utils.py infrastructure/repositories/base_repository.py infrastructure/repositories/company_repository.py infrastructure/repositories/nsd_repository.py infrastructure/repositories/statement_repository.py infrastructure/logging/context_tracker.py infrastructure/logging/logger.py infrastructure/config/config.py infrastructure/config/database.py infrastructure/config/paths.py infrastructure/scrapers/statements_source_adapter.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b34f6e9c4832e9c927b0736d7ad8a