### PR TITLE
Add latest-version filtering to statement transform

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -6,6 +6,7 @@ In scope:
 - NSD (sequential document) synchronization.
 - Mapping DTOs to ORM models via repositories.
 - Service orchestration using use cases.
+- Duplicate raw statement versions are resolved before transformation.
 
 Out of scope:
 

--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -7,6 +7,7 @@ from typing import List
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.utils.version_utils import filter_latest_versions
 
 
 class TransformStatementsUseCase:
@@ -22,6 +23,7 @@ class TransformStatementsUseCase:
 
     def execute(self, raw_dtos: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         """Run transformation pipeline for ``raw_dtos``."""
-        stage1 = self.math_transformer.transform(raw_dtos)
-        stage2 = self.intel_transformer.transform(stage1)  # type: ignore[arg-type]
-        return stage2
+        stage1 = filter_latest_versions(raw_dtos)
+        stage2 = self.math_transformer.transform(stage1)
+        stage3 = self.intel_transformer.transform(stage2)  # type: ignore[arg-type]
+        return stage3

--- a/domain/utils/__init__.py
+++ b/domain/utils/__init__.py
@@ -3,6 +3,7 @@
 from .finance_utils import safe_divide
 from .math_utils import find_missing_quarters, parse_quarter, quarter_index
 from .statement_hash import compute_hash
+from .version_utils import filter_latest_versions
 
 __all__ = [
     "parse_quarter",
@@ -10,4 +11,5 @@ __all__ = [
     "find_missing_quarters",
     "safe_divide",
     "compute_hash",
+    "filter_latest_versions",
 ]

--- a/domain/utils/version_utils.py
+++ b/domain/utils/version_utils.py
@@ -1,0 +1,35 @@
+"""Utilities for handling statement versioning."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from domain.dto.raw_statement_dto import RawStatementDTO
+
+
+def _version_number(version: str | None) -> int:
+    """Return numeric part of ``version`` or ``-1`` when invalid."""
+    if not version:
+        return -1
+    digits = "".join(ch for ch in version if ch.isdigit())
+    return int(digits) if digits.isdigit() else -1
+
+
+def filter_latest_versions(rows: List[RawStatementDTO]) -> List[RawStatementDTO]:
+    """Return only the latest version per quarter from ``rows``."""
+    groups: Dict[Tuple[str, str, str, str, str], List[RawStatementDTO]] = {}
+    for row in rows:
+        key = (
+            row.company_name or "",
+            row.account,
+            row.grupo,
+            row.quadro,
+            row.quarter or "",
+        )
+        groups.setdefault(key, []).append(row)
+
+    result: List[RawStatementDTO] = []
+    for candidates in groups.values():
+        latest = max(candidates, key=lambda r: _version_number(r.version))
+        result.append(latest)
+    return result

--- a/tests/domain/utils/test_version_utils.py
+++ b/tests/domain/utils/test_version_utils.py
@@ -1,0 +1,56 @@
+from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.utils.version_utils import filter_latest_versions
+
+
+def test_filter_latest_versions_keeps_highest():
+    rows = [
+        RawStatementDTO.from_dict(
+            {
+                "nsd": 1,
+                "company_name": "ACME",
+                "quarter": "2020-03-31",
+                "version": "V1",
+                "grupo": "G",
+                "quadro": "Q",
+                "account": "01",
+                "description": "d1",
+                "value": 1,
+            }
+        ),
+        RawStatementDTO.from_dict(
+            {
+                "nsd": 2,
+                "company_name": "ACME",
+                "quarter": "2020-03-31",
+                "version": "V2",
+                "grupo": "G",
+                "quadro": "Q",
+                "account": "01",
+                "description": "d2",
+                "value": 2,
+            }
+        ),
+        RawStatementDTO.from_dict(
+            {
+                "nsd": 3,
+                "company_name": "ACME",
+                "quarter": "2020-06-30",
+                "version": "V1",
+                "grupo": "G",
+                "quadro": "Q",
+                "account": "01",
+                "description": "d3",
+                "value": 3,
+            }
+        ),
+    ]
+
+    result = filter_latest_versions(rows)
+    mapping = {
+        (r.company_name, r.account, r.grupo, r.quadro, r.quarter): r.version
+        for r in result
+    }
+
+    assert mapping[("ACME", "01", "G", "Q", "2020-03-31")] == "V2"
+    assert mapping[("ACME", "01", "G", "Q", "2020-06-30")] == "V1"
+    assert len(result) == 2


### PR DESCRIPTION
## Summary
- filter latest statement versions in new `version_utils`
- expose `filter_latest_versions` from domain utilities
- deduplicate raw statements before math and intel transforms
- document version handling in SCOPE
- test version filtering logic

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6bba47fc832eb09a42fc21e3fef1