### PR TITLE
feat: introduce surrogate ids

### DIFF
--- a/domain/dto/company_data_dto.py
+++ b/domain/dto/company_data_dto.py
@@ -10,10 +10,11 @@ from typing import Optional
 from .raw_company_data_dto import CompanyDataRawDTO
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class CompanyDataDTO:
     """Structured company data extracted from the exchange."""
 
+    id: Optional[int] = None
     cvm_code: Optional[str]
     issuing_company: Optional[str]
     trading_name: Optional[str]
@@ -55,7 +56,6 @@ class CompanyDataDTO:
     date_quotation: Optional[datetime]
     last_date: Optional[datetime]
     listing_date: Optional[datetime]
-    id: Optional[int] = None
 
     @staticmethod
     def from_dict(raw: dict) -> "CompanyDataDTO":
@@ -64,6 +64,7 @@ class CompanyDataDTO:
         # Map incoming keys to the canonical DTO fields. Alternative names are
         # also handled for backward compatibility with existing scrapers.
         return CompanyDataDTO(
+            id=raw.get("id"),
             cvm_code=raw.get("cvm_code") or raw.get("codeCVM"),
             issuing_company=raw.get("issuing_company") or raw.get("issuingCompany"),
             trading_name=raw.get("trading_name") or raw.get("tradingName"),
@@ -98,7 +99,6 @@ class CompanyDataDTO:
             date_quotation=raw.get("date_quotation"),
             last_date=raw.get("last_date"),
             listing_date=raw.get("listing_date"),
-            id=None,
         )
 
     @staticmethod
@@ -114,6 +114,7 @@ class CompanyDataDTO:
 
         # Instantiate the immutable DTO using the serialized raw values
         return CompanyDataDTO(
+            id=None,
             cvm_code=raw.cvm_code,
             issuing_company=raw.issuing_company,
             trading_name=raw.trading_name,
@@ -148,5 +149,4 @@ class CompanyDataDTO:
             date_quotation=raw.date_quotation,
             last_date=raw.last_date,
             listing_date=raw.listing_date,
-            id=None,
         )

--- a/domain/dto/nsd_dto.py
+++ b/domain/dto/nsd_dto.py
@@ -8,10 +8,11 @@ from datetime import datetime
 from typing import Optional
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class NsdDTO:
     """Structured NSD data extracted from the exchange."""
 
+    id: Optional[int] = None
     nsd: int
     company_name: Optional[str]
     quarter: Optional[datetime]
@@ -31,8 +32,13 @@ class NsdDTO:
         if not raw:
             return None
 
+        nsd_raw = raw.get("nsd")
+        if nsd_raw is None or not str(nsd_raw).isdigit():
+            raise ValueError("Invalid NSD value")
+
         return NsdDTO(
-            nsd=raw.get("nsd", 0),
+            id=raw.get("id"),
+            nsd=int(nsd_raw),
             company_name=raw.get("company_name"),
             quarter=raw.get("quarter"),
             version=raw.get("version"),
@@ -49,6 +55,7 @@ class NsdDTO:
     def from_raw(raw: NsdDTO) -> NsdDTO:
         """Build an NsdDTO from a NsdRawDTO instance."""
         return NsdDTO(
+            id=getattr(raw, "id", None),
             nsd=raw.nsd,
             company_name=raw.company_name,
             quarter=raw.quarter,

--- a/domain/dto/parsed_statement_dto.py
+++ b/domain/dto/parsed_statement_dto.py
@@ -6,10 +6,11 @@ from dataclasses import dataclass
 from typing import Optional
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ParsedStatementDTO:
     """Immutable representation of a cleaned statement row."""
 
+    id: Optional[int] = None
     nsd: str
     company_name: Optional[str]
     quarter: Optional[str]
@@ -20,7 +21,6 @@ class ParsedStatementDTO:
     description: str
     value: float
     processing_hash: str = ""
-    id: Optional[int] = None
 
     @staticmethod
     def from_dict(raw: dict) -> "ParsedStatementDTO":
@@ -31,6 +31,7 @@ class ParsedStatementDTO:
         nsd_value = str(nsd_raw)
 
         return ParsedStatementDTO(
+            id=raw.get("id"),
             nsd=nsd_value,
             company_name=raw.get("company_name"),
             quarter=raw.get("quarter"),
@@ -41,5 +42,4 @@ class ParsedStatementDTO:
             description=str(raw.get("description", "")),
             value=float(raw.get("value", 0.0)),
             processing_hash=str(raw.get("processing_hash", "")),
-            id=None,
         )

--- a/domain/dto/raw_statement_dto.py
+++ b/domain/dto/raw_statement_dto.py
@@ -6,10 +6,11 @@ from typing import Optional
 from .parsed_statement_dto import ParsedStatementDTO
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class RawStatementDTO:
     """Immutable DTO representing a scraped statement row."""
 
+    id: Optional[int] = None
     nsd: str
     company_name: Optional[str]
     quarter: Optional[str]
@@ -19,7 +20,6 @@ class RawStatementDTO:
     account: str
     description: str
     value: float
-    id: Optional[int] = None
 
     @staticmethod
     def from_dict(raw: dict) -> "RawStatementDTO":
@@ -31,6 +31,7 @@ class RawStatementDTO:
         nsd_value = str(nsd_raw)
 
         return RawStatementDTO(
+            id=raw.get("id"),
             nsd=nsd_value,
             company_name=raw.get("company_name"),
             quarter=raw.get("quarter"),
@@ -40,7 +41,6 @@ class RawStatementDTO:
             account=str(raw.get("account", "")),
             description=str(raw.get("description", "")),
             value=float(raw.get("value", 0.0)),
-            id=None,
         )
 
     def to_parsed(self, target_line: str) -> "ParsedStatementDTO":
@@ -53,6 +53,7 @@ class RawStatementDTO:
         description = parts[1].strip() if len(parts) > 1 else self.description
 
         return ParsedStatementDTO(
+            id=None,
             nsd=self.nsd,
             company_name=self.company_name,
             quarter=self.quarter,

--- a/infrastructure/models/abstract_statement_model.py
+++ b/infrastructure/models/abstract_statement_model.py
@@ -36,7 +36,9 @@ class AbstractStatementModel(BaseModel):
 
     @classmethod
     def _kwargs_from_dto(cls, dto: object) -> dict:
-        return {field: getattr(dto, field) for field in cls._FIELDS}
+        data = {field: getattr(dto, field) for field in cls._FIELDS}
+        data["id"] = getattr(dto, "id", None)
+        return data
 
     def _dto_kwargs(self) -> dict:
         data = {field: getattr(self, field) for field in self._FIELDS}

--- a/infrastructure/models/company_data_model.py
+++ b/infrastructure/models/company_data_model.py
@@ -5,7 +5,7 @@ import json
 from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import Boolean, DateTime, Index, Integer, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, Index, Integer
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.company_data_dto import CompanyDataDTO
@@ -18,10 +18,9 @@ class CompanyDataModel(BaseModel):
     """ORM adapter for the ``tbl_company`` table."""
 
     __tablename__ = "tbl_company"
-    __table_args__ = (UniqueConstraint("cvm_code", name="uq_company_cvm_code"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    cvm_code: Mapped[str] = mapped_column()
+    cvm_code: Mapped[str] = mapped_column(unique=True, index=True)
     issuing_company: Mapped[Optional[str]] = mapped_column()
     trading_name: Mapped[Optional[str]] = mapped_column()
     company_name: Mapped[Optional[str]] = mapped_column()
@@ -63,10 +62,7 @@ class CompanyDataModel(BaseModel):
     last_date: Mapped[Optional[datetime]] = mapped_column(DateTime)
     listing_date: Mapped[Optional[datetime]] = mapped_column(DateTime)
 
-    __table_args__ = (
-        Index("ix_company_cvm_code", "cvm_code"),
-        Index("ix_company_company_name", "company_name"),
-    )
+    __table_args__ = (Index("ix_company_company_name", "company_name"),)
 
     @staticmethod
     def from_dto(dto: CompanyDataRawDTO | CompanyDataDTO) -> "CompanyDataModel":
@@ -103,6 +99,7 @@ class CompanyDataModel(BaseModel):
             return json.dumps([{"code": c.code, "isin": c.isin} for c in value])
 
         return CompanyDataModel(
+            id=attr("id"),
             cvm_code=attr("cvm_code") or attr("issuing_company") or "",
             issuing_company=attr("issuing_company"),
             trading_name=attr("trading_name"),

--- a/infrastructure/models/nsd_model.py
+++ b/infrastructure/models/nsd_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy import DateTime, ForeignKey, Index, Integer
 from sqlalchemy.orm import Mapped, mapped_column
 
 from domain.dto.nsd_dto import NsdDTO
@@ -16,7 +16,8 @@ class NSDModel(BaseModel):
 
     __tablename__ = "tbl_nsd"
 
-    nsd: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    nsd: Mapped[int] = mapped_column(Integer, nullable=False, unique=True, index=True)
     company_name: Mapped[Optional[str]] = mapped_column(
         ForeignKey("tbl_company.company_name")
     )
@@ -30,16 +31,13 @@ class NSDModel(BaseModel):
     sent_date: Mapped[Optional[datetime]] = mapped_column(DateTime)
     reason: Mapped[Optional[str]] = mapped_column()
 
-    __table_args__ = (
-        UniqueConstraint("nsd", name="uq_nsd"),
-        Index("ix_nsd_nsd", "nsd"),
-        Index("ix_nsd_company_name", "company_name"),
-    )
+    __table_args__ = (Index("ix_nsd_company_name", "company_name"),)
 
     @staticmethod
     def from_dto(dto: NsdDTO) -> "NSDModel":
         """Converts a NsdDTO into an NSDModel for persistence."""
         return NSDModel(
+            id=dto.id,
             nsd=dto.nsd,
             company_name=dto.company_name,
             quarter=dto.quarter,
@@ -56,6 +54,7 @@ class NSDModel(BaseModel):
     def to_dto(self) -> NsdDTO:
         """Converts this ORM model back into a NsdDTO."""
         return NsdDTO(
+            id=self.id,
             nsd=self.nsd,
             company_name=self.company_name,
             quarter=self.quarter,

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
+from sqlalchemy.dialects.sqlite import insert
+
 from domain.dto.company_data_dto import CompanyDataDTO
 from domain.ports import LoggerPort, SqlAlchemyCompanyDataRepositoryPort
 from infrastructure.config import Config
@@ -44,7 +46,7 @@ class SqlAlchemyCompanyDataRepository(
         self.logger = logger
 
     def save_all(self, items: List[CompanyDataDTO]) -> None:
-        """Persist company DTOs using the surrogate id for updates."""
+        """Persist ``CompanyDataDTO`` objects using SQLite upserts."""
         session = self.Session()
         try:
             model, _ = self.get_model_class()
@@ -52,10 +54,17 @@ class SqlAlchemyCompanyDataRepository(
             valid_items = [i for i in flat_items if i is not None]
             for dto in valid_items:
                 obj = model.from_dto(dto)
-                existing = session.query(model).filter_by(cvm_code=obj.cvm_code).first()
-                if existing:
-                    obj.id = existing.id
-                session.merge(obj)
+                data = {c.name: getattr(obj, c.name) for c in model.__table__.columns}
+                stmt = insert(model).values(**data)
+                update_dict = {
+                    c.name: getattr(stmt.excluded, c.name)
+                    for c in model.__table__.columns
+                    if c.name != "id"
+                }
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["cvm_code"], set_=update_dict
+                )
+                session.execute(stmt)
             session.commit()
         except Exception:
             session.rollback()
@@ -71,4 +80,4 @@ class SqlAlchemyCompanyDataRepository(
         Returns:
             type: The model class associated with this repository.
         """
-        return CompanyDataModel, (CompanyDataModel.id,)
+        return CompanyDataModel, (CompanyDataModel.cvm_code,)

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from typing import List, Set, Tuple
 
+from sqlalchemy.dialects.sqlite import insert
+
 from domain.dto.nsd_dto import NsdDTO
 from domain.ports import LoggerPort, NSDRepositoryPort
 from infrastructure.config import Config
+from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.nsd_model import NSDModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
     SqlAlchemyRepositoryBase,
@@ -21,6 +24,33 @@ class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, int], NSDReposito
 
         self.config = config
         self.logger = logger
+
+    def save_all(self, items: List[NsdDTO]) -> None:
+        """Persist ``NsdDTO`` objects using SQLite upserts."""
+        session = self.Session()
+        try:
+            model, _ = self.get_model_class()
+            flat_items = ListFlattener.flatten(items)
+            valid_items = [i for i in flat_items if i is not None]
+            for dto in valid_items:
+                obj = model.from_dto(dto)
+                data = {c.name: getattr(obj, c.name) for c in model.__table__.columns}
+                stmt = insert(model).values(**data)
+                update_dict = {
+                    c.name: getattr(stmt.excluded, c.name)
+                    for c in model.__table__.columns
+                    if c.name != "id"
+                }
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["nsd"], set_=update_dict
+                )
+                session.execute(stmt)
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
     def get_model_class(self) -> Tuple[type, tuple]:
         """Return the SQLAlchemy ORM model class managed by this repository.

--- a/infrastructure/repositories/parsed_statement_repository.py
+++ b/infrastructure/repositories/parsed_statement_repository.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from dataclasses import replace
 from typing import List, Tuple
 
+from sqlalchemy.dialects.sqlite import insert
+
 from domain.dto import ParsedStatementDTO
 from domain.ports import LoggerPort, SqlAlchemyParsedStatementRepositoryPort
 from infrastructure.config import Config
+from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.parsed_statement_model import ParsedStatementModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
     SqlAlchemyRepositoryBase,
@@ -26,6 +29,42 @@ class SqlAlchemyParsedStatementRepository(
 
         self.config = config
         self.logger = logger
+
+    def save_all(self, items: List[ParsedStatementDTO]) -> None:
+        """Persist parsed statements using SQLite upserts."""
+        session = self.Session()
+        try:
+            model, _ = self.get_model_class()
+            flat_items = ListFlattener.flatten(items)
+            valid_items = [i for i in flat_items if i is not None]
+            for dto in valid_items:
+                obj = model.from_dto(dto)
+                data = {c.name: getattr(obj, c.name) for c in model.__table__.columns}
+                stmt = insert(model).values(**data)
+                update_dict = {
+                    c.name: getattr(stmt.excluded, c.name)
+                    for c in model.__table__.columns
+                    if c.name != "id"
+                }
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=[
+                        "nsd",
+                        "company_name",
+                        "quarter",
+                        "version",
+                        "grupo",
+                        "quadro",
+                        "account",
+                    ],
+                    set_=update_dict,
+                )
+                session.execute(stmt)
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
     def get_model_class(self) -> Tuple[type, tuple]:
         """Return the SQLAlchemy ORM model class managed by this repository.

--- a/infrastructure/repositories/raw_statement_repository.py
+++ b/infrastructure/repositories/raw_statement_repository.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Tuple
+from typing import List, Tuple
+
+from sqlalchemy.dialects.sqlite import insert
 
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.ports import LoggerPort, SqlAlchemyRawStatementRepositoryPort
 from infrastructure.config import Config
+from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.raw_statement_model import RawStatementModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
     SqlAlchemyRepositoryBase,
@@ -24,6 +27,42 @@ class SqlAlchemyRawStatementRepository(
         super().__init__(config, logger)
         self.config = config
         self.logger = logger
+
+    def save_all(self, items: List[RawStatementDTO]) -> None:
+        """Persist raw statements using SQLite upserts."""
+        session = self.Session()
+        try:
+            model, _ = self.get_model_class()
+            flat_items = ListFlattener.flatten(items)
+            valid_items = [i for i in flat_items if i is not None]
+            for dto in valid_items:
+                obj = model.from_dto(dto)
+                data = {c.name: getattr(obj, c.name) for c in model.__table__.columns}
+                stmt = insert(model).values(**data)
+                update_dict = {
+                    c.name: getattr(stmt.excluded, c.name)
+                    for c in model.__table__.columns
+                    if c.name != "id"
+                }
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=[
+                        "nsd",
+                        "company_name",
+                        "quarter",
+                        "version",
+                        "grupo",
+                        "quadro",
+                        "account",
+                    ],
+                    set_=update_dict,
+                )
+                session.execute(stmt)
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
     def get_model_class(self) -> Tuple[type, tuple]:
         """Return the SQLAlchemy ORM model class managed by this repository.

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -10,11 +10,17 @@ def test_company_dto_from_dict():
     dto = CompanyDataDTO.from_dict(raw)
     assert dto.issuing_company == "XYZ"
     assert dto.company_name == "Xyz Corp"
+    assert dto.id is None
 
 
 def test_nsd_dto_invalid_nsd():
     with pytest.raises(ValueError):
         NsdDTO.from_dict({"nsd": "not_a_number"})
+
+
+def test_nsd_dto_from_dict_sets_id():
+    dto = NsdDTO.from_dict({"id": 1, "nsd": 2})
+    assert dto.id == 1
 
 
 def test_statement_rows_dto_from_dict():
@@ -32,3 +38,4 @@ def test_statement_rows_dto_from_dict():
     dto = RawStatementDTO.from_dict(raw)
     assert dto.account == "00.01.01"
     assert dto.nsd == "102395"
+    assert dto.id is None

--- a/tests/infrastructure/test_nsd_repository.py
+++ b/tests/infrastructure/test_nsd_repository.py
@@ -1,0 +1,27 @@
+from sqlalchemy import text
+
+from domain.dto.nsd_dto import NsdDTO
+from infrastructure.models.base_model import BaseModel
+from infrastructure.repositories.nsd_repository import SqlAlchemyNsdRepository
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def test_save_all_upserts(SessionLocal, engine):
+    repo = SqlAlchemyNsdRepository(config=DummyConfig(), logger=DummyLogger())
+    repo.engine = engine
+    repo.Session = SessionLocal
+    BaseModel.metadata.drop_all(engine)
+    BaseModel.metadata.create_all(engine)
+
+    first = [NsdDTO.from_dict({"nsd": 1, "company_name": "ACME"})]
+    repo.save_all(first)
+
+    second = [NsdDTO.from_dict({"nsd": 1, "company_name": "ACME", "reason": "dup"})]
+    repo.save_all(second)
+
+    with engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM tbl_nsd")).scalar()
+        reason = conn.execute(text("SELECT reason FROM tbl_nsd WHERE nsd=1")).scalar()
+
+    assert count == 1
+    assert reason == "dup"

--- a/tests/infrastructure/test_parsed_statement_repository.py
+++ b/tests/infrastructure/test_parsed_statement_repository.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 from sqlalchemy import text
 
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
@@ -57,3 +59,45 @@ def test_replace_and_exists(SessionLocal, engine):
 
     assert count == 1
     assert phash == "hash123"
+
+
+def test_save_all_upserts(SessionLocal, engine):
+    repo = SqlAlchemyParsedStatementRepository(
+        config=DummyConfig(), logger=DummyLogger()
+    )
+    repo.engine = engine
+    repo.Session = SessionLocal
+    BaseModel.metadata.drop_all(engine)
+    BaseModel.metadata.create_all(engine)
+
+    base = ParsedStatementDTO(
+        nsd="1",
+        company_name="ACME",
+        quarter="2020-03-31",
+        version="1",
+        grupo="G",
+        quadro="Q",
+        account="01",
+        description="d",
+        value=1.0,
+    )
+    repo.save_all([base])
+
+    updated = replace(base, value=2.0)
+    repo.save_all([updated])
+
+    with engine.connect() as conn:
+        count = conn.execute(
+            text("SELECT COUNT(*) FROM tbl_parsed_statements")
+        ).scalar()
+        value = conn.execute(
+            text(
+                """
+                SELECT value FROM tbl_parsed_statements
+                WHERE nsd='1' AND account='01'
+                """
+            )
+        ).scalar()
+
+    assert count == 1
+    assert value == 2.0

--- a/tests/infrastructure/test_raw_statement_repository.py
+++ b/tests/infrastructure/test_raw_statement_repository.py
@@ -1,0 +1,46 @@
+from sqlalchemy import text
+
+from domain.dto.raw_statement_dto import RawStatementDTO
+from infrastructure.models.base_model import BaseModel
+from infrastructure.repositories.raw_statement_repository import (
+    SqlAlchemyRawStatementRepository,
+)
+from tests.conftest import DummyConfig, DummyLogger
+
+
+def test_save_all_upserts(SessionLocal, engine):
+    repo = SqlAlchemyRawStatementRepository(config=DummyConfig(), logger=DummyLogger())
+    repo.engine = engine
+    repo.Session = SessionLocal
+    BaseModel.metadata.drop_all(engine)
+    BaseModel.metadata.create_all(engine)
+
+    base = {
+        "nsd": 1,
+        "company_name": "ACME",
+        "quarter": "2020-03-31",
+        "version": "1",
+        "grupo": "G",
+        "quadro": "Q",
+        "account": "01",
+        "description": "d",
+        "value": 1.0,
+    }
+    repo.save_all([RawStatementDTO.from_dict(base)])
+
+    updated = base | {"value": 2.0}
+    repo.save_all([RawStatementDTO.from_dict(updated)])
+
+    with engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM tbl_raw_statements")).scalar()
+        value = conn.execute(
+            text(
+                """
+                SELECT value FROM tbl_raw_statements
+                WHERE nsd=1 AND account='01'
+                """
+            )
+        ).scalar()
+
+    assert count == 1
+    assert value == 2.0


### PR DESCRIPTION
## Summary
- add auto-incrementing `id` primary keys and unique natural-key columns for core models
- include optional `id` field in DTOs and support hydration from raw dictionaries
- switch repository saves to SQLite UPSERTs keyed on the natural identifier with new tests

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive .`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68901d469b00832e80a8dd55c9287ee5