### PR TITLE
Add surrogate keys for pagination

### DIFF
--- a/domain/dto/company_data_dto.py
+++ b/domain/dto/company_data_dto.py
@@ -55,6 +55,7 @@ class CompanyDataDTO:
     date_quotation: Optional[datetime]
     last_date: Optional[datetime]
     listing_date: Optional[datetime]
+    id: Optional[int] = None
 
     @staticmethod
     def from_dict(raw: dict) -> "CompanyDataDTO":
@@ -97,6 +98,7 @@ class CompanyDataDTO:
             date_quotation=raw.get("date_quotation"),
             last_date=raw.get("last_date"),
             listing_date=raw.get("listing_date"),
+            id=None,
         )
 
     @staticmethod
@@ -146,4 +148,5 @@ class CompanyDataDTO:
             date_quotation=raw.date_quotation,
             last_date=raw.last_date,
             listing_date=raw.listing_date,
+            id=None,
         )

--- a/domain/dto/nsd_dto.py
+++ b/domain/dto/nsd_dto.py
@@ -23,6 +23,7 @@ class NsdDTO:
     protocol: Optional[str]
     sent_date: Optional[datetime]
     reason: Optional[str]
+    id: Optional[int] = None
 
     @staticmethod
     def from_dict(raw: dict) -> Optional[NsdDTO]:
@@ -49,6 +50,7 @@ class NsdDTO:
             protocol=raw.get("protocol"),
             sent_date=raw.get("sent_date"),
             reason=raw.get("reason"),
+            id=None,
         )
 
     @staticmethod
@@ -66,4 +68,5 @@ class NsdDTO:
             protocol=raw.protocol,
             sent_date=raw.sent_date,
             reason=raw.reason,
+            id=None,
         )

--- a/domain/dto/parsed_statement_dto.py
+++ b/domain/dto/parsed_statement_dto.py
@@ -17,6 +17,7 @@ class ParsedStatementDTO:
     account: str
     description: str
     value: float
+    id: Optional[int] = None
 
     @staticmethod
     def from_dict(raw: dict) -> "ParsedStatementDTO":
@@ -37,4 +38,5 @@ class ParsedStatementDTO:
             account=str(raw.get("account", "")),
             description=str(raw.get("description", "")),
             value=float(raw.get("value", 0.0)),
+            id=None,
         )

--- a/domain/dto/raw_statement_dto.py
+++ b/domain/dto/raw_statement_dto.py
@@ -17,6 +17,7 @@ class RawStatementDTO:
     account: str
     description: str
     value: float
+    id: Optional[int] = None
 
     @staticmethod
     def from_dict(raw: dict) -> "RawStatementDTO":
@@ -37,4 +38,5 @@ class RawStatementDTO:
             account=str(raw.get("account", "")),
             description=str(raw.get("description", "")),
             value=float(raw.get("value", 0.0)),
+            id=None,
         )

--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, List, Sequence, Tuple, TypeVar, Union
 
-T = TypeVar("T")   # DTO type
-K = TypeVar("K")   # Key type (e.g., str, int)
+T = TypeVar("T")  # DTO type
+K = TypeVar("K")  # Key type (e.g., str, int)
 
 
 class SqlAlchemyRepositoryBasePort(ABC, Generic[T, K]):
@@ -49,7 +49,9 @@ class SqlAlchemyRepositoryBasePort(ABC, Generic[T, K]):
         raise NotImplementedError
 
     @abstractmethod
-    def get_existing_by_columns(self, column_names: Union[str, List[str]]) -> List[Tuple]:
+    def get_existing_by_columns(
+        self, column_names: Union[str, List[str]]
+    ) -> List[Tuple]:
         """Retrieve the set of all primary keys currently stored by column.
 
         Returns:
@@ -85,10 +87,14 @@ class SqlAlchemyRepositoryBasePort(ABC, Generic[T, K]):
         raise NotImplementedError
 
     @abstractmethod
+    def get_page_after(self, last_id: int, limit: int) -> List[T]:
+        """Return a page of items with id greater than ``last_id``."""
+        raise NotImplementedError
+
+    @abstractmethod
     def _safe_cast(self, value: Any) -> Union[int, str]:
         raise NotImplementedError
 
     @abstractmethod
     def _sort_key(self, obj: Any, pk_columns: Sequence) -> tuple[Union[int, str], ...]:
         raise NotImplementedError
-

--- a/domain/ports/company_repository_port.py
+++ b/domain/ports/company_repository_port.py
@@ -7,9 +7,13 @@ from domain.dto.company_data_dto import CompanyDataDTO
 from .base_repository_port import SqlAlchemyRepositoryBasePort
 
 
-class SqlAlchemyCompanyDataRepositoryPort(SqlAlchemyRepositoryBasePort[CompanyDataDTO, str]):
-    """Interface (port) for persistence operations related to CompanyData entities.
+class SqlAlchemyCompanyDataRepositoryPort(
+    SqlAlchemyRepositoryBasePort[CompanyDataDTO, int]
+):
+    """Interface (port) for persistence operations related to CompanyData
+    entities.
 
     Acts as an abstraction for the application layer to interact with
-    company-related data storage, decoupling it from the actual database implementation.
+    company-related data storage, decoupling it from the actual database
+    implementation.
     """

--- a/domain/ports/nsd_repository_port.py
+++ b/domain/ports/nsd_repository_port.py
@@ -10,7 +10,7 @@ from domain.dto.nsd_dto import NsdDTO
 from .base_repository_port import SqlAlchemyRepositoryBasePort
 
 
-class NSDRepositoryPort(SqlAlchemyRepositoryBasePort[NsdDTO, str]):
+class NSDRepositoryPort(SqlAlchemyRepositoryBasePort[NsdDTO, int]):
     """Port for NSD persistence operations."""
 
     @abstractmethod

--- a/domain/ports/parsed_statement_repository_port.py
+++ b/domain/ports/parsed_statement_repository_port.py
@@ -6,6 +6,6 @@ from .base_repository_port import SqlAlchemyRepositoryBasePort
 
 
 class SqlAlchemyParsedStatementRepositoryPort(
-    SqlAlchemyRepositoryBasePort[ParsedStatementDTO, str]
+    SqlAlchemyRepositoryBasePort[ParsedStatementDTO, int]
 ):
     """Port for persisting parsed statement rows."""

--- a/domain/ports/raw_statement_repository_port.py
+++ b/domain/ports/raw_statement_repository_port.py
@@ -8,6 +8,6 @@ from .base_repository_port import SqlAlchemyRepositoryBasePort
 
 
 class SqlAlchemyRawStatementRepositoryPort(
-    SqlAlchemyRepositoryBasePort[RawStatementDTO, str], ABC
+    SqlAlchemyRepositoryBasePort[RawStatementDTO, int], ABC
 ):
     """Port for persisting raw statement rows."""

--- a/infrastructure/models/abstract_statement_model.py
+++ b/infrastructure/models/abstract_statement_model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import PrimaryKeyConstraint, String
+from sqlalchemy import Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base_model import BaseModel
@@ -11,7 +11,7 @@ class AbstractStatementModel(BaseModel):
 
     __abstract__ = True
     __table_args__ = (
-        PrimaryKeyConstraint(
+        UniqueConstraint(
             "nsd",
             "company_name",
             "quarter",
@@ -19,17 +19,18 @@ class AbstractStatementModel(BaseModel):
             "grupo",
             "quadro",
             "account",
-            name="pk_statements_temp",
+            name="uq_statements_temp",
         ),
     )
 
-    nsd: Mapped[str] = mapped_column(String, primary_key=True)
-    company_name: Mapped[str | None] = mapped_column(primary_key=True)
-    quarter: Mapped[str | None] = mapped_column(primary_key=True)
-    version: Mapped[str | None] = mapped_column(primary_key=True)
-    grupo: Mapped[str] = mapped_column(primary_key=True)
-    quadro: Mapped[str] = mapped_column(primary_key=True)
-    account: Mapped[str] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    nsd: Mapped[str] = mapped_column(String)
+    company_name: Mapped[str | None] = mapped_column()
+    quarter: Mapped[str | None] = mapped_column()
+    version: Mapped[str | None] = mapped_column()
+    grupo: Mapped[str] = mapped_column()
+    quadro: Mapped[str] = mapped_column()
+    account: Mapped[str] = mapped_column()
     description: Mapped[str] = mapped_column()
     value: Mapped[float] = mapped_column()
 
@@ -50,4 +51,6 @@ class AbstractStatementModel(BaseModel):
         return {field: getattr(dto, field) for field in cls._FIELDS}
 
     def _dto_kwargs(self) -> dict:
-        return {field: getattr(self, field) for field in self._FIELDS}
+        data = {field: getattr(self, field) for field in self._FIELDS}
+        data["id"] = self.id
+        return data

--- a/infrastructure/models/company_data_model.py
+++ b/infrastructure/models/company_data_model.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import dataclasses
 import json
 from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import Boolean, DateTime
+from sqlalchemy import Boolean, DateTime, Integer, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.company_data_dto import CompanyDataDTO
@@ -17,8 +18,10 @@ class CompanyDataModel(BaseModel):
     """ORM adapter for the ``tbl_company`` table."""
 
     __tablename__ = "tbl_company"
+    __table_args__ = (UniqueConstraint("cvm_code", name="uq_company_cvm_code"),)
 
-    cvm_code: Mapped[str] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    cvm_code: Mapped[str] = mapped_column()
     issuing_company: Mapped[Optional[str]] = mapped_column()
     trading_name: Mapped[Optional[str]] = mapped_column()
     company_name: Mapped[Optional[str]] = mapped_column()
@@ -62,7 +65,8 @@ class CompanyDataModel(BaseModel):
 
     @staticmethod
     def from_dto(dto: CompanyDataRawDTO | CompanyDataDTO) -> "CompanyDataModel":
-        """Convert a ``CompanyDataRawDTO`` or ``CompanyDataDTO`` into ``CompanyDataModel``."""
+        """Convert a ``CompanyDataRawDTO`` or ``CompanyDataDTO`` into
+        ``CompanyDataModel``."""
 
         def attr(name: str):
             return getattr(dto, name, None)
@@ -179,4 +183,5 @@ class CompanyDataModel(BaseModel):
             listing_date=self.listing_date,
         )
 
-        return CompanyDataDTO.from_raw(raw)
+        dto = CompanyDataDTO.from_raw(raw)
+        return dataclasses.replace(dto, id=self.id)

--- a/infrastructure/models/nsd_model.py
+++ b/infrastructure/models/nsd_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, String
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.nsd_dto import NsdDTO
@@ -15,8 +15,10 @@ class NSDModel(BaseModel):
     """ORM model for the tbl_nsd table."""
 
     __tablename__ = "tbl_nsd"
+    __table_args__ = (UniqueConstraint("nsd", name="uq_nsd"),)
 
-    nsd: Mapped[str] = mapped_column(String, primary_key=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    nsd: Mapped[str] = mapped_column(String)
     company_name: Mapped[Optional[str]] = mapped_column()
     quarter: Mapped[Optional[datetime]] = mapped_column(DateTime)
     version: Mapped[Optional[str]] = mapped_column()
@@ -48,6 +50,7 @@ class NSDModel(BaseModel):
     def to_dto(self) -> NsdDTO:
         """Converts this ORM model back into a NsdDTO."""
         return NsdDTO(
+            id=self.id,
             nsd=self.nsd,
             company_name=self.company_name,
             quarter=self.quarter,

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Tuple
+from typing import List, Tuple
 
 from domain.dto.company_data_dto import CompanyDataDTO
 from domain.ports import LoggerPort, SqlAlchemyCompanyDataRepositoryPort
 from infrastructure.config import Config
+from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.company_data_model import CompanyDataModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
     SqlAlchemyRepositoryBase,
@@ -14,10 +15,11 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 
 
 class SqlAlchemyCompanyDataRepository(
-    SqlAlchemyRepositoryBase[CompanyDataDTO, str],
+    SqlAlchemyRepositoryBase[CompanyDataDTO, int],
     SqlAlchemyCompanyDataRepositoryPort,
 ):
-    """Concrete repository implementation for CompanyDataDTO using SQLite and SQLAlchemy.
+    """Concrete repository implementation for CompanyDataDTO using SQLite and
+    SQLAlchemy.
 
     This adapter implements the CompanyDataRepositoryPort interface, providing persistence
     operations for company data via a local SQLite database.
@@ -36,10 +38,30 @@ class SqlAlchemyCompanyDataRepository(
             config (Config): Application configuration with database connection details.
             logger (LoggerPort): Logging adapter used for tracking internal behavior.
         """
-        super().__init__(config, logger) 
+        super().__init__(config, logger)
 
         self.config = config
         self.logger = logger
+
+    def save_all(self, items: List[CompanyDataDTO]) -> None:
+        """Persist company DTOs using the surrogate id for updates."""
+        session = self.Session()
+        try:
+            model, _ = self.get_model_class()
+            flat_items = ListFlattener.flatten(items)
+            valid_items = [i for i in flat_items if i is not None]
+            for dto in valid_items:
+                obj = model.from_dto(dto)
+                existing = session.query(model).filter_by(cvm_code=obj.cvm_code).first()
+                if existing:
+                    obj.id = existing.id
+                session.merge(obj)
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
@@ -49,4 +71,4 @@ class SqlAlchemyCompanyDataRepository(
         Returns:
             type: The model class associated with this repository.
         """
-        return CompanyDataModel, (CompanyDataModel.cvm_code,)  # para PK simples
+        return CompanyDataModel, (CompanyDataModel.id,)

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import List, Set, Tuple
 
-from sqlalchemy.orm import Session
-
 from domain.dto.nsd_dto import NsdDTO
 from domain.ports import LoggerPort, NSDRepositoryPort
 from infrastructure.config import Config
@@ -15,7 +13,7 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 )
 
 
-class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, str], NSDRepositoryPort):
+class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, int], NSDRepositoryPort):
     """Concrete repository for NsdDTO using SQLite via SQLAlchemy."""
 
     def __init__(self, config: Config, logger: LoggerPort) -> None:
@@ -30,7 +28,7 @@ class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, str], NSDReposito
         Returns:
             type: The model class associated with this repository.
         """
-        return NSDModel, (NSDModel.nsd,)  # para PK simples
+        return NSDModel, (NSDModel.id,)
 
     def get_all_pending(
         self,
@@ -38,7 +36,8 @@ class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, str], NSDReposito
         valid_types: Set[str],
         exclude_nsd: Set[str],
     ) -> List[NsdDTO]:
-        """Retorna todos os NSDs que ainda não foram processados, filtrando por empresa, tipo e NSD.
+        """Retorna todos os NSDs que ainda não foram processados, filtrando por
+        empresa, tipo e NSD.
 
         Args:
             company_names (Set[str]): Conjunto de nomes de empresas válidas.
@@ -55,7 +54,4 @@ class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, str], NSDReposito
                 ~NSDModel.nsd.in_(exclude_nsd),
             )
             results = query.all()
-        return sorted(
-            [nsd.to_dto() for nsd in results],
-            key=lambda dto: int(dto.nsd)
-        )
+        return sorted([nsd.to_dto() for nsd in results], key=lambda dto: int(dto.nsd))

--- a/infrastructure/repositories/parsed_statement_repository.py
+++ b/infrastructure/repositories/parsed_statement_repository.py
@@ -12,7 +12,7 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 
 
 class SqlAlchemyParsedStatementRepository(
-    SqlAlchemyRepositoryBase[ParsedStatementDTO, str],
+    SqlAlchemyRepositoryBase[ParsedStatementDTO, int],
     SqlAlchemyParsedStatementRepositoryPort,
 ):
     """SQLite-backed repository for ``ParsedStatementDTO`` objects."""
@@ -29,12 +29,4 @@ class SqlAlchemyParsedStatementRepository(
         Returns:
             type: The model class associated with this repository.
         """
-        return ParsedStatementModel, (
-            ParsedStatementModel.nsd,
-            ParsedStatementModel.company_name,
-            ParsedStatementModel.quarter,
-            ParsedStatementModel.version,
-            ParsedStatementModel.grupo,
-            ParsedStatementModel.quadro,
-            ParsedStatementModel.account,
-        )
+        return ParsedStatementModel, (ParsedStatementModel.id,)

--- a/infrastructure/repositories/raw_statement_repository.py
+++ b/infrastructure/repositories/raw_statement_repository.py
@@ -12,7 +12,7 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 
 
 class SqlAlchemyRawStatementRepository(
-    SqlAlchemyRepositoryBase[RawStatementDTO, str],
+    SqlAlchemyRepositoryBase[RawStatementDTO, int],
     SqlAlchemyRawStatementRepositoryPort,
 ):
     """SQLite-backed repository for ``RawStatementDTO`` objects."""
@@ -29,12 +29,4 @@ class SqlAlchemyRawStatementRepository(
         Returns:
             type: The model class associated with this repository.
         """
-        return RawStatementModel, (
-            RawStatementModel.nsd,
-            RawStatementModel.company_name,
-            RawStatementModel.quarter,
-            RawStatementModel.version,
-            RawStatementModel.grupo,
-            RawStatementModel.quadro,
-            RawStatementModel.account,
-        )
+        return RawStatementModel, (RawStatementModel.id,)

--- a/legacy/backend/utils/config.py
+++ b/legacy/backend/utils/config.py
@@ -157,6 +157,7 @@ class Config:
             db_config["raw"]["filename"]: {
                 tbl_company_info: f"""
                     CREATE TABLE IF NOT EXISTS {tbl_company_info} (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
                         cvm_code TEXT,
                         ticker TEXT,
                         company_name TEXT,
@@ -189,13 +190,13 @@ class Config:
                         has_quotation TEXT,
                         has_emissions TEXT,
                         has_bdr TEXT,
-
-                        PRIMARY KEY (company_name)
+                        UNIQUE(company_name)
                     );
                     CREATE INDEX IF NOT EXISTS idx_company_info ON {tbl_company_info} (company_name);
                 """,
                 tbl_nsd: f"""
                     CREATE TABLE IF NOT EXISTS {tbl_nsd} (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
                         nsd INTEGER,
                         company_name TEXT,
                         quarter TEXT,
@@ -206,8 +207,8 @@ class Config:
                         responsible_auditor TEXT,
                         protocol TEXT,
                         sent_date TEXT,
-                        reason TEXT, 
-                        PRIMARY KEY (nsd)
+                        reason TEXT,
+                        UNIQUE(nsd)
                     );
                     CREATE INDEX IF NOT EXISTS idx_nsd ON {tbl_nsd} (nsd);
                 """,
@@ -363,7 +364,8 @@ class Config:
         }
 
     def _find_heaviest_table(self, db_filepath, sample_size=10_000):
-        """Encontra a tabela com linhas mais pesadas para basear o chunk_size."""
+        """Encontra a tabela com linhas mais pesadas para basear o
+        chunk_size."""
         heaviest_table = None
         max_memory_per_row = 1  # fallback seguro
 
@@ -649,19 +651,15 @@ class Config:
             "segmentEng": "segment_eng",
             "activity": "activity",
             "describle_category_bvmf": "describle_category_bvmf",
-
             "last_date": "last_date",
             "dateListing": "date_listing",
             "date_quotation": "date_quotation",
-
             "cnpj": "cnpj",
             "website": "website",
-
             "registrar": "registrar",
             "main_registrar": "main_registrar",
             "status": "status",
             "type": "type",
-
             "marketIndicator": "market_indicator",
             "typeBDR": "type_bdr",
             "has_quotation": "has_quotation",

--- a/tests/application/test_statement_fetch_service.py
+++ b/tests/application/test_statement_fetch_service.py
@@ -62,6 +62,6 @@ def test_fetch_statements_calls_usecase(monkeypatch):
     result = service.fetch_statements(save_callback="cb", threshold=5)
 
     mock_usecase_inst.fetch_statement_rows.assert_called_once_with(
-        batch_rows=targets, save_callback="cb", threshold=5
+        targets=targets, save_callback="cb", threshold=5
     )
     assert result == mock_usecase_inst.fetch_statement_rows.return_value


### PR DESCRIPTION
## Summary
- add `id` columns with autoincrement to ORM models
- keep composite uniqueness via `UniqueConstraint`
- propagate optional `id` field to DTOs
- update repository generics and add `get_page_after`
- adjust company repo save logic for surrogate ids
- fix statement fetch service test
- update legacy SQL table definitions

## Testing
- `ruff format domain infrastructure tests legacy`
- `ruff check domain infrastructure tests legacy --fix`
- `pydocstyle --convention=google domain infrastructure tests legacy`
- `docformatter --in-place --recursive domain infrastructure tests legacy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be964017c832ebe56729002086b9f