### PR TITLE
Validate raw statements after dedupe

### DIFF
--- a/application/services/statement_transform_service.py
+++ b/application/services/statement_transform_service.py
@@ -39,7 +39,6 @@ class StatementTransformService:
         self.transform_usecase = TransformStatementsUseCase(
             math_transformer=math_transformer,
             intel_transformer=intel_transformer,
-            config=config,
             logger=self.logger,
         )
 

--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -19,29 +19,25 @@ class TransformStatementsUseCase:
         self,
         math_transformer: StatementTransformerPort,
         intel_transformer: StatementTransformerPort,
-        config,
         logger: LoggerPort,
     ) -> None:
         """Store dependencies for the statement transformation pipeline."""
         self.math_transformer = math_transformer
         self.intel_transformer = intel_transformer
-        self.config = config
         self.logger = logger
 
     def execute(self, raw_dtos: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         """Run transformation pipeline for ``raw_dtos``."""
-        targets = set(self.config.transformers.math_target_accounts)
-        validation_candidates = [r for r in raw_dtos if r.account in targets]
+        deduped = filter_latest_versions(raw_dtos)
 
-        missing_map = validate_quarter_completeness(validation_candidates)
+        missing_map = validate_quarter_completeness(deduped)
         for key, miss in missing_map.items():
             self.logger.warning(
-                "Group %s missing quarters: %s",
+                "After dedupe, version-group %s missing quarters: %s",
                 key,
                 [d.strftime("%Y-%m-%d") for d in miss],
             )
 
-        stage1 = filter_latest_versions(raw_dtos)
-        stage2 = self.math_transformer.transform(stage1)
-        stage3 = self.intel_transformer.transform(stage2)  # type: ignore[arg-type]
-        return stage3
+        stage1 = self.math_transformer.transform(deduped)
+        stage2 = self.intel_transformer.transform(stage1)  # type: ignore[arg-type]
+        return stage2

--- a/tests/application/test_statement_transform_service.py
+++ b/tests/application/test_statement_transform_service.py
@@ -52,7 +52,6 @@ def test_transform_all_processes_new_data(monkeypatch):
     usecase_cls.assert_called_once_with(
         math_transformer=ANY,
         intel_transformer=ANY,
-        config=config,
         logger=service.logger,
     )
 

--- a/tests/application/test_transform_statements_use_case.py
+++ b/tests/application/test_transform_statements_use_case.py
@@ -4,7 +4,6 @@ from application.ports import StatementTransformerPort
 from application.usecases.transform_statements import TransformStatementsUseCase
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
-from tests.conftest import DummyConfig
 
 
 class DummyTransformer(StatementTransformerPort):
@@ -44,7 +43,6 @@ def test_usecase_logs_missing_and_deduplicates():
     usecase = TransformStatementsUseCase(
         math_transformer=DummyTransformer(),
         intel_transformer=DummyTransformer(),
-        config=DummyConfig(),
         logger=logger,
     )
 
@@ -58,17 +56,11 @@ def test_usecase_logs_missing_and_deduplicates():
 
     result = usecase.execute(rows)
 
-    logger.warning.assert_any_call(
-        "Group %s missing quarters: %s",
-        ("ACME", "ACC", "G", "Q", "V1"),
-        ["2021-06-30"],
-    )
-    logger.warning.assert_any_call(
-        "Group %s missing quarters: %s",
+    logger.warning.assert_called_once_with(
+        "After dedupe, version-group %s missing quarters: %s",
         ("ACME", "ACC", "G", "Q", "V2"),
         ["2021-06-30"],
     )
-    assert logger.warning.call_count == 2
 
     mapping = {(r.quarter, r.version) for r in result}
     assert ("2021-03-31", "V2") in mapping


### PR DESCRIPTION
## Summary
- remove config requirement from `TransformStatementsUseCase`
- validate quarter completeness after deduplication
- update statement transform service
- adjust unit tests for new pipeline

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bab5b6a68832e99cf430cc4df6566