### PR TITLE
Use string type for NSD identifiers

### DIFF
--- a/application/services/nsd_prediction_service.py
+++ b/application/services/nsd_prediction_service.py
@@ -10,7 +10,7 @@ def _find_next_probable_nsd(
     repository: NSDRepositoryPort,
     window_days: int = 30,
     safety_factor: float = 1.5,
-) -> List[int]:
+) -> List[str]:
     """Estimate next NSD numbers based on historical submission rate.
 
     The prediction is calculated from the most recent ``window_days`` worth
@@ -32,7 +32,7 @@ def _find_next_probable_nsd(
     if not records:
         return []
 
-    last_nsd = max(r.nsd for r in records)
+    last_nsd = max(int(r.nsd) for r in records)
     max_date = max(r.sent_date for r in records)
     window_start = max_date - timedelta(days=window_days)
 
@@ -47,4 +47,4 @@ def _find_next_probable_nsd(
     days_since_last = max((datetime.utcnow() - max_date).days, 0)
     estimate = int(daily_avg * days_since_last * safety_factor)
 
-    return [last_nsd + i for i in range(1, estimate + 1)]
+    return [str(last_nsd + i) for i in range(1, estimate + 1)]

--- a/domain/dto/nsd_dto.py
+++ b/domain/dto/nsd_dto.py
@@ -12,7 +12,7 @@ from typing import Optional
 class NsdDTO:
     """Structured NSD data extracted from the exchange."""
 
-    nsd: int
+    nsd: str
     company_name: Optional[str]
     quarter: Optional[datetime]
     version: Optional[str]
@@ -28,10 +28,12 @@ class NsdDTO:
     def from_dict(raw: dict) -> NsdDTO:
         """Build an ``NsdDTO`` from scraped raw data."""
 
-        try:
-            nsd_value = int(raw.get("nsd", 0))
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Invalid NSD value") from exc
+        nsd_raw = raw.get("nsd", "")
+        if nsd_raw is None:
+            nsd_raw = ""
+        nsd_value = str(nsd_raw)
+        if not nsd_value:
+            raise ValueError("Invalid NSD value")
 
         return NsdDTO(
             nsd=nsd_value,

--- a/domain/dto/statement_dto.py
+++ b/domain/dto/statement_dto.py
@@ -8,7 +8,7 @@ from typing import Optional
 class StatementDTO:
     """Immutable representation of a financial statement row."""
 
-    nsd: int
+    nsd: str
     company_name: Optional[str]
     quarter: Optional[str]
     version: Optional[str]
@@ -22,10 +22,12 @@ class StatementDTO:
     def from_dict(raw: dict) -> "StatementDTO":
         """Create ``StatementDTO`` from a raw dictionary."""
 
-        try:
-            nsd_value = int(raw.get("nsd", 0))
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Invalid NSD value") from exc
+        nsd_raw = raw.get("nsd", "")
+        if nsd_raw is None:
+            nsd_raw = ""
+        nsd_value = str(nsd_raw)
+        if not nsd_value:
+            raise ValueError("Invalid NSD value")
 
         return StatementDTO(
             nsd=nsd_value,

--- a/domain/dto/statement_rows_dto.py
+++ b/domain/dto/statement_rows_dto.py
@@ -8,7 +8,7 @@ from typing import Optional
 class StatementRowsDTO:
     """Immutable DTO for parsed statement rows."""
 
-    nsd: int
+    nsd: str
     company_name: Optional[str]
     quarter: Optional[str]
     version: Optional[str]
@@ -22,10 +22,12 @@ class StatementRowsDTO:
     def from_dict(raw: dict) -> "StatementRowsDTO":
         """Create a ``StatementRowsDTO`` from a raw dictionary."""
 
-        try:
-            nsd_value = int(raw.get("nsd", 0))
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Invalid NSD value") from exc
+        nsd_raw = raw.get("nsd", "")
+        if nsd_raw is None:
+            nsd_raw = ""
+        nsd_value = str(nsd_raw)
+        if not nsd_value:
+            raise ValueError("Invalid NSD value")
 
         return StatementRowsDTO(
             nsd=nsd_value,

--- a/infrastructure/models/nsd_model.py
+++ b/infrastructure/models/nsd_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, Integer
+from sqlalchemy import DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.nsd_dto import NsdDTO
@@ -16,7 +16,7 @@ class NSDModel(BaseModel):
 
     __tablename__ = "tbl_nsd"
 
-    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nsd: Mapped[str] = mapped_column(String, primary_key=True)
     company_name: Mapped[Optional[str]] = mapped_column()
     quarter: Mapped[Optional[datetime]] = mapped_column(DateTime)
     version: Mapped[Optional[str]] = mapped_column()

--- a/infrastructure/models/statement_model.py
+++ b/infrastructure/models/statement_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Integer, PrimaryKeyConstraint
+from sqlalchemy import PrimaryKeyConstraint, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.statement_dto import StatementDTO
@@ -25,7 +25,7 @@ class StatementModel(BaseModel):
         ),
     )
 
-    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nsd: Mapped[str] = mapped_column(String, primary_key=True)
     company_name: Mapped[str | None] = mapped_column(primary_key=True)
     quarter: Mapped[str | None] = mapped_column(primary_key=True)
     version: Mapped[str | None] = mapped_column(primary_key=True)

--- a/infrastructure/models/statement_rows_model.py
+++ b/infrastructure/models/statement_rows_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Integer, PrimaryKeyConstraint
+from sqlalchemy import PrimaryKeyConstraint, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.statement_rows_dto import StatementRowsDTO
@@ -25,7 +25,7 @@ class StatementRowsModel(BaseModel):
         ),
     )
 
-    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nsd: Mapped[str] = mapped_column(String, primary_key=True)
     company_name: Mapped[str | None] = mapped_column(primary_key=True)
     quarter: Mapped[str | None] = mapped_column(primary_key=True)
     version: Mapped[str | None] = mapped_column(primary_key=True)

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -24,11 +24,12 @@ class SqlAlchemyNsdRepository(BaseRepository[NsdDTO], NSDRepositoryPort):
         """Persist a list of ``CompanyDTO`` objects."""
         session = self.Session()
         try:
-            flat_items = ListFlattener.flatten(items)  # recebe nested lists, devolve flat list
+            flat_items = ListFlattener.flatten(
+                items
+            )  # recebe nested lists, devolve flat list
 
             valid_items = [
-                item for item in flat_items
-                if item.nsd > 0 and item.sent_date is not None
+                item for item in flat_items if item.nsd and item.sent_date is not None
             ]
 
             for dto in valid_items:
@@ -63,7 +64,7 @@ class SqlAlchemyNsdRepository(BaseRepository[NsdDTO], NSDRepositoryPort):
         database.
 
         Args:
-            identifier (int): The unique identifier of the item to check.
+            identifier (str): The unique identifier of the item to check.
 
         Returns:
             bool: True if the item exists, False otherwise.
@@ -78,7 +79,7 @@ class SqlAlchemyNsdRepository(BaseRepository[NsdDTO], NSDRepositoryPort):
         """Fetches an NSD record from the database by its unique identifier.
 
         Args:
-            id (int): The unique identifier of the NSD to retrieve.
+            id (str): The unique identifier of the NSD to retrieve.
         Returns:
             NsdDTO: Data transfer object representing the retrieved NSD.
         Raises:
@@ -93,7 +94,7 @@ class SqlAlchemyNsdRepository(BaseRepository[NsdDTO], NSDRepositoryPort):
         finally:
             session.close()
 
-    def get_all_primary_keys(self) -> set[int]:
+    def get_all_primary_keys(self) -> set[str]:
         """Retrieve all distinct primary key values from the NSDModel table.
 
         Returns: All unique primary key values (nsd) from the NSDModel table.

--- a/infrastructure/repositories/parsed_statement_repository.py
+++ b/infrastructure/repositories/parsed_statement_repository.py
@@ -23,12 +23,11 @@ class SqlAlchemyParsedStatementRepository(
         session = self.Session()
 
         try:
-            flat_items = ListFlattener.flatten(items)  # recebe nested lists, devolve flat list
+            flat_items = ListFlattener.flatten(
+                items
+            )  # recebe nested lists, devolve flat list
 
-            valid_items = [
-                item for item in flat_items
-                if item is not None
-            ]
+            valid_items = [item for item in flat_items if item is not None]
 
             for dto in valid_items:
                 session.merge(StatementRowsModel.from_dto(dto))
@@ -36,12 +35,13 @@ class SqlAlchemyParsedStatementRepository(
 
             if len(valid_items) > 0:
                 self.logger.log(
-                    f"Saved {len(valid_items)} parsed statement rows", 
-                    level="info"
+                    f"Saved {len(valid_items)} parsed statement rows", level="info"
                 )
         except Exception as exc:  # noqa: BLE001
             session.rollback()
-            self.logger.log(f"Failed to save parsed statement rows: {exc}", level="error")
+            self.logger.log(
+                f"Failed to save parsed statement rows: {exc}", level="error"
+            )
             raise
         finally:
             session.close()
@@ -58,7 +58,7 @@ class SqlAlchemyParsedStatementRepository(
         session = self.Session()
         try:
             return (
-                session.query(StatementRowsModel).filter_by(id=int(identifier)).first()
+                session.query(StatementRowsModel).filter_by(id=identifier).first()
                 is not None
             )
         finally:
@@ -67,14 +67,14 @@ class SqlAlchemyParsedStatementRepository(
     def get_by_id(self, id: str) -> StatementRowsDTO:
         session = self.Session()
         try:
-            obj = session.query(StatementRowsModel).filter_by(id=int(id)).first()
+            obj = session.query(StatementRowsModel).filter_by(id=id).first()
             if not obj:
                 raise ValueError(f"Raw statement not found: {id}")
             return obj.to_dto()
         finally:
             session.close()
 
-    def get_all_primary_keys(self) -> set[int]:
+    def get_all_primary_keys(self) -> set[str]:
         session = self.Session()
         try:
             rows = session.query(StatementRowsModel.nsd).distinct().all()
@@ -85,7 +85,7 @@ class SqlAlchemyParsedStatementRepository(
 
     def get_by_key(
         self,
-        nsd: int,
+        nsd: str,
         company_name: str,
         quarter: str,
         version: str,
@@ -93,21 +93,23 @@ class SqlAlchemyParsedStatementRepository(
         quadro: str,
         account: str,
     ) -> StatementRowsDTO:
-        """
-        Return exactly one raw row matching the full composite key.
+        """Return exactly one raw row matching the full composite key.
+
         Raises if not found.
         """
         session = self.Session()
         try:
-            model = session.query(StatementRowsModel).get({
-                "nsd": nsd,
-                "company_name": company_name,
-                "quarter": quarter,
-                "version": version,
-                "grupo": grupo,
-                "quadro": quadro,
-                "account": account,
-            })
+            model = session.query(StatementRowsModel).get(
+                {
+                    "nsd": nsd,
+                    "company_name": company_name,
+                    "quarter": quarter,
+                    "version": version,
+                    "grupo": grupo,
+                    "quadro": quadro,
+                    "account": account,
+                }
+            )
             if model is None:
                 raise ValueError(f"No raw statement for key {nsd}, {company_name}, …")
             return model.to_dto()
@@ -115,21 +117,22 @@ class SqlAlchemyParsedStatementRepository(
             session.close()
 
     def get_by_column(self, column_name: str, value: Any) -> List[StatementRowsDTO]:
-        """
-        Return all raw rows where `column_name == value`.
-        """
+        """Return all raw rows where `column_name == value`."""
         session = self.Session()
         try:
             # Dynamically get the column attribute from the model
             column_attr = getattr(StatementRowsModel, column_name)
-            models = session.query(StatementRowsModel).filter(column_attr == value).all()
+            models = (
+                session.query(StatementRowsModel).filter(column_attr == value).all()
+            )
             return [m.to_dto() for m in models]
         finally:
             session.close()
 
     def get_existing_by_column(self, column_name: str) -> Set[Any]:
-        """
-        Return the distinct values for the given column in tbl_raw_statements.
+        """Return the distinct values for the given column in
+        tbl_raw_statements.
+
         e.g. repo.get_existing_by_column("nsd") -> {94790, 12345, …}
         """
         session = self.Session()

--- a/infrastructure/repositories/raw_statement_repository.py
+++ b/infrastructure/repositories/raw_statement_repository.py
@@ -23,12 +23,11 @@ class SqlAlchemyRawStatementRepository(
     def save_all(self, items: List[StatementDTO]) -> None:
         session = self.Session()
         try:
-            flat_items = ListFlattener.flatten(items)  # recebe nested lists, devolve flat list
+            flat_items = ListFlattener.flatten(
+                items
+            )  # recebe nested lists, devolve flat list
 
-            valid_items = [
-                item for item in flat_items
-                if item is not None
-            ]
+            valid_items = [item for item in flat_items if item is not None]
 
             for dto in valid_items:
                 model = StatementModel.from_dto(dto)
@@ -37,8 +36,7 @@ class SqlAlchemyRawStatementRepository(
 
             if len(valid_items) > 0:
                 self.logger.log(
-                    f"Saved {len(valid_items)} raw statement rows", 
-                    level="info"
+                    f"Saved {len(valid_items)} raw statement rows", level="info"
                 )
         except Exception as exc:  # noqa: BLE001
             session.rollback()
@@ -59,7 +57,7 @@ class SqlAlchemyRawStatementRepository(
         session = self.Session()
         try:
             return (
-                session.query(StatementModel).filter_by(id=int(identifier)).first()
+                session.query(StatementModel).filter_by(id=identifier).first()
                 is not None
             )
         finally:
@@ -68,7 +66,7 @@ class SqlAlchemyRawStatementRepository(
     def get_by_id(self, id: str) -> StatementDTO:
         session = self.Session()
         try:
-            obj = session.query(StatementModel).filter_by(id=int(id)).first()
+            obj = session.query(StatementModel).filter_by(id=id).first()
             if not obj:
                 raise ValueError(f"Statement not found: {id}")
             return obj.to_dto()

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -165,7 +165,6 @@ class NsdScraper(NSDSourcePort):
 
             return NsdDTO.from_dict(parsed)
 
-
         def handle_batch(item: Optional[NsdDTO]) -> None:
             if item is not None:
                 strategy.handle([item])
@@ -364,7 +363,7 @@ class NsdScraper(NSDSourcePort):
             after the last stored record.
         """
         # Get all nsd with valid sent_date
-        all_nsds = self.repository.get_all_primary_keys()
+        all_nsds = {int(nsd) for nsd in self.repository.get_all_primary_keys()}
         if not all_nsds:
             return start
 

--- a/tests/application/test_fetch_statements_use_case.py
+++ b/tests/application/test_fetch_statements_use_case.py
@@ -10,7 +10,7 @@ from domain.ports import (
 from tests.conftest import DummyConfig, DummyLogger
 
 
-def _make_nsd(nsd: int) -> NsdDTO:
+def _make_nsd(nsd: str) -> NsdDTO:
     return NsdDTO(
         nsd=nsd,
         company_name=None,
@@ -30,7 +30,7 @@ def test_fetch_statement_rows_skips_existing(monkeypatch):
     source = MagicMock(spec=RawStatementSourcePort)
     rows_repo = MagicMock(spec=ParsedStatementRepositoryPort)
     stmt_repo = MagicMock(spec=RawStatementRepositoryPort)
-    stmt_repo.get_all_primary_keys = MagicMock(return_value={1})
+    stmt_repo.get_all_primary_keys = MagicMock(return_value={"1"})
 
     collector = MagicMock()
     worker_pool = MagicMock()
@@ -43,13 +43,12 @@ def test_fetch_statement_rows_skips_existing(monkeypatch):
         metrics_collector=collector,
         worker_pool_executor=worker_pool,
         config=DummyConfig(),
-        max_workers=2,
     )
 
     mock_fetch_all = MagicMock(return_value=[("result", [])])
     monkeypatch.setattr(usecase, "fetch_all", mock_fetch_all)
 
-    targets = [_make_nsd(1), _make_nsd(2)]
+    targets = [_make_nsd("1"), _make_nsd("2")]
     result = usecase.fetch_statement_rows(targets, save_callback="cb", threshold=5)
 
     stmt_repo.get_all_primary_keys.assert_not_called()

--- a/tests/application/test_nsd_prediction_service.py
+++ b/tests/application/test_nsd_prediction_service.py
@@ -15,7 +15,7 @@ def test_find_next_probable_nsd_returns_sequence():
     for i in range(10):
         items.append(
             NsdDTO(
-                nsd=i + 1,
+                nsd=str(i + 1),
                 company_name=None,
                 quarter=None,
                 version=None,
@@ -42,7 +42,7 @@ def test_find_next_probable_nsd_returns_sequence():
     daily_avg = len(items) / days_span
     days_since_last = (now - max_date).days
     expected_count = int(daily_avg * days_since_last * 1.0)
-    expected = [len(items) + i for i in range(1, expected_count + 1)]
+    expected = [str(len(items) + i) for i in range(1, expected_count + 1)]
 
     assert result == expected
 

--- a/tests/application/test_statement_fetch_service.py
+++ b/tests/application/test_statement_fetch_service.py
@@ -42,7 +42,6 @@ def test_fetch_statements_calls_usecase(monkeypatch):
         config=dummy_config,
         metrics_collector=collector,
         worker_pool_executor=worker_pool,
-        max_workers=3,
     )
 
     mock_usecase_cls.assert_called_once_with(
@@ -53,7 +52,6 @@ def test_fetch_statements_calls_usecase(monkeypatch):
         metrics_collector=collector,
         worker_pool_executor=worker_pool,
         config=dummy_config,
-        max_workers=3,
     )
 
     targets = [MagicMock(spec=NsdDTO)]

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -1,5 +1,3 @@
-import pytest
-
 from domain.dto.company_dto import CompanyDTO
 from domain.dto.nsd_dto import NsdDTO
 from domain.dto.statement_rows_dto import StatementRowsDTO
@@ -12,9 +10,9 @@ def test_company_dto_from_dict():
     assert dto.company_name == "Xyz Corp"
 
 
-def test_nsd_dto_invalid_nsd():
-    with pytest.raises(ValueError):
-        NsdDTO.from_dict({"nsd": "not_a_number"})
+def test_nsd_dto_accepts_string_nsd():
+    dto = NsdDTO.from_dict({"nsd": "not_a_number"})
+    assert dto.nsd == "not_a_number"
 
 
 def test_statement_rows_dto_from_dict():
@@ -25,10 +23,10 @@ def test_statement_rows_dto_from_dict():
         "grupo": "Dados da Empresa",
         "quadro": "Composi\u00e7\u00e3o do Capital",
         "company_name": "2W ECOBANK SA",
-        "nsd": 102395,
+        "nsd": "102395",
         "quarter": "2020-12-31",
         "version": "V1",
     }
     dto = StatementRowsDTO.from_dict(raw)
     assert dto.account == "00.01.01"
-    assert dto.nsd == 102395
+    assert dto.nsd == "102395"


### PR DESCRIPTION
## Summary
- treat `nsd` as a string across DTOs and ORM models
- update repositories and scraper logic for new NSD type
- adjust nsd prediction to return a list of strings
- update tests for the new behaviour

## Testing
- `ruff check . --fix`
- `ruff format .`
- `docformatter --in-place --recursive .`
- `pydocstyle --convention=google .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785ea263bc832eb9ae04fb38621ddd