### PR TITLE
Use company_name FK for NSD and statements

### DIFF
--- a/domain/dto/nsd_dto.py
+++ b/domain/dto/nsd_dto.py
@@ -14,7 +14,7 @@ class NsdDTO:
 
     id: Optional[int] = None
     nsd: int
-    cvm_code: Optional[str]
+    company_name: str
     quarter: Optional[datetime]
     version: Optional[str]
     nsd_type: Optional[str]
@@ -39,7 +39,7 @@ class NsdDTO:
         return NsdDTO(
             id=raw.get("id"),
             nsd=int(nsd_raw),
-            cvm_code=raw.get("codecvm"),
+            company_name=raw.get("company_name"),
             quarter=raw.get("quarter"),
             version=raw.get("version"),
             nsd_type=raw.get("nsd_type"),
@@ -57,7 +57,7 @@ class NsdDTO:
         return NsdDTO(
             id=getattr(raw, "id", None),
             nsd=raw.nsd,
-            cvm_code=raw.cvm_code,
+            company_name=raw.company_name,
             quarter=raw.quarter,
             version=raw.version,
             nsd_type=raw.nsd_type,

--- a/infrastructure/models/abstract_statement_model.py
+++ b/infrastructure/models/abstract_statement_model.py
@@ -13,7 +13,7 @@ class AbstractStatementModel(BaseModel):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     nsd: Mapped[str] = mapped_column()
-    cvm_code: Mapped[str | None] = mapped_column()
+    company_name: Mapped[str | None] = mapped_column()
     quarter: Mapped[str | None] = mapped_column()
     version: Mapped[str | None] = mapped_column()
     grupo: Mapped[str] = mapped_column()
@@ -24,7 +24,7 @@ class AbstractStatementModel(BaseModel):
 
     _FIELDS = (
         "nsd",
-        "cvm_code",
+        "company_name",
         "quarter",
         "version",
         "grupo",

--- a/infrastructure/models/nsd_model.py
+++ b/infrastructure/models/nsd_model.py
@@ -18,9 +18,9 @@ class NSDModel(BaseModel):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     nsd: Mapped[int] = mapped_column(Integer, nullable=False, unique=True, index=True)
-    cvm_code: Mapped[str] = mapped_column(
+    company_name: Mapped[str] = mapped_column(
         String,
-        ForeignKey("tbl_company.cvm_code"),
+        ForeignKey("tbl_company.company_name"),
         nullable=False,
     )
     quarter: Mapped[Optional[datetime]] = mapped_column(DateTime)
@@ -33,7 +33,7 @@ class NSDModel(BaseModel):
     sent_date: Mapped[Optional[datetime]] = mapped_column(DateTime)
     reason: Mapped[Optional[str]] = mapped_column()
 
-    __table_args__ = (Index("ix_nsd_cvm_code", "cvm_code"),)
+    __table_args__ = (Index("ix_nsd_company_name", "company_name"),)
 
     @staticmethod
     def from_dto(dto: NsdDTO) -> "NSDModel":
@@ -41,7 +41,7 @@ class NSDModel(BaseModel):
         return NSDModel(
             id=dto.id,
             nsd=dto.nsd,
-            cvm_code=dto.cvm_code,
+            company_name=dto.company_name,
             quarter=dto.quarter,
             version=dto.version,
             nsd_type=dto.nsd_type,
@@ -58,7 +58,7 @@ class NSDModel(BaseModel):
         return NsdDTO(
             id=self.id,
             nsd=self.nsd,
-            cvm_code=self.cvm_code,
+            company_name=self.company_name,
             quarter=self.quarter,
             version=self.version,
             nsd_type=self.nsd_type,

--- a/infrastructure/models/parsed_statement_model.py
+++ b/infrastructure/models/parsed_statement_model.py
@@ -17,15 +17,15 @@ class ParsedStatementModel(AbstractStatementModel):
         String,
         ForeignKey("tbl_nsd.nsd"),
     )
-    cvm_code: Mapped[str | None] = mapped_column(
+    company_name: Mapped[str | None] = mapped_column(
         String,
-        ForeignKey("tbl_company.cvm_code"),
+        ForeignKey("tbl_company.company_name"),
     )
 
     __table_args__ = (
         UniqueConstraint(
             "nsd",
-            "cvm_code",
+            "company_name",
             "quarter",
             "version",
             "grupo",
@@ -33,11 +33,11 @@ class ParsedStatementModel(AbstractStatementModel):
             "account",
             name="uq_parsed_statements_fullkey",
         ),
-        Index("ix_parsed_statements_cvm_code", "cvm_code"),
+        Index("ix_parsed_statements_company_name", "company_name"),
         Index("ix_parsed_statements_quarter", "quarter"),
         Index("ix_parsed_statements_account", "account"),
         Index("ix_parsed_statements_nsd", "nsd"),
-        Index("ix_parsed_statements_cvm_code_quarter", "cvm_code", "quarter"),
+        Index("ix_parsed_statements_company_name_quarter", "company_name", "quarter"),
     )
 
     processing_hash: Mapped[str | None] = mapped_column(String, index=True)

--- a/infrastructure/models/raw_statement_model.py
+++ b/infrastructure/models/raw_statement_model.py
@@ -17,15 +17,15 @@ class RawStatementModel(AbstractStatementModel):
         String,
         ForeignKey("tbl_nsd.nsd"),
     )
-    cvm_code: Mapped[str | None] = mapped_column(
+    company_name: Mapped[str | None] = mapped_column(
         String,
-        ForeignKey("tbl_company.cvm_code"),
+        ForeignKey("tbl_company.company_name"),
     )
 
     __table_args__ = (
         UniqueConstraint(
             "nsd",
-            "cvm_code",
+            "company_name",
             "quarter",
             "version",
             "grupo",
@@ -33,11 +33,11 @@ class RawStatementModel(AbstractStatementModel):
             "account",
             name="uq_raw_statements_fullkey",
         ),
-        Index("ix_raw_statements_cvm_code", "cvm_code"),
+        Index("ix_raw_statements_company_name", "company_name"),
         Index("ix_raw_statements_quarter", "quarter"),
         Index("ix_raw_statements_account", "account"),
         Index("ix_raw_statements_nsd", "nsd"),
-        Index("ix_raw_statements_cvm_code_quarter", "cvm_code", "quarter"),
+        Index("ix_raw_statements_company_name_quarter", "company_name", "quarter"),
     )
 
     @staticmethod

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import time
 from datetime import datetime
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional
 
 from bs4 import BeautifulSoup
 
@@ -15,7 +15,7 @@ from domain.ports import (
     MetricsCollectorPort,
     NSDRepositoryPort,
     NSDSourcePort,
-    SqlAlchemyCompanyDataRepositoryPort, 
+    SqlAlchemyCompanyDataRepositoryPort,
     WorkerPoolPort,
 )
 from infrastructure.config import Config
@@ -128,18 +128,13 @@ class NsdScraper(NSDSourcePort):
                 #     level="info",
                 # )
                 parsed = self._parse_html(nsd, response.text)
-
-                # converte o company_name que veio do HTML em cvm_code para a FK bater
-                if parsed and parsed.get("company_name"):
-                    parsed["cvm_code"] = self.company_repo.get_cvm_by_name(parsed["company_name"])
-                else:
-                    parsed["cvm_code"] = None
+                # we now persist by company_name, no CVM lookup needed
             # ————————————————————————————————————————————————————————————————
 
-                # self.logger.log(
-                #     "End  Method controller.run()._nsd_service().run().sync_nsd_usecase.run().processor()._parse_html()",
-                #     level="info",
-                # )
+            # self.logger.log(
+            #     "End  Method controller.run()._nsd_service().run().sync_nsd_usecase.run().processor()._parse_html()",
+            #     level="info",
+            # )
             except Exception as e:
                 self.logger.log(
                     f"Failed to fetch NSD {nsd}: {e}",
@@ -312,7 +307,7 @@ class NsdScraper(NSDSourcePort):
             hole_count += 1
 
         # Phase 2: exponential search to locate an invalid boundary
-        nsd = nsd + 1 # move forward
+        nsd = nsd + 1  # move forward
         multiplier = 0
         while nsd <= max_limit and hole_count < max_linear_holes:
             parsed = self._try_nsd(nsd)

--- a/tests/application/test_fetch_statements_use_case.py
+++ b/tests/application/test_fetch_statements_use_case.py
@@ -13,7 +13,7 @@ from tests.conftest import DummyConfig, DummyLogger
 def _make_nsd(nsd: int) -> NsdDTO:
     return NsdDTO(
         nsd=str(nsd),
-        company_name=None,
+        company_name="Comp",
         quarter=None,
         version=None,
         nsd_type=None,

--- a/tests/application/test_nsd_prediction_service.py
+++ b/tests/application/test_nsd_prediction_service.py
@@ -16,7 +16,7 @@ def test_find_next_probable_nsd_returns_sequence():
         items.append(
             NsdDTO(
                 nsd=str(i + 1),
-                company_name=None,
+                company_name="Comp",
                 quarter=None,
                 version=None,
                 nsd_type=None,

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -12,7 +12,7 @@ from tests.conftest import DummyLogger
 
 def test_execute_converts_and_saves():
     repo = MagicMock(spec=SqlAlchemyCompanyDataRepositoryPort)
-    repo.get_all_primary_keys = MagicMock(return_value={"SKIP"})
+    repo.get_existing_by_columns = MagicMock(return_value=[("SKIP",)])
 
     raw = types.SimpleNamespace(
         cvm_code="001",
@@ -57,7 +57,7 @@ def test_execute_converts_and_saves():
         save_callback=None,
         max_workers=None,
     ):
-        assert skip_codes == {"SKIP"}
+        assert skip_codes == ["SKIP"]
         if save_callback:
             save_callback([raw])
         metrics = MetricsDTO(elapsed_time=0.0, network_bytes=100, processing_bytes=0)
@@ -76,7 +76,7 @@ def test_execute_converts_and_saves():
 
     result = usecase.synchronize_companies()
 
-    repo.get_all_primary_keys.assert_called_once()
+    repo.get_existing_by_columns.assert_called_once()
     scraper.fetch_all.assert_called_once()
     repo.save_all.assert_called_once()
     saved = repo.save_all.call_args.args[0]

--- a/tests/domain/test_dtos.py
+++ b/tests/domain/test_dtos.py
@@ -15,11 +15,11 @@ def test_company_dto_from_dict():
 
 def test_nsd_dto_invalid_nsd():
     with pytest.raises(ValueError):
-        NsdDTO.from_dict({"nsd": "not_a_number"})
+        NsdDTO.from_dict({"nsd": "not_a_number", "company_name": "ACME"})
 
 
 def test_nsd_dto_from_dict_sets_id():
-    dto = NsdDTO.from_dict({"id": 1, "nsd": 2})
+    dto = NsdDTO.from_dict({"id": 1, "nsd": 2, "company_name": "ACME"})
     assert dto.id == 1
 
 


### PR DESCRIPTION
## Summary
- link NSD records to companies by `company_name` instead of `cvm_code`
- simplify NSD scraper and DTO to work with `company_name`
- update statement models and tests to use `company_name` foreign keys

## Testing
- `ruff format domain/dto/nsd_dto.py infrastructure/models/nsd_model.py infrastructure/scrapers/nsd_scraper.py infrastructure/models/abstract_statement_model.py infrastructure/models/raw_statement_model.py infrastructure/models/parsed_statement_model.py tests/application/test_fetch_statements_use_case.py tests/application/test_nsd_prediction_service.py tests/application/test_sync_companies_use_case.py tests/domain/test_dtos.py`
- `ruff check domain/dto/nsd_dto.py infrastructure/models/nsd_model.py infrastructure/scrapers/nsd_scraper.py infrastructure/models/abstract_statement_model.py infrastructure/models/raw_statement_model.py infrastructure/models/parsed_statement_model.py tests/application/test_fetch_statements_use_case.py tests/application/test_nsd_prediction_service.py tests/application/test_sync_companies_use_case.py tests/domain/test_dtos.py --fix`
- `pydocstyle --convention=google domain/dto/nsd_dto.py infrastructure/models/nsd_model.py infrastructure/scrapers/nsd_scraper.py infrastructure/models/abstract_statement_model.py infrastructure/models/raw_statement_model.py infrastructure/models/parsed_statement_model.py tests/application/test_fetch_statements_use_case.py tests/application/test_nsd_prediction_service.py tests/application/test_sync_companies_use_case.py tests/domain/test_dtos.py`
- `docformatter --in-place domain/dto/nsd_dto.py infrastructure/models/nsd_model.py infrastructure/scrapers/nsd_scraper.py infrastructure/models/abstract_statement_model.py infrastructure/models/raw_statement_model.py infrastructure/models/parsed_statement_model.py tests/application/test_fetch_statements_use_case.py tests/application/test_nsd_prediction_service.py tests/application/test_sync_companies_use_case.py tests/domain/test_dtos.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ced6e9d4832eaaa024b7deaba2d7