### PR TITLE
Fix per-version quarter validation

### DIFF
--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -28,10 +28,10 @@ class TransformStatementsUseCase:
 
     def execute(self, raw_dtos: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         """Run transformation pipeline for ``raw_dtos``."""
-        missing = validate_quarter_completeness(raw_dtos)
-        if missing:
+        missing_map = validate_quarter_completeness(raw_dtos)
+        for key, miss in missing_map.items():
             self.logger.log(
-                f"Missing quarters in raw data: {[d.strftime('%Y-%m-%d') for d in missing]}",
+                f"Group {key} is missing quarters: {[d.strftime('%Y-%m-%d') for d in miss]}",
                 level="warning",
             )
 

--- a/domain/utils/validation_utils.py
+++ b/domain/utils/validation_utils.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List
+from typing import Dict, List, Tuple
 
 from domain.dto.raw_statement_dto import RawStatementDTO
-from domain.utils.math_utils import detect_missing_quarters, extract_sorted_quarters
+from domain.utils.math_utils import detect_missing_quarters
 
 
-def validate_quarter_completeness(rows: List[RawStatementDTO]) -> List[datetime]:
-    """Return any missing quarter-end dates across ``rows``."""
-    groups = {}
+def validate_quarter_completeness(
+    rows: List[RawStatementDTO],
+) -> Dict[Tuple[str, str, str, str, str], List[datetime]]:
+    """Return missing quarters for each distinct statement group."""
+    groups: Dict[Tuple[str, str, str, str, str], List[datetime]] = {}
     for row in rows:
-        dt = datetime.fromisoformat(row.quarter) if row.quarter else None
+        if not row.quarter:
+            continue
+        dt = datetime.fromisoformat(row.quarter)
         key = (
             row.company_name or "",
             row.account,
@@ -21,7 +25,13 @@ def validate_quarter_completeness(rows: List[RawStatementDTO]) -> List[datetime]
             row.quadro,
             row.version or "",
         )
-        groups.setdefault(key, []).append((dt, row))
+        groups.setdefault(key, []).append(dt)
 
-    quarters = extract_sorted_quarters(groups)
-    return detect_missing_quarters(quarters)
+    missing_by_group: Dict[Tuple[str, str, str, str, str], List[datetime]] = {}
+    for key, dts in groups.items():
+        unique_sorted = sorted(set(dts))
+        miss = detect_missing_quarters(unique_sorted)
+        if miss:
+            missing_by_group[key] = miss
+
+    return missing_by_group

--- a/infrastructure/transformers/math_statement_transformer.py
+++ b/infrastructure/transformers/math_statement_transformer.py
@@ -1,3 +1,5 @@
+"""Adapters to perform math transformations on statement rows."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -13,6 +15,7 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
     """Adjust quarterly statement values."""
 
     def __init__(self, config: Config) -> None:
+        """Store transformation rules from ``config``."""
         self.year_end_prefixes = tuple(config.transformers.math_year_end_prefixes)
         self.cumulative_prefixes = tuple(config.transformers.math_cumulative_prefixes)
         self.target_accounts = set(config.transformers.math_target_accounts)
@@ -37,6 +40,7 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
             return None
 
     def transform(self, rows: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
+        """Convert raw rows into parsed ones applying math adjustments."""
         groups: Dict[
             Tuple[str, str, str, str, str, str],
             List[Tuple[datetime | None, RawStatementDTO]],
@@ -49,28 +53,6 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
         result: List[ParsedStatementDTO] = []
         for i, group in enumerate(groups.items()):
             (company, account, grupo, quadro, year, version), items = group
-
-            if account in self.target_accounts:
-                if len(items) > 4:
-                    print(
-                        f"Sheet {i}/{len(groups)} de tamanho maior que 4 itens, possíveis duplicatas\n{items}"
-                    )
-                elif len(items) == 1:
-                    print(
-                        f"Sheet {i}/{len(groups)} de tamanho {len(items)}, único demonstrativo {items[0][1].quarter} {year} {version} - {grupo} {quadro} {account}"
-                    )
-                    pass
-                elif len(items) == 4:
-                    print(
-                        f"Sheet {i}/{len(groups)} Ano cheio {len(items)} items {year} {version} - {grupo} {quadro} {account}"
-                    )
-                    pass
-                else:
-                    print(f"Sheet de tamanho {len(items)}, o que está faltando?")
-                    for item in items:
-                        print(
-                            f"{i}/{len(groups)} - {item[1].version} item {item[1].quarter}, grupo {item[1].grupo} account {item[1].account}"
-                        )
 
             items.sort(key=lambda x: (x[0] or datetime.min))
             if account.startswith(self.year_end_prefixes):

--- a/tests/application/test_transform_statements_use_case.py
+++ b/tests/application/test_transform_statements_use_case.py
@@ -56,10 +56,13 @@ def test_usecase_logs_missing_and_deduplicates():
 
     result = usecase.execute(rows)
 
-    logger.log.assert_called_with(
-        "Missing quarters in raw data: ['2021-06-30']",
-        level="warning",
-    )
+    expected = {
+        "Group ('ACME', 'ACC', 'G', 'Q', 'V1') is missing quarters: ['2021-06-30']",
+        "Group ('ACME', 'ACC', 'G', 'Q', 'V2') is missing quarters: ['2021-06-30']",
+    }
+
+    actual = {args[0] for args, kwargs in logger.log.call_args_list}
+    assert actual == expected
 
     mapping = {(r.quarter, r.version) for r in result}
     assert ("2021-03-31", "V2") in mapping

--- a/tests/domain/utils/test_validation_utils.py
+++ b/tests/domain/utils/test_validation_utils.py
@@ -18,14 +18,16 @@ def _make_row(quarter: str, version: str) -> RawStatementDTO:
     )
 
 
-def test_validate_quarter_completeness_detects_gap():
+def test_validate_quarter_completeness_detects_gap_per_group():
     rows = [
         _make_row("2021-03-31", "V1"),
-        _make_row("2021-03-31", "V2"),
-        _make_row("2021-09-30", "V1"),
         _make_row("2021-12-31", "V1"),
     ]
 
-    missing = validate_quarter_completeness(rows)
+    missing_map = validate_quarter_completeness(rows)
+    key = ("ACME", "ACC", "G", "Q", "V1")
 
-    assert missing == [datetime(2021, 6, 30)]
+    assert missing_map[key] == [
+        datetime(2021, 6, 30),
+        datetime(2021, 9, 30),
+    ]


### PR DESCRIPTION
## Summary
- update `validate_quarter_completeness` to check missing quarters per group
- drop debug prints from the math transformer
- log missing quarters for each group inside `TransformStatementsUseCase`
- adjust tests for new behaviour

## Testing
- `ruff format application/usecases/transform_statements.py domain/utils/validation_utils.py infrastructure/transformers/math_statement_transformer.py tests/application/test_transform_statements_use_case.py tests/domain/utils/test_validation_utils.py`
- `ruff check application/usecases/transform_statements.py domain/utils/validation_utils.py infrastructure/transformers/math_statement_transformer.py tests/application/test_transform_statements_use_case.py tests/domain/utils/test_validation_utils.py --fix`
- `pydocstyle --convention=google application/usecases/transform_statements.py domain/utils/validation_utils.py infrastructure/transformers/math_statement_transformer.py tests/application/test_transform_statements_use_case.py tests/domain/utils/test_validation_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b89a0bf78832eafaa83ccc5c5eb30