### PR TITLE
Refactor run methods

### DIFF
--- a/application/services/company_service.py
+++ b/application/services/company_service.py
@@ -28,10 +28,16 @@ class CompanyService:
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
-    def run(self) -> SyncCompaniesResultDTO:
+    def sync_companies(self) -> SyncCompaniesResultDTO:
         """Execute company synchronization using the injected use case."""
         # Delegate execution to the underlying use case and return the result.
-        # self.logger.log("Call Method sync_companies_usecase.run()", level="info")
-        result = self.sync_companies_usecase.run()
-        # self.logger.log("End  Method sync_companies_usecase.run()", level="info")
+        # self.logger.log(
+        #     "Call Method sync_companies_usecase.synchronize_companies()",
+        #     level="info",
+        # )
+        result = self.sync_companies_usecase.synchronize_companies()
+        # self.logger.log(
+        #     "End  Method sync_companies_usecase.synchronize_companies()",
+        #     level="info",
+        # )
         return result

--- a/application/services/nsd_service.py
+++ b/application/services/nsd_service.py
@@ -23,9 +23,9 @@ class NsdService:
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
-    def run(self) -> None:
+    def sync_nsd(self) -> None:
         """Start the NSD synchronization workflow."""
         # Delegate the work to the injected use case.
-        # self.logger.log("Call Method controller.run()._nsd_service().run().sync_nsd_usecase.run()", level="info")
-        self.sync_nsd_usecase.run()
-        # self.logger.log("End  Method controller.run()._nsd_service().run().sync_nsd_usecase.run()", level="info")
+        # self.logger.log("Call Method controller.start()._nsd_service().sync_nsd().sync_nsd_usecase.synchronize_nsd()", level="info")
+        self.sync_nsd_usecase.synchronize_nsd()
+        # self.logger.log("End  Method controller.start()._nsd_service().sync_nsd().sync_nsd_usecase.synchronize_nsd()", level="info")

--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -95,7 +95,7 @@ class StatementFetchService:
 
         return sorted(results, key=lambda n: (n.company_name, n.quarter, n.nsd))
 
-    def run(
+    def fetch_statements(
         self,
         save_callback: Optional[Callable[[List[StatementRowsDTO]], None]] = None,
         threshold: Optional[int] = None,
@@ -133,7 +133,7 @@ class StatementFetchService:
         #     "Call Method controller.run()._statement_service().statements_fetch_service.run().fetch_usecase.run(save_callback, threshold)",
         #     level="info",
         # )
-        rows = self.fetch_usecase.run(
+        rows = self.fetch_usecase.fetch_statement_rows(
             batch_rows=targets,
             save_callback=save_callback,
             threshold=threshold,

--- a/application/services/statement_parse_service.py
+++ b/application/services/statement_parse_service.py
@@ -48,12 +48,14 @@ class StatementParseService:
 
         def processor(task: WorkerTaskDTO) -> List[StatementDTO]:
             _nsd, rows = task.data
-            return [self.parse_usecase.run(r) for r in rows]
+            return [self.parse_usecase.parse_and_store_row(r) for r in rows]
 
         result = parse_pool.run(tasks=tasks, processor=processor, logger=self.logger)
         return result.items
 
-    def run(self, fetched: List[Tuple[NsdDTO, List[StatementRowsDTO]]]) -> None:
+    def parse_statements(
+        self, fetched: List[Tuple[NsdDTO, List[StatementRowsDTO]]]
+    ) -> None:
         """Parse and persist statements from ``fetched`` rows."""
         # self.logger.log("Run  Method statement_parse_service.run()", level="info")
 

--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -185,7 +185,7 @@ class FetchStatementsUseCase:
 
         return result.items
 
-    def run(
+    def fetch_statement_rows(
         self,
         batch_rows: Iterable[NsdDTO],
         save_callback: Optional[Callable[[List[StatementRowsDTO]], None]] = None,

--- a/application/usecases/parse_and_classify_statements.py
+++ b/application/usecases/parse_and_classify_statements.py
@@ -25,7 +25,7 @@ class ParseAndClassifyStatementsUseCase:
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
-    def run(self, row: StatementRowsDTO) -> StatementDTO:
+    def parse_and_store_row(self, row: StatementRowsDTO) -> StatementDTO:
         """Build a :class:`StatementDTO` from a statement row."""
         dto = StatementDTO(
             batch_id=str(row.nsd),

--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -26,7 +26,7 @@ class SyncCompaniesUseCase:
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
-    def run(self) -> SyncCompaniesResultDTO:
+    def synchronize_companies(self) -> SyncCompaniesResultDTO:
         """Start the full synchronization pipeline.
 
         Steps:

--- a/application/usecases/sync_nsd.py
+++ b/application/usecases/sync_nsd.py
@@ -20,7 +20,7 @@ class SyncNSDUseCase:
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
-    def     run(self) -> None:
+    def synchronize_nsd(self) -> None:
         """Start the NSD synchronization workflow."""
 
         # self.logger.log("Run  Method controller.run()._nsd_service().run().sync_nsd_usecase.run()", level="info")

--- a/infrastructure/config/statements.py
+++ b/infrastructure/config/statements.py
@@ -157,7 +157,7 @@ def load_statements_config() -> StatementsConfig:
     statement_items = [item.copy() for item in STATEMENT_ITEMS]
     statement_items.sort(
         key=lambda item: (
-            1 if item.get("grupo") == "Dados da Empresa" else 0,
+            0 if item.get("grupo") == "Dados da Empresa" else 1,
             item.get("informacao", 0),
             item.get("demonstracao", 0),
         )

--- a/infrastructure/helpers/fetch_utils.py
+++ b/infrastructure/helpers/fetch_utils.py
@@ -172,21 +172,23 @@ class FetchUtils:
                 if response.status_code == 200:
                     # On success, log the total block time if any
                     if block_start:
-                        block_duration = time.perf_counter() - block_start
+                        _block_duration = time.perf_counter() - block_start
                         # self.logger.log(
                         #     f"Dodging server block: {block_duration:.2f}s",
                         #     level="warning",
                         #     worker_id=worker_id,
                         # )
                     return response, scraper
-            except (requests.Timeout, requests.ConnectionError) as e:
+            except (requests.Timeout, requests.ConnectionError):
                 if not self.test_internet():
                     continue
 
             except Exception:  # noqa: BLE001
                 # Ignore network errors and retry with a new scraper
                 pass
-                self.logger.log(f"Attempt {attempt + 1} {url}", level="warning", worker_id=worker_id)
+                self.logger.log(
+                    f"Attempt {attempt + 1} {url}", level="warning", worker_id=worker_id
+                )
 
             # Record the start of blocking period on first failure
             if block_start is None:

--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Callable, Generic, List, Optional, TypeVar, Union
+from typing import Callable, Generic, List, Optional, TypeVar
 
 from infrastructure.config import Config
 
@@ -51,15 +51,17 @@ class SaveStrategy(Generic[T]):
         if remaining is None and self.config:
             remaining = self.config.global_settings.threshold
 
-        self.buffer.append(item) # type: ignore
+        if isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
+            self.buffer.extend(item)
+        else:
+            self.buffer.append(item)  # type: ignore
 
         should_flush = len(self.buffer) >= self.threshold
-        # if remaining is not None:
-        #     should_flush = should_flush or remaining % self.threshold == 0
+        if remaining is not None:
+            should_flush = should_flush or remaining % self.threshold == 0
 
         if remaining == 0 or should_flush:
             self.flush()
-
 
     def flush(self) -> None:
         """Invoke the callback with all buffered items and clear the buffer."""

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -42,7 +42,7 @@ class CLIController:
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
-    def run(self):
+    def start(self):
         """Execute the main CLI tasks sequentially."""
         # self.logger.log("Run  Method controller.run()", level="info")
 
@@ -123,11 +123,13 @@ class CLIController:
 
         # Trigger the actual company synchronization process.
         # self.logger.log(
-        #     "Call Method controller.run().company_service.run()", level="info"
+        #     "Call Method controller.start().company_service.sync_companies()",
+        #     level="info",
         # )
-        company_service.run()
+        company_service.sync_companies()
         # self.logger.log(
-        #     "Finish Method controller.run().company_service.run()", level="info"
+        #     "Finish Method controller.start().company_service.sync_companies()",
+        #     level="info",
         # )
 
         # self.logger.log(
@@ -182,11 +184,11 @@ class CLIController:
         )
 
         # self.logger.log(
-        #     "Call Method controller.run()._nsd_service().run()", level="info"
+        #     "Call Method controller.start()._nsd_service().sync_nsd()", level="info"
         # )
-        nsd_service.run()
+        nsd_service.sync_nsd()
         # self.logger.log(
-        #     "End  Method controller.run()._nsd_service().run()", level="info"
+        #     "End  Method controller.start()._nsd_service().sync_nsd()", level="info"
         # )
 
         # self.logger.log("End Instance nsd_service (nsd_repo, nsd_scraper", level="info")
@@ -225,7 +227,7 @@ class CLIController:
 
         # self.logger.log("Instantiate collector", level="info")
         collector = MetricsCollector()
-        collector._network_bytes = 4508770675 # setup initial value for reloading
+        collector._network_bytes = 4508770675  # setup initial value for reloading
 
         # self.logger.log("Instantiate source", level="info")
         source = RequestsStatementSourceAdapter(
@@ -255,7 +257,7 @@ class CLIController:
         #     "Call Method controller.run()._statement_service().statements_fetch_service.run()",
         #     level="info",
         # )
-        raw_rows = statements_fetch_service.run()
+        raw_rows = statements_fetch_service.fetch_statements()
         # self.logger.log(
         #     "End  Method controller.run()._statement_service().statements_fetch_service.run()",
         #     level="info",
@@ -276,12 +278,12 @@ class CLIController:
         )
 
         # self.logger.log(
-        #     "Call Method controller.run()._statement_service().parse_service.run()",
+        #     "Call Method controller.start()._statement_service().parse_service.parse_statements()",
         #     level="info",
         # )
-        parse_service.run(raw_rows)
+        parse_service.parse_statements(raw_rows)
         # self.logger.log(
-        #     "End  Method controller.run()._statement_service().parse_service.run(",
+        #     "End  Method controller.start()._statement_service().parse_service.parse_statements(",
         #     level="info",
         # )
 

--- a/run in background.py
+++ b/run in background.py
@@ -25,9 +25,9 @@ if __name__ == "__main__":
     controller = CLIController(config=config, logger=logger, data_cleaner=data_cleaner)
 
     # Run Controller
-    # logger.log("Call Method controller.run()", level="info")
-    controller.run()
-    # logger.log("End  Method controller.run()", level="info")
+    # logger.log("Call Method controller.start()", level="info")
+    controller.start()
+    # logger.log("End  Method controller.start()", level="info")
 
     # logger.log("End Instance controller", level="info")
 

--- a/run.py
+++ b/run.py
@@ -25,9 +25,9 @@ if __name__ == "__main__":
     controller = CLIController(config=config, logger=logger, data_cleaner=data_cleaner)
 
     # Run Controller
-    # logger.log("Call Method controller.run()", level="info")
-    controller.run()
-    # logger.log("End  Method controller.run()", level="info")
+    # logger.log("Call Method controller.start()", level="info")
+    controller.start()
+    # logger.log("End  Method controller.start()", level="info")
 
     # logger.log("End Instance controller", level="info")
 

--- a/tests/application/test_company_service.py
+++ b/tests/application/test_company_service.py
@@ -7,7 +7,7 @@ from domain.ports import CompanyRepositoryPort, CompanySourcePort
 from tests.conftest import DummyConfig, DummyLogger
 
 
-def test_run_calls_usecase_execute(monkeypatch):
+def test_sync_companies_calls_usecase(monkeypatch):
     dummy_config = DummyConfig()
     dummy_config.global_settings.max_workers = 3
 
@@ -37,7 +37,7 @@ def test_run_calls_usecase_execute(monkeypatch):
         max_workers=3,
     )
 
-    result = service.run()
+    result = service.sync_companies()
 
-    mock_usecase_inst.run.assert_called_once()
-    assert result == mock_usecase_inst.run.return_value
+    mock_usecase_inst.synchronize_companies.assert_called_once()
+    assert result == mock_usecase_inst.synchronize_companies.return_value

--- a/tests/application/test_fetch_statements_use_case.py
+++ b/tests/application/test_fetch_statements_use_case.py
@@ -26,7 +26,7 @@ def _make_nsd(nsd: int) -> NsdDTO:
     )
 
 
-def test_run_skips_existing(monkeypatch):
+def test_fetch_statement_rows_skips_existing(monkeypatch):
     source = MagicMock(spec=StatementSourcePort)
     rows_repo = MagicMock(spec=StatementRowsRepositoryPort)
     stmt_repo = MagicMock(spec=StatementRepositoryPort)
@@ -45,7 +45,7 @@ def test_run_skips_existing(monkeypatch):
     monkeypatch.setattr(usecase, "fetch_all", mock_fetch_all)
 
     targets = [_make_nsd(1), _make_nsd(2)]
-    result = usecase.run(targets, save_callback="cb", threshold=5)
+    result = usecase.fetch_statement_rows(targets, save_callback="cb", threshold=5)
 
     stmt_repo.get_all_primary_keys.assert_not_called()
     mock_fetch_all.assert_called_once_with(

--- a/tests/application/test_statement_fetch_service.py
+++ b/tests/application/test_statement_fetch_service.py
@@ -13,7 +13,7 @@ from domain.ports import (
 from tests.conftest import DummyConfig, DummyLogger
 
 
-def test_run_calls_usecase(monkeypatch):
+def test_fetch_statements_calls_usecase(monkeypatch):
     dummy_config = DummyConfig()
 
     mock_usecase_cls = MagicMock(spec=FetchStatementsUseCase)
@@ -53,9 +53,9 @@ def test_run_calls_usecase(monkeypatch):
     targets = [MagicMock(spec=NsdDTO)]
     monkeypatch.setattr(service, "_build_targets", lambda: targets)
 
-    result = service.run(save_callback="cb", threshold=5)
+    result = service.fetch_statements(save_callback="cb", threshold=5)
 
-    mock_usecase_inst.run.assert_called_once_with(
+    mock_usecase_inst.fetch_statement_rows.assert_called_once_with(
         batch_rows=targets, save_callback="cb", threshold=5
     )
-    assert result == mock_usecase_inst.run.return_value
+    assert result == mock_usecase_inst.fetch_statement_rows.return_value

--- a/tests/application/test_statement_parse_service.py
+++ b/tests/application/test_statement_parse_service.py
@@ -9,7 +9,7 @@ from domain.ports import StatementRepositoryPort
 from tests.conftest import DummyConfig, DummyLogger
 
 
-def test_run_invokes_parse_and_finalize(monkeypatch):
+def test_parse_statements_invokes_usecase_and_finalize(monkeypatch):
     dummy_config = DummyConfig()
 
     mock_usecase_cls = MagicMock(spec=ParseAndClassifyStatementsUseCase)
@@ -38,7 +38,7 @@ def test_run_invokes_parse_and_finalize(monkeypatch):
 
     fetched = [(MagicMock(spec=NsdDTO), [MagicMock(spec=StatementRowsDTO)])]
 
-    service.run(fetched)
+    service.parse_statements(fetched)
 
     parse_all.assert_called_once_with(fetched)
     mock_usecase_inst.finalize.assert_called_once()

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -74,7 +74,7 @@ def test_execute_converts_and_saves():
         max_workers=2,
     )
 
-    result = usecase.run()
+    result = usecase.synchronize_companies()
 
     repo.get_all_primary_keys.assert_called_once()
     scraper.fetch_all.assert_called_once()


### PR DESCRIPTION
## Summary
- rename implementation `run` methods to descriptive verbs
- keep abstract contracts intact
- update service and use case interactions
- fix `SaveStrategy` to flush by remaining count and handle iterables
- adjust statements config ordering and docs
- update tests accordingly

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68723c9d2738832eb29d543ae3b1ce22