### PR TITLE
Move quarter completeness validation into usecase

### DIFF
--- a/application/services/statement_transform_service.py
+++ b/application/services/statement_transform_service.py
@@ -39,6 +39,7 @@ class StatementTransformService:
         self.transform_usecase = TransformStatementsUseCase(
             math_transformer=math_transformer,
             intel_transformer=intel_transformer,
+            logger=self.logger,
         )
 
     def transform_all(self) -> None:

--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -7,6 +7,8 @@ from typing import List
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.ports import LoggerPort
+from domain.utils.validation_utils import validate_quarter_completeness
 from domain.utils.version_utils import filter_latest_versions
 
 
@@ -17,12 +19,22 @@ class TransformStatementsUseCase:
         self,
         math_transformer: StatementTransformerPort,
         intel_transformer: StatementTransformerPort,
+        logger: LoggerPort,
     ) -> None:
+        """Store dependencies for the statement transformation pipeline."""
         self.math_transformer = math_transformer
         self.intel_transformer = intel_transformer
+        self.logger = logger
 
     def execute(self, raw_dtos: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         """Run transformation pipeline for ``raw_dtos``."""
+        missing = validate_quarter_completeness(raw_dtos)
+        if missing:
+            self.logger.log(
+                f"Missing quarters in raw data: {[d.strftime('%Y-%m-%d') for d in missing]}",
+                level="warning",
+            )
+
         stage1 = filter_latest_versions(raw_dtos)
         stage2 = self.math_transformer.transform(stage1)
         stage3 = self.intel_transformer.transform(stage2)  # type: ignore[arg-type]

--- a/domain/utils/__init__.py
+++ b/domain/utils/__init__.py
@@ -3,6 +3,7 @@
 from .finance_utils import safe_divide
 from .math_utils import find_missing_quarters, parse_quarter, quarter_index
 from .statement_hash import compute_hash
+from .validation_utils import validate_quarter_completeness
 from .version_utils import filter_latest_versions
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "safe_divide",
     "compute_hash",
     "filter_latest_versions",
+    "validate_quarter_completeness",
 ]

--- a/domain/utils/validation_utils.py
+++ b/domain/utils/validation_utils.py
@@ -1,0 +1,27 @@
+"""Validation helpers for raw statement rows."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.utils.math_utils import detect_missing_quarters, extract_sorted_quarters
+
+
+def validate_quarter_completeness(rows: List[RawStatementDTO]) -> List[datetime]:
+    """Return any missing quarter-end dates across ``rows``."""
+    groups = {}
+    for row in rows:
+        dt = datetime.fromisoformat(row.quarter) if row.quarter else None
+        key = (
+            row.company_name or "",
+            row.account,
+            row.grupo,
+            row.quadro,
+            row.version or "",
+        )
+        groups.setdefault(key, []).append((dt, row))
+
+    quarters = extract_sorted_quarters(groups)
+    return detect_missing_quarters(quarters)

--- a/infrastructure/transformers/math_statement_transformer.py
+++ b/infrastructure/transformers/math_statement_transformer.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Tuple
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
-from domain.utils.math_utils import detect_missing_quarters, extract_sorted_quarters
 from infrastructure.config import Config
 
 
@@ -46,16 +45,6 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
             dt = self._parse(row.quarter)
             key = self._group_key(row, dt)
             groups.setdefault(key, []).append((dt, row))
-
-        # Verificação de completude dos quarters
-        quarters = extract_sorted_quarters(groups)
-        missing = detect_missing_quarters(quarters)
-        if missing:
-            print(
-                "Quarters ausentes na base: faça uma busca no nsd para verificar se estão disponíveis"
-            )
-            for q in missing:
-                print(" -", q.strftime("%Y-%m-%d"))
 
         result: List[ParsedStatementDTO] = []
         for i, group in enumerate(groups.items()):

--- a/tests/application/test_statement_transform_service.py
+++ b/tests/application/test_statement_transform_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 from application.services.statement_transform_service import StatementTransformService
 from domain.dto.raw_statement_dto import RawStatementDTO
@@ -46,6 +46,12 @@ def test_transform_all_processes_new_data(monkeypatch):
         raw_repo=raw_repo,
         parsed_repo=parsed_repo,
         config=DummyConfig(),
+    )
+
+    usecase_cls.assert_called_once_with(
+        math_transformer=ANY,
+        intel_transformer=ANY,
+        logger=service.logger,
     )
 
     service.transform_all()

--- a/tests/application/test_transform_statements_use_case.py
+++ b/tests/application/test_transform_statements_use_case.py
@@ -1,0 +1,68 @@
+from unittest.mock import MagicMock
+
+from application.ports import StatementTransformerPort
+from application.usecases.transform_statements import TransformStatementsUseCase
+from domain.dto.parsed_statement_dto import ParsedStatementDTO
+from domain.dto.raw_statement_dto import RawStatementDTO
+
+
+class DummyTransformer(StatementTransformerPort):
+    def transform(self, rows):
+        return [
+            ParsedStatementDTO(
+                nsd=r.nsd,
+                company_name=r.company_name,
+                quarter=r.quarter,
+                version=r.version,
+                grupo=r.grupo,
+                quadro=r.quadro,
+                account=r.account,
+                description=r.description,
+                value=r.value,
+            )
+            for r in rows
+        ]
+
+
+def _make_row(quarter: str, version: str) -> RawStatementDTO:
+    return RawStatementDTO(
+        nsd="1",
+        company_name="ACME",
+        quarter=quarter,
+        version=version,
+        grupo="G",
+        quadro="Q",
+        account="ACC",
+        description="",
+        value=0.0,
+    )
+
+
+def test_usecase_logs_missing_and_deduplicates():
+    logger = MagicMock()
+    usecase = TransformStatementsUseCase(
+        math_transformer=DummyTransformer(),
+        intel_transformer=DummyTransformer(),
+        logger=logger,
+    )
+
+    rows = [
+        _make_row("2021-03-31", "V1"),
+        _make_row("2021-03-31", "V2"),
+        _make_row("2021-09-30", "V1"),
+        _make_row("2021-09-30", "V2"),
+        _make_row("2021-12-31", "V1"),
+    ]
+
+    result = usecase.execute(rows)
+
+    logger.log.assert_called_with(
+        "Missing quarters in raw data: ['2021-06-30']",
+        level="warning",
+    )
+
+    mapping = {(r.quarter, r.version) for r in result}
+    assert ("2021-03-31", "V2") in mapping
+    assert ("2021-09-30", "V2") in mapping
+    assert ("2021-12-31", "V1") in mapping
+    assert len(result) == 3

--- a/tests/domain/utils/test_validation_utils.py
+++ b/tests/domain/utils/test_validation_utils.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.utils.validation_utils import validate_quarter_completeness
+
+
+def _make_row(quarter: str, version: str) -> RawStatementDTO:
+    return RawStatementDTO(
+        nsd="1",
+        company_name="ACME",
+        quarter=quarter,
+        version=version,
+        grupo="G",
+        quadro="Q",
+        account="ACC",
+        description="",
+        value=0.0,
+    )
+
+
+def test_validate_quarter_completeness_detects_gap():
+    rows = [
+        _make_row("2021-03-31", "V1"),
+        _make_row("2021-03-31", "V2"),
+        _make_row("2021-09-30", "V1"),
+        _make_row("2021-12-31", "V1"),
+    ]
+
+    missing = validate_quarter_completeness(rows)
+
+    assert missing == [datetime(2021, 6, 30)]


### PR DESCRIPTION
## Summary
- add new `validate_quarter_completeness` utility
- validate quarters inside `TransformStatementsUseCase` and log warning
- remove validation logic from `MathStatementTransformerAdapter`
- update service wiring to pass logger to the use case
- add unit tests for the validator and the use case
- adjust existing service tests

## Testing
- `ruff format application/services/statement_transform_service.py application/usecases/transform_statements.py domain/utils/__init__.py infrastructure/transformers/math_statement_transformer.py tests/application/test_statement_transform_service.py tests/application/test_transform_statements_use_case.py tests/domain/utils/test_validation_utils.py domain/utils/validation_utils.py`
- `ruff check application/services/statement_transform_service.py application/usecases/transform_statements.py domain/utils/__init__.py infrastructure/transformers/math_statement_transformer.py tests/application/test_statement_transform_service.py tests/application/test_transform_statements_use_case.py tests/domain/utils/test_validation_utils.py domain/utils/validation_utils.py --fix`
- `pydocstyle --convention=google application/usecases/transform_statements.py domain/utils/validation_utils.py`
- `docformatter --in-place application/usecases/transform_statements.py domain/utils/validation_utils.py tests/application/test_transform_statements_use_case.py tests/domain/utils/test_validation_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b73420368832e9318daf8dcceef48