### PR TITLE
Ensure config uses immutable structures

### DIFF
--- a/infrastructure/config/config.py
+++ b/infrastructure/config/config.py
@@ -1,6 +1,7 @@
 """Pure configuration DTO definitions."""
 
 from dataclasses import dataclass
+from typing import Final
 
 from .database import DatabaseConfig
 from .domain import DomainConfig
@@ -17,12 +18,12 @@ from .transformers import TransformersConfig
 class Config:
     """Immutable aggregate of all configuration sections."""
 
-    paths: PathConfig
-    database: DatabaseConfig
-    exchange: ExchangeApiConfig
-    scraping: ScrapingConfig
-    logging: LoggingConfig
-    global_settings: GlobalSettingsConfig
-    domain: DomainConfig
-    statements: StatementsConfig
-    transformers: TransformersConfig
+    paths: Final[PathConfig]
+    database: Final[DatabaseConfig]
+    exchange: Final[ExchangeApiConfig]
+    scraping: Final[ScrapingConfig]
+    logging: Final[LoggingConfig]
+    global_settings: Final[GlobalSettingsConfig]
+    domain: Final[DomainConfig]
+    statements: Final[StatementsConfig]
+    transformers: Final[TransformersConfig]

--- a/infrastructure/config/domain.py
+++ b/infrastructure/config/domain.py
@@ -1,42 +1,45 @@
-from dataclasses import dataclass, field
+"""Domain-level immutable configuration settings."""
 
-WORDS_TO_REMOVE = [
+from dataclasses import dataclass, field
+from typing import Tuple
+
+WORDS_TO_REMOVE: Tuple[str, ...] = (
     "EM LIQUIDACAO",
     "EM LIQUIDACAO EXTRAJUDICIAL",
     "EXTRAJUDICIAL",
     "EM RECUPERACAO JUDICIAL",
     "EM REC JUDICIAL",
     "EMPRESA FALIDA",
-    "MASSA FALIDA DA", 
-]
+    "MASSA FALIDA DA",
+)
 
-STATEMENTS_TYPES = [
+STATEMENTS_TYPES: Tuple[str, ...] = (
     "DEMONSTRACOES FINANCEIRAS PADRONIZADAS",
     "INFORMACOES TRIMESTRAIS",
-]
+)
 
 
 @dataclass(frozen=True)
 class DomainConfig:
-    """GlobalSettingsConfig holds global configuration settings for the
-    application.
+    """Domain-specific configuration container.
 
     Attributes:
-        words_to_remove (list): A list of words to be removed, initialized with the default value from WORDS_TO_REMOVE.
+        words_to_remove (Tuple[str, ...]): A tuple of words to be removed,
+            initialized with the default value from ``WORDS_TO_REMOVE``.
     """
 
     # Configuration attributes with defaults from WORDS_TO_REMOVE
-    words_to_remove: list = field(default_factory=lambda: WORDS_TO_REMOVE.copy())
-    statements_types: list = field(default_factory=lambda: STATEMENTS_TYPES.copy())
+    words_to_remove: Tuple[str, ...] = field(default_factory=lambda: WORDS_TO_REMOVE)
+    statements_types: Tuple[str, ...] = field(default_factory=lambda: STATEMENTS_TYPES)
 
 
 def load_domain_config() -> DomainConfig:
-    """Loads the global domain configuration settings.
+    """Load the global domain configuration settings.
 
     Returns:
-        GlobalSettingsConfig: An instance of GlobalSettingsConfig initialized with default constants for wait and threshold.
+        GlobalSettingsConfig: An instance of GlobalSettingsConfig initialized
+        with default constants for wait and threshold.
     """
-
     # Run domain settings using default constants
     return DomainConfig(
         words_to_remove=WORDS_TO_REMOVE,


### PR DESCRIPTION
## Summary
- expose configuration subsections as immutable fields
- use tuples for domain configuration constants

## Testing
- `ruff format infrastructure/config/config.py infrastructure/config/domain.py`
- `ruff check infrastructure/config/config.py infrastructure/config/domain.py --fix`
- `pydocstyle --convention=google infrastructure/config/config.py infrastructure/config/domain.py`
- `docformatter --in-place infrastructure/config/config.py infrastructure/config/domain.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689667febc64832ea8cb6ee874e42465