### PR TITLE
Add quarter completeness validation step

### DIFF
--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -7,6 +7,7 @@ from typing import List
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.utils.validation_utils import validate_quarter_completeness
 from domain.utils.version_utils import filter_latest_versions
 
 
@@ -23,11 +24,26 @@ class TransformStatementsUseCase:
 
     def execute(self, raw_dtos: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         """Run transformation pipeline for ``raw_dtos``."""
+        # Stage 1: dedupe to latest version per quarter
         stage1 = filter_latest_versions(raw_dtos)
 
         from infrastructure.utils.csv_utils import save_dtos_to_csv
+
         save_dtos_to_csv(stage1, "raws_latest_statements.csv")
 
-        stage2 = self.math_transformer.transform(stage1)
-        stage3 = self.intel_transformer.transform(stage2)  # type: ignore[arg-type]
-        return stage3
+        # Stage 2: validate completeness
+        missing_map = validate_quarter_completeness(stage1)
+        if missing_map:
+            for key, dates in missing_map.items():
+                print(
+                    f"After dedupe, group {key} missing quarters: "
+                    f"{[d.strftime('%Y-%m-%d') for d in dates]}"
+                )
+        stage2_validated = stage1
+
+        # Stage 3: math transformation
+        stage3 = self.math_transformer.transform(stage2_validated)
+
+        # Stage 4: intel transformation
+        stage4 = self.intel_transformer.transform(stage3)  # type: ignore[arg-type]
+        return stage4

--- a/tests/application/test_transform_statements_usecase.py
+++ b/tests/application/test_transform_statements_usecase.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from application.usecases.transform_statements import TransformStatementsUseCase
+from domain.dto.raw_statement_dto import RawStatementDTO
+
+
+@pytest.fixture()
+def sample_rows():
+    return [
+        RawStatementDTO(
+            nsd="1",
+            company_name="ACME",
+            quarter="2020-03-31",
+            version="V1",
+            grupo="G",
+            quadro="Q",
+            account="01",
+            description="d1",
+            value=10.0,
+        ),
+        RawStatementDTO(
+            nsd="2",
+            company_name="ACME",
+            quarter="2020-06-30",
+            version="V1",
+            grupo="G",
+            quadro="Q",
+            account="01",
+            description="d2",
+            value=20.0,
+        ),
+    ]
+
+
+def test_execute_validates_and_runs_pipeline(monkeypatch, sample_rows):
+    math_transformer = MagicMock()
+    intel_transformer = MagicMock()
+
+    math_transformer.transform.return_value = ["math"]
+    intel_transformer.transform.return_value = ["intel"]
+
+    monkeypatch.setattr(
+        "infrastructure.utils.csv_utils.save_dtos_to_csv",
+        lambda *args, **kwargs: None,
+    )
+
+    missing = {
+        (
+            "ACME",
+            "01",
+            "G",
+            "Q",
+            "V1",
+        ): [datetime(2020, 9, 30)]
+    }
+    validate_mock = MagicMock(return_value=missing)
+    monkeypatch.setattr(
+        "application.usecases.transform_statements.validate_quarter_completeness",
+        validate_mock,
+    )
+
+    print_mock = MagicMock()
+    monkeypatch.setattr("builtins.print", print_mock)
+
+    usecase = TransformStatementsUseCase(math_transformer, intel_transformer)
+    result = usecase.execute(sample_rows)
+
+    validate_mock.assert_called_once()
+    print_mock.assert_any_call(
+        "After dedupe, group ('ACME', '01', 'G', 'Q', 'V1') missing quarters: ['2020-09-30']"
+    )
+    math_transformer.transform.assert_called_once()
+    intel_transformer.transform.assert_called_once_with(["math"])
+    assert result == ["intel"]


### PR DESCRIPTION
## Summary
- add `validate_quarter_completeness` check to `TransformStatementsUseCase`
- log any missing quarters after deduplication
- ensure pipeline stages remain in order
- add unit test for the new validation behavior

## Testing
- `ruff format application/usecases/transform_statements.py tests/application/test_transform_statements_usecase.py`
- `ruff check application/usecases/transform_statements.py tests/application/test_transform_statements_usecase.py --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive application/usecases/transform_statements.py tests/application/test_transform_statements_usecase.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bcd361770832eb668f179d055d5e3