### PR TITLE
Integrate MetricsCollector into statement fetching

### DIFF
--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -82,7 +82,7 @@ class StatementFetchService:
             )
         ]
 
-        full_results = [
+        _full_results = [
             n
             for n in nsd_records
             if (n.nsd_type in valid_types and n.company_name in common_company_names)

--- a/infrastructure/config/statements.py
+++ b/infrastructure/config/statements.py
@@ -154,8 +154,12 @@ class StatementsConfig:
 
 def load_statements_config() -> StatementsConfig:
     """Run the statements scraping configuration."""
+    statement_items = [item.copy() for item in STATEMENT_ITEMS]
+    statement_items.sort(
+        key=lambda item: 0 if item.get("grupo") == "Dados da Empresa" else 1
+    )
     return StatementsConfig(
-        statement_items=[item.copy() for item in STATEMENT_ITEMS],
+        statement_items=statement_items,
         nsd_type_map=NSD_TYPE_MAP.copy(),
         capital_items=[item.copy() for item in CAPITAL_ITEMS],
         url_df=URL_DF,

--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -49,7 +49,11 @@ class SaveStrategy(Generic[T]):
 
         self.buffer.append(item)
 
-        should_flush = len(self.buffer) >= self.threshold
+        flush_by_remaining = False
+        if remaining is not None:
+            flush_by_remaining = remaining % self.threshold == 0
+
+        should_flush = len(self.buffer) >= self.threshold or flush_by_remaining
         # if remaining is not None:
         #     should_flush = should_flush or remaining % self.threshold == 0
 

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -223,9 +223,14 @@ class CLIController:
         )
         # self.logger.log("End Instance raw_rows_repo", level="info")
 
+        # self.logger.log("Instantiate collector", level="info")
+        collector = MetricsCollector()
         # self.logger.log("Instantiate source", level="info")
         source = RequestsStatementSourceAdapter(
-            config=self.config, logger=self.logger, data_cleaner=self.data_cleaner
+            config=self.config,
+            logger=self.logger,
+            data_cleaner=self.data_cleaner,
+            metrics_collector=collector,
         )
         # self.logger.log("End Instance source", level="info")
 


### PR DESCRIPTION
## Summary
- enable MetricsCollector on statement source adapter and CLI
- track network usage when fetching statements
- allow SaveStrategy flush based on remaining items
- ensure statement config loads with company section first

## Testing
- `ruff format application/services/statement_fetch_service.py infrastructure/helpers/save_strategy.py infrastructure/scrapers/statements_source_adapter.py presentation/cli.py infrastructure/config/statements.py`
- `ruff check application/services/statement_fetch_service.py infrastructure/helpers/save_strategy.py infrastructure/scrapers/statements_source_adapter.py presentation/cli.py infrastructure/config/statements.py --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place application/services/statement_fetch_service.py infrastructure/helpers/save_strategy.py infrastructure/scrapers/statements_source_adapter.py presentation/cli.py infrastructure/config/statements.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e307917c8832ea0aa5170546234c2