### PR TITLE
Propagate metrics collector in statement fetch use case

### DIFF
--- a/infrastructure/helpers/__init__.py
+++ b/infrastructure/helpers/__init__.py
@@ -1,3 +1,4 @@
+from .byte_formatter import ByteFormatter
 from .data_cleaner import DataCleaner
 from .fetch_utils import FetchUtils
 from .metrics_collector import MetricsCollector
@@ -12,4 +13,5 @@ __all__ = [
     "WorkerPool",
     "MetricsCollector",
     "SaveStrategy",
+    "ByteFormatter",
 ]


### PR DESCRIPTION
## Summary
- reuse the source's metrics collector when fetching statements
- display per-statement download size in fetch logs
- export `ByteFormatter` helper

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e633d1abc832e9795b834ad12a385