### PR TITLE
Move math target accounts to config

### DIFF
--- a/infrastructure/config/__init__.py
+++ b/infrastructure/config/__init__.py
@@ -1,3 +1,3 @@
-from .config import Config
+from .config import Config, math_target_accounts
 
-__all__ = ["Config"]
+__all__ = ["Config", "math_target_accounts"]

--- a/infrastructure/config/config.py
+++ b/infrastructure/config/config.py
@@ -9,9 +9,12 @@ from .paths import PathConfig, load_paths
 from .scraping import ScrapingConfig, load_scraping_config
 from .statements import StatementsConfig, load_statements_config
 from .transformers import (
+    MATH_TARGET_ACCOUNTS,
     TransformersConfig,
     load_transformers_config,
 )
+
+math_target_accounts = MATH_TARGET_ACCOUNTS
 
 
 class Config:

--- a/infrastructure/config/transformers.py
+++ b/infrastructure/config/transformers.py
@@ -5,6 +5,15 @@ from domain.utils import intel
 
 MATH_YEAR_END_PREFIXES: Tuple[str, ...] = ("3", "4")
 MATH_CUMULATIVE_PREFIXES: Tuple[str, ...] = ("6", "7")
+MATH_TARGET_ACCOUNTS: Tuple[str, ...] = (
+    "00.01.01",
+    "1",
+    "2",
+    "3.01",
+    "4.01",
+    "6.01",
+    "7.01",
+)
 INTEL_YEAR_END_PREFIXES: Tuple[str, ...] = ("03", "04")
 INTEL_CUMULATIVE_PREFIXES: Tuple[str, ...] = ("06", "07")
 INTEL_SECTION_CRITERIA: Tuple[Tuple[str, Iterable[dict]], ...] = (
@@ -27,6 +36,9 @@ class TransformersConfig:
     math_cumulative_prefixes: Tuple[str, ...] = field(
         default_factory=lambda: MATH_CUMULATIVE_PREFIXES
     )
+    math_target_accounts: Tuple[str, ...] = field(
+        default_factory=lambda: MATH_TARGET_ACCOUNTS
+    )
     intel_year_end_prefixes: Tuple[str, ...] = field(
         default_factory=lambda: INTEL_YEAR_END_PREFIXES
     )
@@ -43,6 +55,7 @@ def load_transformers_config() -> TransformersConfig:
     return TransformersConfig(
         math_year_end_prefixes=MATH_YEAR_END_PREFIXES,
         math_cumulative_prefixes=MATH_CUMULATIVE_PREFIXES,
+        math_target_accounts=MATH_TARGET_ACCOUNTS,
         intel_year_end_prefixes=INTEL_YEAR_END_PREFIXES,
         intel_cumulative_prefixes=INTEL_CUMULATIVE_PREFIXES,
         intel_section_criteria=INTEL_SECTION_CRITERIA,

--- a/infrastructure/models/base_model.py
+++ b/infrastructure/models/base_model.py
@@ -5,3 +5,7 @@ class BaseModel(DeclarativeBase):
     """Base class for all ORM models."""
 
     pass
+
+
+# Alias used in tests and other modules
+Base = BaseModel

--- a/infrastructure/transformers/math_statement_transformer.py
+++ b/infrastructure/transformers/math_statement_transformer.py
@@ -16,6 +16,7 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
     def __init__(self, config: Config) -> None:
         self.year_end_prefixes = tuple(config.transformers.math_year_end_prefixes)
         self.cumulative_prefixes = tuple(config.transformers.math_cumulative_prefixes)
+        self.target_accounts = set(config.transformers.math_target_accounts)
 
     def _group_key(self, row: RawStatementDTO, dt: datetime | None) -> Tuple:
         year = dt.year if dt else 0
@@ -27,6 +28,7 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
             str(year),
             row.version or "",
         )
+
     def _parse(self, quarter: str | None) -> datetime | None:
         if not quarter:
             return None
@@ -37,7 +39,8 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
 
     def transform(self, rows: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         groups: Dict[
-            Tuple[str, str, str, str, str, str], List[Tuple[datetime | None, RawStatementDTO]]
+            Tuple[str, str, str, str, str, str],
+            List[Tuple[datetime | None, RawStatementDTO]],
         ] = {}
         for row in rows:
             dt = self._parse(row.quarter)
@@ -48,7 +51,9 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
         quarters = extract_sorted_quarters(groups)
         missing = detect_missing_quarters(quarters)
         if missing:
-            print("Quarters ausentes na base: faça uma busca no nsd para verificar se estão disponíveis")
+            print(
+                "Quarters ausentes na base: faça uma busca no nsd para verificar se estão disponíveis"
+            )
             for q in missing:
                 print(" -", q.strftime("%Y-%m-%d"))
 
@@ -56,20 +61,27 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
         for i, group in enumerate(groups.items()):
             (company, account, grupo, quadro, year, version), items = group
 
-            target_accounts = ['00.01.01', '1', '2', '3.01', '4.01', '6.01', '7.01']
-            if account in target_accounts:
-                if len(items)>4:
-                    print(f"Sheet {i}/{len(groups)} de tamanho maior que 4 itens, possíveis duplicatas\n{items}")
+            if account in self.target_accounts:
+                if len(items) > 4:
+                    print(
+                        f"Sheet {i}/{len(groups)} de tamanho maior que 4 itens, possíveis duplicatas\n{items}"
+                    )
                 elif len(items) == 1:
-                    print(f"Sheet {i}/{len(groups)} de tamanho {len(items)}, único demonstrativo {items[0][1].quarter} {year} {version} - {grupo} {quadro} {account}")
+                    print(
+                        f"Sheet {i}/{len(groups)} de tamanho {len(items)}, único demonstrativo {items[0][1].quarter} {year} {version} - {grupo} {quadro} {account}"
+                    )
                     pass
                 elif len(items) == 4:
-                    print(f"Sheet {i}/{len(groups)} Ano cheio {len(items)} items {year} {version} - {grupo} {quadro} {account}")
+                    print(
+                        f"Sheet {i}/{len(groups)} Ano cheio {len(items)} items {year} {version} - {grupo} {quadro} {account}"
+                    )
                     pass
                 else:
                     print(f"Sheet de tamanho {len(items)}, o que está faltando?")
                     for item in items:
-                        print(f"{i}/{len(groups)} - {item[1].version} item {item[1].quarter}, grupo {item[1].grupo} account {item[1].account}")
+                        print(
+                            f"{i}/{len(groups)} - {item[1].version} item {item[1].quarter}, grupo {item[1].grupo} account {item[1].account}"
+                        )
 
             items.sort(key=lambda x: (x[0] or datetime.min))
             if account.startswith(self.year_end_prefixes):

--- a/setup_env.py
+++ b/setup_env.py
@@ -1,5 +1,7 @@
-import os
+"""Setup environment for the project."""
+
 import json
+import os
 import platform
 
 # Detecta o sistema operacional
@@ -19,9 +21,7 @@ else:
 os.makedirs(vscode_dir, exist_ok=True)
 
 # Monta o dicionário de configuração
-settings = {
-    "python.defaultInterpreterPath": python_path
-}
+settings = {"python.defaultInterpreterPath": python_path}
 
 # Salva o settings.json
 with open(settings_path, "w") as f:


### PR DESCRIPTION
## Summary
- provide math transformer target accounts via the config
- expose `math_target_accounts` from the config package
- consume configured target accounts in `MathStatementTransformerAdapter`
- add docstring for environment setup script
- export Base alias for tests

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6165aab8832ea983c12bf8a1c2d6