### PR TITLE
Limit quarter validation

### DIFF
--- a/application/services/statement_transform_service.py
+++ b/application/services/statement_transform_service.py
@@ -39,6 +39,8 @@ class StatementTransformService:
         self.transform_usecase = TransformStatementsUseCase(
             math_transformer=math_transformer,
             intel_transformer=intel_transformer,
+            config=config,
+            logger=logger,
         )
 
     def transform_all(self) -> None:
@@ -68,4 +70,3 @@ class StatementTransformService:
                 )
             except Exception as exc:  # pragma: no cover - log and continue
                 self.logger.log(f"[{company_name}] Error: {exc}", level="error")
-

--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import List
 
 from application.ports import StatementTransformerPort
@@ -9,6 +10,7 @@ from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.utils.validation_utils import validate_quarter_completeness
 from domain.utils.version_utils import filter_latest_versions
+from infrastructure.config import Config
 
 
 class TransformStatementsUseCase:
@@ -18,41 +20,55 @@ class TransformStatementsUseCase:
         self,
         math_transformer: StatementTransformerPort,
         intel_transformer: StatementTransformerPort,
+        config: Config,
+        logger: logging.Logger,
     ) -> None:
         self.math_transformer = math_transformer
         self.intel_transformer = intel_transformer
+        self.config = config
+        self.logger = logger
 
     def execute(self, raw_dtos: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         """Run transformation pipeline for ``raw_dtos``."""
         stage1 = filter_latest_versions(raw_dtos)
 
         from infrastructure.utils.csv_utils import save_dtos_to_csv
+
         save_dtos_to_csv(stage1, "raws_statements_stage_1.csv")
 
-        # Stage 2: validate completeness
-        missing_map = validate_quarter_completeness(stage1)
+        # Stage 1.5: restrict validation to MATH_TARGET_ACCOUNTS
+        targets = tuple(self.config.transformers.math_target_accounts)
+        validation_candidates = [
+            r for r in stage1 if any(r.account.startswith(prefix) for prefix in targets)
+        ]
+
+        # Stage 2: detect missing quarter-ends only for filtered accounts
+        missing_map = validate_quarter_completeness(validation_candidates)
         if missing_map:
             for key, dates in missing_map.items():
-                print(
-                    f"After dedupe, group {key} missing quarters: "
-                    f"{[d.strftime('%Y-%m-%d') for d in dates]}"
+                self.logger.warning(
+                    "After dedupe, account-group %s missing quarters: %s",
+                    key,
+                    [d.strftime("%Y-%m-%d") for d in dates],
                 )
         stage2 = stage1
 
         from infrastructure.utils.csv_utils import save_dtos_to_csv
+
         save_dtos_to_csv(stage2, "raws_statements_stage_2.csv")
 
         # Stage 3: math transformation
         stage3 = self.math_transformer.transform(stage2)
 
         from infrastructure.utils.csv_utils import save_dtos_to_csv
+
         save_dtos_to_csv(stage3, "raws_statements_stage_3.csv")
 
         # Stage 4: intel transformation
         stage4 = self.intel_transformer.transform(stage3)  # type: ignore[arg-type]
 
         from infrastructure.utils.csv_utils import save_dtos_to_csv
+
         save_dtos_to_csv(stage4, "raws_statements_stage_4.csv")
 
         return stage4
-

--- a/infrastructure/transformers/math_statement_transformer.py
+++ b/infrastructure/transformers/math_statement_transformer.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Tuple
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
-from domain.utils.math_utils import detect_missing_quarters, extract_sorted_quarters
 from infrastructure.config import Config
 
 
@@ -46,16 +45,6 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
             dt = self._parse(row.quarter)
             key = self._group_key(row, dt)
             groups.setdefault(key, []).append((dt, row))
-
-        # Verificação de completude dos quarters
-        quarters = extract_sorted_quarters(groups)
-        missing = detect_missing_quarters(quarters)
-        if missing:
-            print(
-                "Quarters ausentes na base: faça uma busca no nsd para verificar se estão disponíveis"
-            )
-            for q in missing:
-                print(" -", q.strftime("%Y-%m-%d"))
 
         result: List[ParsedStatementDTO] = []
         for i, group in enumerate(groups.items()):

--- a/tests/application/test_transform_statements_usecase.py
+++ b/tests/application/test_transform_statements_usecase.py
@@ -5,6 +5,7 @@ import pytest
 
 from application.usecases.transform_statements import TransformStatementsUseCase
 from domain.dto.raw_statement_dto import RawStatementDTO
+from tests.conftest import DummyConfig
 
 
 @pytest.fixture()
@@ -62,15 +63,27 @@ def test_execute_validates_and_runs_pipeline(monkeypatch, sample_rows):
         validate_mock,
     )
 
-    print_mock = MagicMock()
-    monkeypatch.setattr("builtins.print", print_mock)
+    logger = MagicMock()
 
-    usecase = TransformStatementsUseCase(math_transformer, intel_transformer)
+    usecase = TransformStatementsUseCase(
+        math_transformer,
+        intel_transformer,
+        DummyConfig(),
+        logger,
+    )
     result = usecase.execute(sample_rows)
 
-    validate_mock.assert_called_once()
-    print_mock.assert_any_call(
-        "After dedupe, group ('ACME', '01', 'G', 'Q', 'V1') missing quarters: ['2020-09-30']"
+    validate_mock.assert_called_once_with(sample_rows)
+    logger.warning.assert_called_once_with(
+        "After dedupe, account-group %s missing quarters: %s",
+        (
+            "ACME",
+            "01",
+            "G",
+            "Q",
+            "V1",
+        ),
+        ["2020-09-30"],
     )
     math_transformer.transform.assert_called_once()
     intel_transformer.transform.assert_called_once_with(["math"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,9 @@ class DummyLogger:
     def log(self, *args, **kwargs):
         pass
 
+    def warning(self, *args, **kwargs):
+        pass
+
 
 class DummyConfig:
     class Database:
@@ -43,3 +46,8 @@ class DummyConfig:
         queue_size = 10
 
     global_settings = Global()
+
+    class Transformers:
+        math_target_accounts = ("01",)
+
+    transformers = Transformers()

--- a/tests/domain/utils/test_validation_utils.py
+++ b/tests/domain/utils/test_validation_utils.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.utils.validation_utils import validate_quarter_completeness
+
+
+def test_validate_quarter_completeness_detects_missing():
+    rows = [
+        RawStatementDTO(
+            nsd="1",
+            company_name="ACME",
+            quarter="2020-03-31",
+            version="V1",
+            grupo="G",
+            quadro="Q",
+            account="01",
+            description="",
+            value=1.0,
+        ),
+        RawStatementDTO(
+            nsd="2",
+            company_name="ACME",
+            quarter="2020-12-31",
+            version="V1",
+            grupo="G",
+            quadro="Q",
+            account="01",
+            description="",
+            value=2.0,
+        ),
+    ]
+
+    missing = validate_quarter_completeness(rows)
+    key = ("ACME", "01", "G", "Q", "V1")
+    assert missing[key] == [datetime(2020, 6, 30), datetime(2020, 9, 30)]


### PR DESCRIPTION
## Summary
- warn about missing quarters only for math target accounts
- wire new logger and config dependencies
- drop duplicate validation from math transformer
- expand DummyConfig for tests
- add unit tests for validation utils

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688be33e3034832e8b30f8630e5366bd