### PR TITLE
Add missing quarters checker

### DIFF
--- a/domain/utils/__init__.py
+++ b/domain/utils/__init__.py
@@ -1,7 +1,13 @@
 """Domain utility helpers."""
 
 from .finance_utils import safe_divide
-from .math_utils import parse_quarter, quarter_index
+from .math_utils import find_missing_quarters, parse_quarter, quarter_index
 from .statement_hash import compute_hash
 
-__all__ = ["parse_quarter", "quarter_index", "safe_divide", "compute_hash"]
+__all__ = [
+    "parse_quarter",
+    "quarter_index",
+    "find_missing_quarters",
+    "safe_divide",
+    "compute_hash",
+]

--- a/domain/utils/math_utils.py
+++ b/domain/utils/math_utils.py
@@ -18,3 +18,51 @@ def parse_quarter(quarter: str | None) -> datetime | None:
 def quarter_index(dt: datetime) -> int:
     """Return quarter number (1-4) for ``dt``."""
     return (dt.month - 1) // 3 + 1
+
+
+def find_missing_quarters(dates: list[datetime]) -> list[datetime]:
+    """Return the expected quarter-end dates missing from ``dates``.
+
+    Parameters
+    ----------
+    dates:
+        Collection of datetimes representing quarter ends or arbitrary dates.
+
+    Returns
+    -------
+    list[datetime]
+        Quarter-end dates that should exist between the first and last provided
+        dates but are absent from ``dates``.
+    """
+
+    if not dates:
+        return []
+
+    unique_dates = sorted(set(dates))
+    start = unique_dates[0]
+    end = unique_dates[-1]
+
+    def to_quarter_end(dt: datetime) -> datetime:
+        month = dt.month
+        if month in (1, 2, 3):
+            return datetime(dt.year, 3, 31)
+        if month in (4, 5, 6):
+            return datetime(dt.year, 6, 30)
+        if month in (7, 8, 9):
+            return datetime(dt.year, 9, 30)
+        return datetime(dt.year, 12, 31)
+
+    expected: list[datetime] = []
+    y, m = start.year, to_quarter_end(start).month
+    current = datetime(y, m, 1)
+    while current <= end:
+        quarter_end = to_quarter_end(current)
+        expected.append(quarter_end)
+        next_month = current.month + 3
+        next_year = current.year + (next_month - 1) // 12
+        next_month = ((next_month - 1) % 12) + 1
+        current = datetime(next_year, next_month, 1)
+
+    actual_quarters = {to_quarter_end(dt) for dt in dates}
+
+    return [q for q in expected if q not in actual_quarters]

--- a/tests/domain/test_missing_quarters.py
+++ b/tests/domain/test_missing_quarters.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from domain.utils.math_utils import find_missing_quarters
+
+
+def test_find_missing_quarters_basic():
+    dates = [datetime(2020, 3, 31), datetime(2020, 12, 31)]
+    missing = find_missing_quarters(dates)
+    assert missing == [datetime(2020, 6, 30), datetime(2020, 9, 30)]
+
+
+def test_find_missing_quarters_unsorted_duplicates():
+    dates = [
+        datetime(2020, 12, 31),
+        datetime(2020, 3, 31),
+        datetime(2020, 6, 30),
+        datetime(2020, 3, 31),
+    ]
+    missing = find_missing_quarters(dates)
+    assert missing == [datetime(2020, 9, 30)]


### PR DESCRIPTION
## Summary
- add helper `find_missing_quarters` to detect gaps in quarter sequences
- export the helper from `domain.utils`
- test the new function

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687e4dae08f4832eb74e8220d05246f2