### PR TITLE
Add quarter completeness validation

### DIFF
--- a/application/services/statement_transform_service.py
+++ b/application/services/statement_transform_service.py
@@ -39,6 +39,7 @@ class StatementTransformService:
         self.transform_usecase = TransformStatementsUseCase(
             math_transformer=math_transformer,
             intel_transformer=intel_transformer,
+            config=config,
             logger=self.logger,
         )
 

--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -19,20 +19,26 @@ class TransformStatementsUseCase:
         self,
         math_transformer: StatementTransformerPort,
         intel_transformer: StatementTransformerPort,
+        config,
         logger: LoggerPort,
     ) -> None:
         """Store dependencies for the statement transformation pipeline."""
         self.math_transformer = math_transformer
         self.intel_transformer = intel_transformer
+        self.config = config
         self.logger = logger
 
     def execute(self, raw_dtos: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         """Run transformation pipeline for ``raw_dtos``."""
-        missing_map = validate_quarter_completeness(raw_dtos)
+        targets = set(self.config.transformers.math_target_accounts)
+        validation_candidates = [r for r in raw_dtos if r.account in targets]
+
+        missing_map = validate_quarter_completeness(validation_candidates)
         for key, miss in missing_map.items():
-            self.logger.log(
-                f"Group {key} is missing quarters: {[d.strftime('%Y-%m-%d') for d in miss]}",
-                level="warning",
+            self.logger.warning(
+                "Group %s missing quarters: %s",
+                key,
+                [d.strftime("%Y-%m-%d") for d in miss],
             )
 
         stage1 = filter_latest_versions(raw_dtos)

--- a/domain/ports/logger_port.py
+++ b/domain/ports/logger_port.py
@@ -19,3 +19,23 @@ class LoggerPort(ABC):
     ) -> None:
         """Emit a log message from a worker or service."""
         raise NotImplementedError
+
+    def warning(
+        self,
+        message: str,
+        *args,
+        progress: Optional[dict] = None,
+        extra: Optional[dict] = None,
+        worker_id: Optional[str] = None,
+        show_path: Optional[bool] = None,
+    ) -> None:
+        """Convenience wrapper to log a warning-level message."""
+        formatted = message % args if args else message
+        self.log(
+            formatted,
+            level="warning",
+            progress=progress,
+            extra=extra,
+            worker_id=worker_id,
+            show_path=show_path,
+        )

--- a/infrastructure/logging/logger.py
+++ b/infrastructure/logging/logger.py
@@ -120,6 +120,26 @@ class Logger(LoggerPort):
             # fallback on error
             self._logger.error(f"Logging failed: {e} - {full_message}")
 
+    def warning(
+        self,
+        message: str,
+        *args,
+        progress: Optional[dict] = None,
+        extra: Optional[dict] = None,
+        worker_id: Optional[str] = None,
+        show_path: Optional[bool] = None,
+    ) -> None:
+        """Emit a warning-level log message."""
+        formatted = message % args if args else message
+        self.log(
+            formatted,
+            level="warning",
+            progress=progress,
+            extra=extra,
+            worker_id=worker_id,
+            show_path=show_path,
+        )
+
 
 class SafeFormatter(logging.Formatter):
     """Formatter that injects default values for missing log attributes."""

--- a/tests/application/test_statement_transform_service.py
+++ b/tests/application/test_statement_transform_service.py
@@ -41,16 +41,18 @@ def test_transform_all_processes_new_data(monkeypatch):
 
     parsed_repo.exists_with_hash.return_value = False
 
+    config = DummyConfig()
     service = StatementTransformService(
         logger=DummyLogger(),
         raw_repo=raw_repo,
         parsed_repo=parsed_repo,
-        config=DummyConfig(),
+        config=config,
     )
 
     usecase_cls.assert_called_once_with(
         math_transformer=ANY,
         intel_transformer=ANY,
+        config=config,
         logger=service.logger,
     )
 

--- a/tests/application/test_transform_statements_use_case.py
+++ b/tests/application/test_transform_statements_use_case.py
@@ -4,6 +4,7 @@ from application.ports import StatementTransformerPort
 from application.usecases.transform_statements import TransformStatementsUseCase
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
+from tests.conftest import DummyConfig
 
 
 class DummyTransformer(StatementTransformerPort):
@@ -43,6 +44,7 @@ def test_usecase_logs_missing_and_deduplicates():
     usecase = TransformStatementsUseCase(
         math_transformer=DummyTransformer(),
         intel_transformer=DummyTransformer(),
+        config=DummyConfig(),
         logger=logger,
     )
 
@@ -56,13 +58,17 @@ def test_usecase_logs_missing_and_deduplicates():
 
     result = usecase.execute(rows)
 
-    expected = {
-        "Group ('ACME', 'ACC', 'G', 'Q', 'V1') is missing quarters: ['2021-06-30']",
-        "Group ('ACME', 'ACC', 'G', 'Q', 'V2') is missing quarters: ['2021-06-30']",
-    }
-
-    actual = {args[0] for args, kwargs in logger.log.call_args_list}
-    assert actual == expected
+    logger.warning.assert_any_call(
+        "Group %s missing quarters: %s",
+        ("ACME", "ACC", "G", "Q", "V1"),
+        ["2021-06-30"],
+    )
+    logger.warning.assert_any_call(
+        "Group %s missing quarters: %s",
+        ("ACME", "ACC", "G", "Q", "V2"),
+        ["2021-06-30"],
+    )
+    assert logger.warning.call_count == 2
 
     mapping = {(r.quarter, r.version) for r in result}
     assert ("2021-03-31", "V2") in mapping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,11 @@ class DummyLogger:
     def log(self, *args, **kwargs):
         pass
 
+    def warning(self, message, *args, **kwargs):
+        if args:
+            message = message % args
+        self.log(message, level="warning", **kwargs)
+
 
 class DummyConfig:
     class Database:
@@ -43,3 +48,8 @@ class DummyConfig:
         queue_size = 10
 
     global_settings = Global()
+
+    class Transformers:
+        math_target_accounts = ("ACC",)
+
+    transformers = Transformers()


### PR DESCRIPTION
## Summary
- log missing quarter warnings using a new `warning` logger helper
- only validate configured accounts before deduplication
- expose the transformers config in the statement transform service
- update dummy config/logger and tests

## Testing
- `ruff format application/services/statement_transform_service.py application/usecases/transform_statements.py domain/ports/logger_port.py infrastructure/logging/logger.py tests/application/test_statement_transform_service.py tests/application/test_transform_statements_use_case.py tests/conftest.py`
- `ruff check application/services/statement_transform_service.py application/usecases/transform_statements.py domain/ports/logger_port.py infrastructure/logging/logger.py tests/application/test_statement_transform_service.py tests/application/test_transform_statements_use_case.py tests/conftest.py --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place application/services/statement_transform_service.py application/usecases/transform_statements.py domain/ports/logger_port.py infrastructure/logging/logger.py tests/application/test_statement_transform_service.py tests/application/test_transform_statements_use_case.py tests/conftest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b96c9841c832ea87f46dc55fd641e