### PR TITLE
Implement hash-based statement transformation

### DIFF
--- a/application/services/__init__.py
+++ b/application/services/__init__.py
@@ -2,10 +2,12 @@ from .company_data_service import CompanyDataService
 from .nsd_service import NsdService
 from .statement_fetch_service import StatementFetchService
 from .statement_parse_service import StatementParseService
+from .statement_transform_service import StatementTransformService
 
 __all__ = [
     "CompanyDataService",
     "NsdService",
     "StatementFetchService",
     "StatementParseService",
+    "StatementTransformService",
 ]

--- a/application/services/statement_transform_service.py
+++ b/application/services/statement_transform_service.py
@@ -1,0 +1,67 @@
+"""Service to batch-transform raw statements into parsed rows."""
+
+from __future__ import annotations
+
+from typing import List
+
+from application.usecases.transform_statements import TransformStatementsUseCase
+from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.ports import (
+    LoggerPort,
+    SqlAlchemyParsedStatementRepositoryPort,
+    SqlAlchemyRawStatementRepositoryPort,
+)
+from domain.utils import compute_hash
+from infrastructure.config import Config
+from infrastructure.transformers import (
+    IntelStatementTransformerAdapter,
+    MathStatementTransformerAdapter,
+)
+
+
+class StatementTransformService:
+    """Transform raw statement rows in company batches."""
+
+    def __init__(
+        self,
+        logger: LoggerPort,
+        raw_repo: SqlAlchemyRawStatementRepositoryPort,
+        parsed_repo: SqlAlchemyParsedStatementRepositoryPort,
+        config: Config,
+    ) -> None:
+        """Create service with repositories and configuration."""
+        self.logger = logger
+        self.raw_repo = raw_repo
+        self.parsed_repo = parsed_repo
+
+        math_transformer = MathStatementTransformerAdapter(config)
+        intel_transformer = IntelStatementTransformerAdapter(config)
+        self.transform_usecase = TransformStatementsUseCase(
+            math_transformer=math_transformer,
+            intel_transformer=intel_transformer,
+        )
+
+    def transform_all(self) -> None:
+        """Process raw rows one company at a time."""
+        company_keys = self.raw_repo.get_existing_by_columns("company_name")
+
+        for (company_name,) in company_keys:
+            raw_dtos: List[RawStatementDTO] = self.raw_repo.get_by_company_name(
+                company_name
+            )
+            current_hash = compute_hash(raw_dtos)
+
+            if self.parsed_repo.exists_with_hash(company_name, current_hash):
+                self.logger.log(f"[{company_name}] Already processed. Skipping.")
+                continue
+
+            try:
+                parsed_dtos = self.transform_usecase.execute(raw_dtos)
+                self.parsed_repo.replace_all_for_company(
+                    company_name, parsed_dtos, current_hash
+                )
+                self.logger.log(
+                    f"[{company_name}] Transformation completed.", level="info"
+                )
+            except Exception as exc:  # pragma: no cover - log and continue
+                self.logger.log(f"[{company_name}] Error: {exc}", level="error")

--- a/domain/dto/parsed_statement_dto.py
+++ b/domain/dto/parsed_statement_dto.py
@@ -1,3 +1,5 @@
+"""DTO for transformed statement rows."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -17,12 +19,12 @@ class ParsedStatementDTO:
     account: str
     description: str
     value: float
+    processing_hash: str = ""
     id: Optional[int] = None
 
     @staticmethod
     def from_dict(raw: dict) -> "ParsedStatementDTO":
         """Create ``ParsedStatementDTO`` from a raw dictionary."""
-
         nsd_raw = raw.get("nsd", "")
         if nsd_raw is None or not str(nsd_raw).isdigit():
             raise ValueError("Invalid NSD value")
@@ -38,5 +40,6 @@ class ParsedStatementDTO:
             account=str(raw.get("account", "")),
             description=str(raw.get("description", "")),
             value=float(raw.get("value", 0.0)),
+            processing_hash=str(raw.get("processing_hash", "")),
             id=None,
         )

--- a/domain/ports/parsed_statement_repository_port.py
+++ b/domain/ports/parsed_statement_repository_port.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import List
+
 from domain.dto import ParsedStatementDTO
 
 from .base_repository_port import SqlAlchemyRepositoryBasePort
@@ -9,3 +11,18 @@ class SqlAlchemyParsedStatementRepositoryPort(
     SqlAlchemyRepositoryBasePort[ParsedStatementDTO, int]
 ):
     """Port for persisting parsed statement rows."""
+
+    def exists_with_hash(self, company_name: str, hash_: str) -> bool:
+        """Return True when ``company_name`` has ``hash_`` persisted."""
+
+        raise NotImplementedError
+
+    def replace_all_for_company(
+        self,
+        company_name: str,
+        parsed_dtos: List[ParsedStatementDTO],
+        new_hash: str,
+    ) -> None:
+        """Replace all rows for ``company_name`` with ``parsed_dtos``."""
+
+        raise NotImplementedError

--- a/domain/ports/raw_statement_repository_port.py
+++ b/domain/ports/raw_statement_repository_port.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from typing import List
 
 from domain.dto.raw_statement_dto import RawStatementDTO
 
@@ -11,3 +12,8 @@ class SqlAlchemyRawStatementRepositoryPort(
     SqlAlchemyRepositoryBasePort[RawStatementDTO, int], ABC
 ):
     """Port for persisting raw statement rows."""
+
+    def get_by_company_name(self, company_name: str) -> List[RawStatementDTO]:
+        """Return all raw rows for ``company_name``."""
+
+        raise NotImplementedError

--- a/domain/utils/__init__.py
+++ b/domain/utils/__init__.py
@@ -2,5 +2,6 @@
 
 from .finance_utils import safe_divide
 from .math_utils import parse_quarter, quarter_index
+from .statement_hash import compute_hash
 
-__all__ = ["parse_quarter", "quarter_index", "safe_divide"]
+__all__ = ["parse_quarter", "quarter_index", "safe_divide", "compute_hash"]

--- a/domain/utils/statement_hash.py
+++ b/domain/utils/statement_hash.py
@@ -1,0 +1,25 @@
+"""Utilities for hashing statement data."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict
+from typing import List
+
+from domain.dto.raw_statement_dto import RawStatementDTO
+
+from .math_utils import parse_quarter
+
+
+def compute_hash(raw_dtos: List[RawStatementDTO]) -> str:
+    """Return SHA256 hash for ``raw_dtos`` sorted by account and date."""
+
+    def sort_key(dto: RawStatementDTO) -> tuple:
+        dt = parse_quarter(dto.quarter)
+        year = dt.year if dt else 0
+        quarter = dto.quarter or ""
+        return dto.account, year, quarter
+
+    sorted_dtos = sorted(raw_dtos, key=sort_key)
+    joined = "".join(str(asdict(dto)) for dto in sorted_dtos)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()

--- a/infrastructure/models/parsed_statement_model.py
+++ b/infrastructure/models/parsed_statement_model.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 
 from .abstract_statement_model import AbstractStatementModel
@@ -9,6 +12,10 @@ class ParsedStatementModel(AbstractStatementModel):
     """ORM model for parsed statement rows."""
 
     __tablename__ = "tbl_parsed_statements"
+
+    processing_hash: Mapped[str | None] = mapped_column(String, index=True)
+
+    _FIELDS = AbstractStatementModel._FIELDS + ("processing_hash",)
 
     @staticmethod
     def from_dto(dto: ParsedStatementDTO) -> "ParsedStatementModel":

--- a/infrastructure/repositories/parsed_statement_repository.py
+++ b/infrastructure/repositories/parsed_statement_repository.py
@@ -1,6 +1,9 @@
+"""SQLAlchemy adapter for parsed statement persistence."""
+
 from __future__ import annotations
 
-from typing import Tuple
+from dataclasses import replace
+from typing import List, Tuple
 
 from domain.dto import ParsedStatementDTO
 from domain.ports import LoggerPort, SqlAlchemyParsedStatementRepositoryPort
@@ -18,6 +21,7 @@ class SqlAlchemyParsedStatementRepository(
     """SQLite-backed repository for ``ParsedStatementDTO`` objects."""
 
     def __init__(self, config: Config, logger: LoggerPort) -> None:
+        """Initialize repository with ``config`` and ``logger``."""
         super().__init__(config, logger)
 
         self.config = config
@@ -30,3 +34,32 @@ class SqlAlchemyParsedStatementRepository(
             type: The model class associated with this repository.
         """
         return ParsedStatementModel, (ParsedStatementModel.id,)
+
+    def exists_with_hash(self, company_name: str, hash_: str) -> bool:
+        """Return True if ``company_name`` has rows with ``hash_``."""
+        with self.Session() as session:
+            query = session.query(ParsedStatementModel).filter(
+                ParsedStatementModel.company_name == company_name,
+                ParsedStatementModel.processing_hash == hash_,
+            )
+            return session.query(query.exists()).scalar()
+
+    def replace_all_for_company(
+        self,
+        company_name: str,
+        parsed_dtos: List[ParsedStatementDTO],
+        new_hash: str,
+    ) -> None:
+        """Replace parsed rows for ``company_name`` with ``parsed_dtos``."""
+        with self.Session() as session:
+            session.query(ParsedStatementModel).filter(
+                ParsedStatementModel.company_name == company_name
+            ).delete()
+            models = [
+                ParsedStatementModel.from_dto(
+                    replace(dto, processing_hash=new_hash, id=None)
+                )
+                for dto in parsed_dtos
+            ]
+            session.add_all(models)
+            session.commit()

--- a/infrastructure/repositories/raw_statement_repository.py
+++ b/infrastructure/repositories/raw_statement_repository.py
@@ -1,3 +1,5 @@
+"""SQLAlchemy adapter for raw statement persistence."""
+
 from __future__ import annotations
 
 from typing import Tuple
@@ -18,8 +20,8 @@ class SqlAlchemyRawStatementRepository(
     """SQLite-backed repository for ``RawStatementDTO`` objects."""
 
     def __init__(self, config: Config, logger: LoggerPort) -> None:
+        """Initialize repository with ``config`` and ``logger``."""
         super().__init__(config, logger)
-
         self.config = config
         self.logger = logger
 
@@ -30,3 +32,13 @@ class SqlAlchemyRawStatementRepository(
             type: The model class associated with this repository.
         """
         return RawStatementModel, (RawStatementModel.id,)
+
+    def get_by_company_name(self, company_name: str) -> list[RawStatementDTO]:
+        """Return raw statement rows for the given company."""
+        with self.Session() as session:
+            results = (
+                session.query(RawStatementModel)
+                .filter(RawStatementModel.company_name == company_name)
+                .all()
+            )
+            return [r.to_dto() for r in results]

--- a/tests/application/test_statement_fetch_service.py
+++ b/tests/application/test_statement_fetch_service.py
@@ -62,6 +62,6 @@ def test_fetch_statements_calls_usecase(monkeypatch):
     result = service.fetch_statements(save_callback="cb", threshold=5)
 
     mock_usecase_inst.fetch_statement_rows.assert_called_once_with(
-        targets=targets, save_callback="cb", threshold=5
+        batch_rows=targets, save_callback="cb", threshold=5
     )
     assert result == mock_usecase_inst.fetch_statement_rows.return_value

--- a/tests/domain/test_statement_hash.py
+++ b/tests/domain/test_statement_hash.py
@@ -1,0 +1,36 @@
+from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.utils.statement_hash import compute_hash
+
+
+def test_compute_hash_consistent_order():
+    rows = [
+        RawStatementDTO.from_dict(
+            {
+                "nsd": 1,
+                "company_name": "A",
+                "quarter": "2020-03-31",
+                "version": "1",
+                "grupo": "G",
+                "quadro": "Q",
+                "account": "01",
+                "description": "d1",
+                "value": 1,
+            }
+        ),
+        RawStatementDTO.from_dict(
+            {
+                "nsd": 2,
+                "company_name": "A",
+                "quarter": "2020-06-30",
+                "version": "1",
+                "grupo": "G",
+                "quadro": "Q",
+                "account": "02",
+                "description": "d2",
+                "value": 2,
+            }
+        ),
+    ]
+
+    reversed_rows = list(reversed(rows))
+    assert compute_hash(rows) == compute_hash(reversed_rows)

--- a/tests/infrastructure/test_parsed_statement_repository.py
+++ b/tests/infrastructure/test_parsed_statement_repository.py
@@ -1,0 +1,59 @@
+from sqlalchemy import text
+
+from domain.dto.parsed_statement_dto import ParsedStatementDTO
+from infrastructure.models.base_model import Base
+from infrastructure.repositories.parsed_statement_repository import (
+    SqlAlchemyParsedStatementRepository,
+)
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def test_replace_and_exists(SessionLocal, engine):
+    repo = SqlAlchemyParsedStatementRepository(
+        config=DummyConfig(), logger=DummyLogger()
+    )
+    repo.engine = engine
+    repo.Session = SessionLocal
+    Base.metadata.create_all(engine)
+
+    dto = ParsedStatementDTO(
+        nsd="1",
+        company_name="ACME",
+        quarter="2020-03-31",
+        version="1",
+        grupo="G",
+        quadro="Q",
+        account="01",
+        description="d",
+        value=1.0,
+        processing_hash="old",
+    )
+    repo.save_all([dto])
+
+    new_dto = ParsedStatementDTO(
+        nsd="2",
+        company_name="ACME",
+        quarter="2020-06-30",
+        version="1",
+        grupo="G",
+        quadro="Q",
+        account="02",
+        description="d",
+        value=2.0,
+        processing_hash="new",
+    )
+
+    repo.replace_all_for_company("ACME", [new_dto], "hash123")
+
+    assert repo.exists_with_hash("ACME", "hash123") is True
+
+    with engine.connect() as conn:
+        count = conn.execute(
+            text("SELECT COUNT(*) FROM tbl_parsed_statements")
+        ).scalar()
+        phash = conn.execute(
+            text("SELECT processing_hash FROM tbl_parsed_statements")
+        ).scalar()
+
+    assert count == 1
+    assert phash == "hash123"


### PR DESCRIPTION
## Summary
- add processing_hash to parsed statements
- compute SHA256 hashes for raw rows
- implement replace and exists methods on repositories
- implement StatementTransformService
- test hash calculations and repository logic

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c08156278832e8e58082d02d8aab4