### PR TITLE
Fix SaveStrategy to accept iterables

### DIFF
--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -155,15 +155,11 @@ class FetchStatementsUseCase:
             return fetched["nsd"], fetched["statements"]
 
         def handle_batch(item: Tuple[NsdDTO, List[StatementRowsDTO]]) -> None:
-            # self.logger.log(
-            #     "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all().strategy.handle()",
-            #     level="info",
-            # )
+            """Buffer fetched statement rows via ``strategy``."""
+
+            # ``SaveStrategy.handle`` can accept an iterable of rows, so pass
+            # the entire list at once for more efficient buffering.
             strategy.handle(item[1])
-            # self.logger.log(
-            #     "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all().strategy.handle()",
-            #     level="info",
-            # )
 
         # self.logger.log(
         #     "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run().fetch_all().worker_pool.run(tasks, processor, handle_batch)",

--- a/tests/infrastructure/test_save_strategy.py
+++ b/tests/infrastructure/test_save_strategy.py
@@ -49,3 +49,19 @@ def test_threshold_loaded_from_config():
 
     assert collected == [[1], [2]]
     assert strategy.buffer == []
+
+
+def test_handle_accepts_iterable():
+    """Items provided as an iterable should be buffered individually."""
+
+    collected = []
+
+    def cb(buffer):
+        collected.append(list(buffer))
+
+    strategy = SaveStrategy(cb, threshold=4)
+    strategy.handle([1, 2])
+    strategy.handle([3, 4])
+
+    assert collected == [[1, 2, 3, 4]]
+    assert strategy.buffer == []


### PR DESCRIPTION
## Summary
- pass full list of fetched statements to SaveStrategy
- extend SaveStrategy.handle to accept iterables
- test buffering when provided a list

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f8e85a24c832e91836d9705a70ec2