### PR TITLE
Refactor repository inheritance

### DIFF
--- a/application/services/company_service.py
+++ b/application/services/company_service.py
@@ -23,6 +23,7 @@ class CompanyService:
             logger=self.logger,
             repository=repository,
             scraper=scraper,
+            max_workers=self.config.global_settings.max_workers,
         )
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")

--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -52,6 +52,7 @@ class StatementFetchService:
             metrics_collector=self.collector,
             worker_pool_executor=self.worker_pool_executor,
             config=self.config,
+            max_workers=self.max_workers,
         )
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
@@ -92,10 +93,7 @@ class StatementFetchService:
         _full_results = [
             n
             for n in nsd_records
-            if (
-                n.nsd_type in valid_types 
-                and n.company_name in common_company_names
-            )
+            if (n.nsd_type in valid_types and n.company_name in common_company_names)
         ]
         # self.logger.log(f"results: {len(results)} full_results: {len(full_results)}")
         # self.logger.log(

--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -31,6 +31,7 @@ class FetchStatementsUseCase:
         metrics_collector: MetricsCollectorPort,
         worker_pool_executor: WorkerPool,
         config: Config,
+        max_workers: int | None = None,
     ) -> None:
         """Store dependencies for fetching and saving raw rows."""
         self.logger = logger
@@ -40,6 +41,7 @@ class FetchStatementsUseCase:
         self.config = config
         self.collector = metrics_collector
         self.worker_pool_executor = worker_pool_executor
+        self.max_workers = max_workers
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 

--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Generic, List, Set, TypeVar
 
-T = TypeVar("T")   # DTO
-K = TypeVar("K")   # Key type: str, int, etc.
+T = TypeVar("T")
 
 
-class BaseRepositoryPort(ABC, Generic[T, K]):
+class BaseRepositoryPort(ABC, Generic[T]):
     """Generic repository port for persistence operations."""
 
     @abstractmethod
@@ -23,16 +22,16 @@ class BaseRepositoryPort(ABC, Generic[T, K]):
         raise NotImplementedError
 
     @abstractmethod
-    def has_item(self, identifier: K) -> bool:
+    def has_item(self, identifier: str) -> bool:
         """Check if an item exists in the repository."""
         raise NotImplementedError
 
     @abstractmethod
-    def get_by_id(self, id: K) -> T:
+    def get_by_id(self, id: str) -> T:
         """Retrieve an item by its identifier."""
         raise NotImplementedError
 
     @abstractmethod
-    def get_all_primary_keys(self) -> Set[K]:
+    def get_all_primary_keys(self) -> Set[str]:
         """Retrieve the set of all primary keys already persisted."""
         raise NotImplementedError

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 from typing import List, Set
 
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
 from domain.dto.company_dto import CompanyDTO
 from domain.ports import CompanyRepositoryPort, LoggerPort
 from infrastructure.config import Config
 from infrastructure.helpers.list_flattener import ListFlattener
+from infrastructure.models.base_model import BaseModel
 from infrastructure.models.company_model import CompanyModel
-from infrastructure.repositories import BaseRepository
 
 
-class SqlAlchemyCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryPort):
+class SqlAlchemyCompanyRepository(CompanyRepositoryPort):
     """Concrete implementation of the repository using SQLite.
 
     Note:
@@ -23,7 +26,21 @@ class SqlAlchemyCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryP
     """
 
     def __init__(self, config: Config, logger: LoggerPort) -> None:
-        super().__init__(config, logger)
+        self.config = config
+        self.logger = logger
+
+        self.engine = create_engine(
+            config.database.connection_string,
+            connect_args={"check_same_thread": False},
+            future=True,
+        )
+        with self.engine.connect() as conn:
+            conn.execute(text("PRAGMA journal_mode=WAL"))
+
+        self.Session = sessionmaker(
+            bind=self.engine, autoflush=True, expire_on_commit=True
+        )
+        BaseModel.metadata.create_all(self.engine)
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
@@ -31,12 +48,11 @@ class SqlAlchemyCompanyRepository(BaseRepository[CompanyDTO], CompanyRepositoryP
         """Persist a list of ``CompanyDTO`` objects."""
         session = self.Session()
         try:
-            flat_items = ListFlattener.flatten(items)  # recebe nested lists, devolve flat list
+            flat_items = ListFlattener.flatten(
+                items
+            )  # recebe nested lists, devolve flat list
 
-            valid_items = [
-                item for item in flat_items
-                if item is not None
-            ]
+            valid_items = [item for item in flat_items if item is not None]
 
             for dto in valid_items:
                 session.merge(CompanyModel.from_dto(dto))

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -4,19 +4,36 @@ from __future__ import annotations
 
 from typing import List
 
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
 from domain.dto.nsd_dto import NsdDTO
 from domain.ports import LoggerPort, NSDRepositoryPort
 from infrastructure.config import Config
 from infrastructure.helpers.list_flattener import ListFlattener
+from infrastructure.models.base_model import BaseModel
 from infrastructure.models.nsd_model import NSDModel
-from infrastructure.repositories import BaseRepository
 
 
 class SqlAlchemyNsdRepository(NSDRepositoryPort):
     """Concrete repository for NsdDTO using SQLite via SQLAlchemy."""
 
     def __init__(self, config: Config, logger: LoggerPort) -> None:
-        super().__init__(config, logger)
+        self.config = config
+        self.logger = logger
+
+        self.engine = create_engine(
+            config.database.connection_string,
+            connect_args={"check_same_thread": False},
+            future=True,
+        )
+        with self.engine.connect() as conn:
+            conn.execute(text("PRAGMA journal_mode=WAL"))
+
+        self.Session = sessionmaker(
+            bind=self.engine, autoflush=True, expire_on_commit=True
+        )
+        BaseModel.metadata.create_all(self.engine)
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
@@ -24,10 +41,13 @@ class SqlAlchemyNsdRepository(NSDRepositoryPort):
         """Persist a list of ``CompanyDTO`` objects."""
         session = self.Session()
         try:
-            flat_items = ListFlattener.flatten(items)  # recebe nested lists, devolve flat list
+            flat_items = ListFlattener.flatten(
+                items
+            )  # recebe nested lists, devolve flat list
 
             valid_items = [
-                item for item in flat_items
+                item
+                for item in flat_items
                 if item.nsd > 0 and item.sent_date is not None
             ]
 

--- a/infrastructure/repositories/parsed_statement_repository.py
+++ b/infrastructure/repositories/parsed_statement_repository.py
@@ -2,33 +2,47 @@ from __future__ import annotations
 
 from typing import Any, List, Set
 
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
 from domain.dto.statement_rows_dto import StatementRowsDTO
 from domain.ports import LoggerPort, ParsedStatementRepositoryPort
 from infrastructure.config import Config
 from infrastructure.helpers.list_flattener import ListFlattener
+from infrastructure.models.base_model import BaseModel
 from infrastructure.models.statement_rows_model import StatementRowsModel
-from infrastructure.repositories.base_repository import BaseRepository
 
 
-class SqlAlchemyParsedStatementRepository(
-    BaseRepository[StatementRowsDTO], ParsedStatementRepositoryPort
-):
+class SqlAlchemyParsedStatementRepository(ParsedStatementRepositoryPort):
     """SQLite-backed repository for ``StatementRowsDTO`` objects."""
 
     def __init__(self, config: Config, logger: LoggerPort) -> None:
-        super().__init__(config, logger)
+        self.config = config
+        self.logger = logger
+
+        self.engine = create_engine(
+            config.database.connection_string,
+            connect_args={"check_same_thread": False},
+            future=True,
+        )
+        with self.engine.connect() as conn:
+            conn.execute(text("PRAGMA journal_mode=WAL"))
+
+        self.Session = sessionmaker(
+            bind=self.engine, autoflush=True, expire_on_commit=True
+        )
+        BaseModel.metadata.create_all(self.engine)
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
     def save_all(self, items: List[StatementRowsDTO]) -> None:
         session = self.Session()
 
         try:
-            flat_items = ListFlattener.flatten(items)  # recebe nested lists, devolve flat list
+            flat_items = ListFlattener.flatten(
+                items
+            )  # recebe nested lists, devolve flat list
 
-            valid_items = [
-                item for item in flat_items
-                if item is not None
-            ]
+            valid_items = [item for item in flat_items if item is not None]
 
             for dto in valid_items:
                 session.merge(StatementRowsModel.from_dto(dto))
@@ -36,12 +50,13 @@ class SqlAlchemyParsedStatementRepository(
 
             if len(valid_items) > 0:
                 self.logger.log(
-                    f"Saved {len(valid_items)} parsed statement rows", 
-                    level="info"
+                    f"Saved {len(valid_items)} parsed statement rows", level="info"
                 )
         except Exception as exc:  # noqa: BLE001
             session.rollback()
-            self.logger.log(f"Failed to save parsed statement rows: {exc}", level="error")
+            self.logger.log(
+                f"Failed to save parsed statement rows: {exc}", level="error"
+            )
             raise
         finally:
             session.close()
@@ -93,21 +108,23 @@ class SqlAlchemyParsedStatementRepository(
         quadro: str,
         account: str,
     ) -> StatementRowsDTO:
-        """
-        Return exactly one raw row matching the full composite key.
+        """Return exactly one raw row matching the full composite key.
+
         Raises if not found.
         """
         session = self.Session()
         try:
-            model = session.query(StatementRowsModel).get({
-                "nsd": nsd,
-                "company_name": company_name,
-                "quarter": quarter,
-                "version": version,
-                "grupo": grupo,
-                "quadro": quadro,
-                "account": account,
-            })
+            model = session.query(StatementRowsModel).get(
+                {
+                    "nsd": nsd,
+                    "company_name": company_name,
+                    "quarter": quarter,
+                    "version": version,
+                    "grupo": grupo,
+                    "quadro": quadro,
+                    "account": account,
+                }
+            )
             if model is None:
                 raise ValueError(f"No raw statement for key {nsd}, {company_name}, …")
             return model.to_dto()
@@ -115,21 +132,22 @@ class SqlAlchemyParsedStatementRepository(
             session.close()
 
     def get_by_column(self, column_name: str, value: Any) -> List[StatementRowsDTO]:
-        """
-        Return all raw rows where `column_name == value`.
-        """
+        """Return all raw rows where `column_name == value`."""
         session = self.Session()
         try:
             # Dynamically get the column attribute from the model
             column_attr = getattr(StatementRowsModel, column_name)
-            models = session.query(StatementRowsModel).filter(column_attr == value).all()
+            models = (
+                session.query(StatementRowsModel).filter(column_attr == value).all()
+            )
             return [m.to_dto() for m in models]
         finally:
             session.close()
 
     def get_existing_by_column(self, column_name: str) -> Set[Any]:
-        """
-        Return the distinct values for the given column in tbl_raw_statements.
+        """Return the distinct values for the given column in
+        tbl_raw_statements.
+
         e.g. repo.get_existing_by_column("nsd") -> {94790, 12345, …}
         """
         session = self.Session()


### PR DESCRIPTION
## Summary
- make BaseRepositoryPort generic over DTO type only
- drop BaseRepository usage from SQLAlchemy repositories
- add worker settings to company and statement services
- propagate worker settings in related use cases

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6876549bfa28832eb02ac4fe0db0731c