### PR TITLE
Switch NSD fields to strings

### DIFF
--- a/application/services/nsd_prediction_service.py
+++ b/application/services/nsd_prediction_service.py
@@ -32,7 +32,7 @@ def _find_next_probable_nsd(
     if not records:
         return []
 
-    last_nsd = max(r.nsd for r in records)
+    last_nsd = max(int(r.nsd) for r in records)
     max_date = max(r.sent_date for r in records)
     window_start = max_date - timedelta(days=window_days)
 

--- a/application/services/statement_fetch_service.py
+++ b/application/services/statement_fetch_service.py
@@ -71,8 +71,6 @@ class StatementFetchService:
 
         if not company_records or not nsd_records:
             return []
-        raw_rows_records = self.raw_statement_repo.get_all()
-        parsed_rows_records = self.parsed_statements_repo.get_all()
         nsd_rows_processed = self.raw_statement_repo.get_existing_by_column(
             column_name="nsd"
         )

--- a/domain/dto/nsd_dto.py
+++ b/domain/dto/nsd_dto.py
@@ -12,7 +12,7 @@ from typing import Optional
 class NsdDTO:
     """Structured NSD data extracted from the exchange."""
 
-    nsd: int
+    nsd: str
     company_name: Optional[str]
     quarter: Optional[datetime]
     version: Optional[str]
@@ -28,10 +28,10 @@ class NsdDTO:
     def from_dict(raw: dict) -> NsdDTO:
         """Build an ``NsdDTO`` from scraped raw data."""
 
-        try:
-            nsd_value = int(raw.get("nsd", 0))
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Invalid NSD value") from exc
+        nsd_raw = raw.get("nsd", "")
+        if nsd_raw is None or not str(nsd_raw).isdigit():
+            raise ValueError("Invalid NSD value")
+        nsd_value = str(nsd_raw)
 
         return NsdDTO(
             nsd=nsd_value,

--- a/domain/dto/parsed_statement_dto.py
+++ b/domain/dto/parsed_statement_dto.py
@@ -8,7 +8,7 @@ from typing import Optional
 class ParsedStatementDTO:
     """Immutable representation of a cleaned statement row."""
 
-    nsd: int
+    nsd: str
     company_name: Optional[str]
     quarter: Optional[str]
     version: Optional[str]
@@ -22,10 +22,10 @@ class ParsedStatementDTO:
     def from_dict(raw: dict) -> "ParsedStatementDTO":
         """Create ``ParsedStatementDTO`` from a raw dictionary."""
 
-        try:
-            nsd_value = int(raw.get("nsd", 0))
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Invalid NSD value") from exc
+        nsd_raw = raw.get("nsd", "")
+        if nsd_raw is None or not str(nsd_raw).isdigit():
+            raise ValueError("Invalid NSD value")
+        nsd_value = str(nsd_raw)
 
         return ParsedStatementDTO(
             nsd=nsd_value,

--- a/domain/dto/raw_statement_dto.py
+++ b/domain/dto/raw_statement_dto.py
@@ -8,7 +8,7 @@ from typing import Optional
 class RawStatementDTO:
     """Immutable DTO representing a scraped statement row."""
 
-    nsd: int
+    nsd: str
     company_name: Optional[str]
     quarter: Optional[str]
     version: Optional[str]
@@ -22,10 +22,10 @@ class RawStatementDTO:
     def from_dict(raw: dict) -> "RawStatementDTO":
         """Create a ``RawStatementDTO`` from a raw dictionary."""
 
-        try:
-            nsd_value = int(raw.get("nsd", 0))
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Invalid NSD value") from exc
+        nsd_raw = raw.get("nsd", "")
+        if nsd_raw is None or not str(nsd_raw).isdigit():
+            raise ValueError("Invalid NSD value")
+        nsd_value = str(nsd_raw)
 
         return RawStatementDTO(
             nsd=nsd_value,

--- a/domain/ports/nsd_repository_port.py
+++ b/domain/ports/nsd_repository_port.py
@@ -7,5 +7,5 @@ from domain.dto.nsd_dto import NsdDTO
 from .base_repository_port import SqlAlchemyRepositoryBasePort
 
 
-class NSDRepositoryPort(SqlAlchemyRepositoryBasePort[NsdDTO, int]):
+class NSDRepositoryPort(SqlAlchemyRepositoryBasePort[NsdDTO, str]):
     """Port for NSD persistence operations."""

--- a/domain/ports/parsed_statement_repository_port.py
+++ b/domain/ports/parsed_statement_repository_port.py
@@ -6,6 +6,6 @@ from .base_repository_port import SqlAlchemyRepositoryBasePort
 
 
 class SqlAlchemyParsedStatementRepositoryPort(
-    SqlAlchemyRepositoryBasePort[ParsedStatementDTO, int]
+    SqlAlchemyRepositoryBasePort[ParsedStatementDTO, str]
 ):
     """Port for persisting parsed statement rows."""

--- a/infrastructure/models/nsd_model.py
+++ b/infrastructure/models/nsd_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, Integer
+from sqlalchemy import DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.nsd_dto import NsdDTO
@@ -16,7 +16,7 @@ class NSDModel(BaseModel):
 
     __tablename__ = "tbl_nsd"
 
-    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nsd: Mapped[str] = mapped_column(String, primary_key=True)
     company_name: Mapped[Optional[str]] = mapped_column()
     quarter: Mapped[Optional[datetime]] = mapped_column(DateTime)
     version: Mapped[Optional[str]] = mapped_column()

--- a/infrastructure/models/statement_model.py
+++ b/infrastructure/models/statement_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Integer, PrimaryKeyConstraint
+from sqlalchemy import PrimaryKeyConstraint, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
@@ -25,7 +25,7 @@ class StatementModel(BaseModel):
         ),
     )
 
-    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nsd: Mapped[str] = mapped_column(String, primary_key=True)
     company_name: Mapped[str | None] = mapped_column(primary_key=True)
     quarter: Mapped[str | None] = mapped_column(primary_key=True)
     version: Mapped[str | None] = mapped_column(primary_key=True)

--- a/infrastructure/models/statement_rows_model.py
+++ b/infrastructure/models/statement_rows_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Integer, PrimaryKeyConstraint
+from sqlalchemy import PrimaryKeyConstraint, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.raw_statement_dto import RawStatementDTO
@@ -25,7 +25,7 @@ class StatementRowsModel(BaseModel):
         ),
     )
 
-    nsd: Mapped[int] = mapped_column(Integer, primary_key=True)
+    nsd: Mapped[str] = mapped_column(String, primary_key=True)
     company_name: Mapped[str | None] = mapped_column(primary_key=True)
     quarter: Mapped[str | None] = mapped_column(primary_key=True)
     version: Mapped[str | None] = mapped_column(primary_key=True)

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -13,11 +13,11 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 )
 
 
-class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, int], NSDRepositoryPort):
+class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, str], NSDRepositoryPort):
     """Concrete repository for NsdDTO using SQLite via SQLAlchemy."""
 
     def __init__(self, config: Config, logger: LoggerPort) -> None:
-        super().__init__(config, logger) 
+        super().__init__(config, logger)
 
         self.config = config
         self.logger = logger
@@ -29,4 +29,3 @@ class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, int], NSDReposito
             type: The model class associated with this repository.
         """
         return NSDModel, NSDModel.nsd
-

--- a/infrastructure/repositories/parsed_statement_repository.py
+++ b/infrastructure/repositories/parsed_statement_repository.py
@@ -12,7 +12,7 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 
 
 class SqlAlchemyParsedStatementRepository(
-    SqlAlchemyRepositoryBase[ParsedStatementDTO, int],
+    SqlAlchemyRepositoryBase[ParsedStatementDTO, str],
     SqlAlchemyParsedStatementRepositoryPort,
 ):
     """SQLite-backed repository for ``ParsedStatementDTO`` objects."""

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -165,7 +165,6 @@ class NsdScraper(NSDSourcePort):
 
             return NsdDTO.from_dict(parsed)
 
-
         def handle_batch(item: Optional[NsdDTO]) -> None:
             if item is not None:
                 strategy.handle([item])
@@ -368,9 +367,10 @@ class NsdScraper(NSDSourcePort):
         if not all_nsds:
             return start
 
-        # First and last date from first and last date
-        first_date = self.repository.get_by_id(min(all_nsds)).sent_date
-        last_date = self.repository.get_by_id(max(all_nsds)).sent_date
+        first_pk = min(all_nsds, key=lambda n: int(n))
+        last_pk = max(all_nsds, key=lambda n: int(n))
+        first_date = self.repository.get_by_id(first_pk).sent_date
+        last_date = self.repository.get_by_id(last_pk).sent_date
 
         # Days span between dates
         total_span_days = (last_date - first_date).days or 1  # type: ignore[assignment]

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -220,18 +220,18 @@ class CLIAdapter:
         )
         _company_all = company_repo.get_all()
         _company_all_primary_keys = company_repo.get_all_primary_keys()
-        identifier = cvm_code = '25224'
+        identifier = "25224"
         _company_has = company_repo.has_item(identifier)
         _company_by_id = company_repo.get_by_id(identifier)
-        column_name = 'cvm_code'
+        column_name = "cvm_code"
         _company_by_column = company_repo.get_existing_by_column(column_name)
 
         _nsd_all = nsd_repo.get_all()
         _nsd_all_primary_keys = nsd_repo.get_all_primary_keys()
-        identifier = cvm_code = 25224
+        identifier = 25224
         _nsd_has = nsd_repo.has_item(identifier)
         _nsd_by_id = nsd_repo.get_by_id(identifier)
-        column_name = 'cvm_code'
+        column_name = "cvm_code"
         _nsd_by_column = nsd_repo.get_existing_by_column(column_name)
 
         # Execute fetch process and log total rows fetched

--- a/tests/application/test_fetch_statements_use_case.py
+++ b/tests/application/test_fetch_statements_use_case.py
@@ -12,7 +12,7 @@ from tests.conftest import DummyConfig, DummyLogger
 
 def _make_nsd(nsd: int) -> NsdDTO:
     return NsdDTO(
-        nsd=nsd,
+        nsd=str(nsd),
         company_name=None,
         quarter=None,
         version=None,

--- a/tests/application/test_nsd_prediction_service.py
+++ b/tests/application/test_nsd_prediction_service.py
@@ -15,7 +15,7 @@ def test_find_next_probable_nsd_returns_sequence():
     for i in range(10):
         items.append(
             NsdDTO(
-                nsd=i + 1,
+                nsd=str(i + 1),
                 company_name=None,
                 quarter=None,
                 version=None,

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -31,4 +31,4 @@ def test_statement_rows_dto_from_dict():
     }
     dto = RawStatementDTO.from_dict(raw)
     assert dto.account == "00.01.01"
-    assert dto.nsd == 102395
+    assert dto.nsd == "102395"


### PR DESCRIPTION
## Summary
- store NSD identifiers as strings
- adjust NSD prediction logic
- update SQLAlchemy models and repositories
- fix CLI sample variables
- update tests for new NSD type

## Testing
- `ruff format application/services/nsd_prediction_service.py application/services/statement_fetch_service.py domain/dto/nsd_dto.py domain/dto/parsed_statement_dto.py domain/dto/raw_statement_dto.py domain/ports/nsd_repository_port.py domain/ports/parsed_statement_repository_port.py infrastructure/models/nsd_model.py infrastructure/models/statement_model.py infrastructure/models/statement_rows_model.py infrastructure/repositories/nsd_repository.py infrastructure/repositories/parsed_statement_repository.py infrastructure/scrapers/nsd_scraper.py presentation/cli.py tests/application/test_fetch_statements_use_case.py tests/application/test_nsd_prediction_service.py tests/domain/test_dtos.py`
- `ruff check application/services/nsd_prediction_service.py application/services/statement_fetch_service.py domain/dto/nsd_dto.py domain/dto/parsed_statement_dto.py domain/dto/raw_statement_dto.py domain/ports/nsd_repository_port.py domain/ports/parsed_statement_repository_port.py infrastructure/models/nsd_model.py infrastructure/models/statement_model.py infrastructure/models/statement_rows_model.py infrastructure/repositories/nsd_repository.py infrastructure/repositories/parsed_statement_repository.py infrastructure/scrapers/nsd_scraper.py presentation/cli.py tests/application/test_fetch_statements_use_case.py tests/application/test_nsd_prediction_service.py tests/domain/test_dtos.py --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687878581328832e8b1ea6d0a4285559