### PR TITLE
Add import path logging

### DIFF
--- a/infrastructure/config/logging.py
+++ b/infrastructure/config/logging.py
@@ -3,31 +3,35 @@ from pathlib import Path
 
 from .paths import load_paths
 
-LOG_FILENAME = "fly_logger.log" # Nome do arquivo de log padrão
+LOG_FILENAME = "fly_logger.log"  # Nome do arquivo de log padrão
 LEVEL = "INFO"  # Nível de log padrão
+SHOW_IMPORT_PATH = False  # Include caller import path in logs
+
 
 @dataclass(frozen=True)
 class LoggingConfig:
-    """
-    Logging system configuration.
+    """Logging system configuration.
+
     Attributes:
         log_dir: Directory where logs will be saved.
         log_file_name: Name of the log file.
         level: Default logging level.
         full_path: Full path to the log file.
     """
+
     log_dir: Path
     log_file_name: str = field(default=LOG_FILENAME)
     level: str = field(default=LEVEL)
+    show_import_path: bool = field(default=SHOW_IMPORT_PATH)
 
     @property
     def full_path(self) -> Path:
         return self.log_dir / self.log_file_name
 
+
 def load_logging_config() -> LoggingConfig:
-    """
-    Creates and returns an instance of LoggingConfig,
-    ensuring that the log directory exists.
+    """Creates and returns an instance of LoggingConfig, ensuring that the log
+    directory exists.
 
     Returns:
         LoggingConfig: The logging configuration object with directory, filename, and level.
@@ -40,4 +44,5 @@ def load_logging_config() -> LoggingConfig:
         log_dir=paths.log_dir,
         log_file_name=LOG_FILENAME,
         level=LEVEL,
+        show_import_path=SHOW_IMPORT_PATH,
     )

--- a/tests/infrastructure/test_context_tracker_import_path.py
+++ b/tests/infrastructure/test_context_tracker_import_path.py
@@ -1,0 +1,14 @@
+import re
+
+from infrastructure.config.config import Config
+from infrastructure.logging.context_tracker import ContextTracker
+
+
+def sample_function():
+    tracker = ContextTracker(Config().paths.root_dir)
+    return tracker.get_import_path()
+
+
+def test_get_import_path_contains_function_name():
+    path = sample_function()
+    assert re.search(r"test_get_import_path_contains_function_name$", path)


### PR DESCRIPTION
## Summary
- allow specifying an optional import path on log messages
- add a toggle flag in `Logger` and the configuration
- implement `ContextTracker.get_import_path`
- cover import path tracking with tests

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68766ab3cf30832eb8d3771911d8e1fc