### PR TITLE
Introduce config protocols for type-safe adapters

### DIFF
--- a/application/processors/fetch_statements_processor.py
+++ b/application/processors/fetch_statements_processor.py
@@ -8,6 +8,7 @@ from application.usecases.fetch_statements import FetchStatementsUseCase
 from domain.dto import NsdDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     MetricsCollectorPort,
     NSDRepositoryPort,
@@ -16,7 +17,6 @@ from domain.ports import (
     SqlAlchemyParsedStatementRepositoryPort,
     SqlAlchemyRawStatementRepositoryPort,
 )
-from infrastructure.config import Config
 from infrastructure.helpers import WorkerPool
 
 from .base_processor import BaseProcessor
@@ -24,7 +24,11 @@ from .base_processor import BaseProcessor
 
 class FetchStatementsProcessor(
     BaseProcessor[
-        Tuple[List[NsdDTO], Optional[Callable[[List[RawStatementDTO]], None]], Optional[int]],  # TypeVar("L")
+        Tuple[
+            List[NsdDTO],
+            Optional[Callable[[List[RawStatementDTO]], None]],
+            Optional[int],
+        ],  # TypeVar("L")
         List[Tuple[NsdDTO, List[RawStatementDTO]]],  # TypeVar("T")
         List[Tuple[NsdDTO, List[RawStatementDTO]]],  # TypeVar("P")
     ]
@@ -34,7 +38,7 @@ class FetchStatementsProcessor(
     def __init__(
         self,
         logger: LoggerPort,
-        config: Config,
+        config: ConfigPort,
         source: RawStatementScraperPort,
         company_repo: SqlAlchemyCompanyDataRepositoryPort,
         nsd_repo: NSDRepositoryPort,
@@ -130,4 +134,3 @@ class FetchStatementsProcessor(
     ) -> List[Tuple[NsdDTO, List[RawStatementDTO]]]:
         """No-op persist step; the use case already saves rows."""
         return data
-

--- a/application/processors/parse_statements_processor.py
+++ b/application/processors/parse_statements_processor.py
@@ -9,8 +9,7 @@ from application.usecases.parse_and_classify_statements import (
 )
 from domain.dto import NsdDTO, ParsedStatementDTO, WorkerTaskDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
-from domain.ports import LoggerPort, SqlAlchemyParsedStatementRepositoryPort
-from infrastructure.config import Config
+from domain.ports import ConfigPort, LoggerPort, SqlAlchemyParsedStatementRepositoryPort
 from infrastructure.helpers import MetricsCollector, WorkerPool
 
 from .base_processor import BaseProcessor
@@ -23,7 +22,7 @@ class ParseStatementsProcessor(BaseProcessor):
         self,
         logger: LoggerPort,
         repository: SqlAlchemyParsedStatementRepositoryPort,
-        config: Config,
+        config: ConfigPort,
         max_workers: int = 1,
     ) -> None:
         """Store dependencies for the processor."""

--- a/application/processors/transform_statements_processor.py
+++ b/application/processors/transform_statements_processor.py
@@ -6,9 +6,8 @@ from typing import List
 
 from application.usecases.transform_statements import TransformStatementsUseCase
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
-from domain.ports import LoggerPort, SqlAlchemyParsedStatementRepositoryPort
+from domain.ports import ConfigPort, LoggerPort, SqlAlchemyParsedStatementRepositoryPort
 from domain.services import StatementClassificationService
-from infrastructure.config import Config
 from infrastructure.transformers import (
     IntelStatementTransformerAdapter,
     MathStatementTransformerAdapter,
@@ -22,7 +21,7 @@ class TransformStatementsProcessor(BaseProcessor):
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         parsed_repo: SqlAlchemyParsedStatementRepositoryPort,
     ) -> None:

--- a/application/services/company_data_service.py
+++ b/application/services/company_data_service.py
@@ -4,10 +4,10 @@ from application.usecases.sync_companies import SyncCompanyDataUseCase
 from domain.dto import SyncCompanyDataResultDTO
 from domain.ports import (
     CompanyDataScraperPort,
+    ConfigPort,
     LoggerPort,
     SqlAlchemyCompanyDataRepositoryPort,
 )
-from infrastructure.config import Config
 
 
 class CompanyDataService:
@@ -15,7 +15,7 @@ class CompanyDataService:
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         repository: SqlAlchemyCompanyDataRepositoryPort,
         scraper: CompanyDataScraperPort,

--- a/application/services/nsd_service.py
+++ b/application/services/nsd_service.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from application.usecases.sync_nsd import SyncNSDUseCase
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     NSDRepositoryPort,
     NSDSourcePort,
     SqlAlchemyCompanyDataRepositoryPort,
 )
-from infrastructure.config import Config
-from infrastructure.utils.id_generator import IdGenerator
 
 
 class NsdService:
@@ -16,7 +15,7 @@ class NsdService:
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         repository: NSDRepositoryPort,
         company_repo: SqlAlchemyCompanyDataRepositoryPort,
@@ -31,7 +30,7 @@ class NsdService:
             logger=logger,
             repository=repository,
             company_repo=company_repo,
-            scraper=scraper
+            scraper=scraper,
         )
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")

--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -9,13 +9,13 @@ from domain.dto.nsd_dto import NsdDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.dto.worker_class_dto import WorkerTaskDTO
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     MetricsCollectorPort,
     RawStatementScraperPort,
     SqlAlchemyParsedStatementRepositoryPort,
     SqlAlchemyRawStatementRepositoryPort,
 )
-from infrastructure.config import Config
 from infrastructure.helpers import ByteFormatter, SaveStrategy, WorkerPool
 
 
@@ -30,7 +30,7 @@ class FetchStatementsUseCase:
         parsed_statements_repo: SqlAlchemyParsedStatementRepositoryPort,
         metrics_collector: MetricsCollectorPort,
         worker_pool_executor: WorkerPool,
-        config: Config,
+        config: ConfigPort,
         max_workers: int = 1,
     ) -> None:
         """Store dependencies for fetching and saving raw rows."""

--- a/application/usecases/parse_and_classify_statements.py
+++ b/application/usecases/parse_and_classify_statements.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from domain.dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     SqlAlchemyParsedStatementRepositoryPort,
 )
 from domain.utils.statement_processing import classify_section
-from infrastructure.config import Config
 from infrastructure.helpers import SaveStrategy
 
 
@@ -18,7 +18,7 @@ class ParseAndClassifyStatementsUseCase:
         self,
         logger: LoggerPort,
         repository: SqlAlchemyParsedStatementRepositoryPort,
-        config: Config,
+        config: ConfigPort,
     ) -> None:
         self.logger = logger
         self.repository = repository

--- a/application/usecases/sync_nsd.py
+++ b/application/usecases/sync_nsd.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from domain.dto.nsd_dto import NsdDTO
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     NSDRepositoryPort,
     NSDSourcePort,
     SqlAlchemyCompanyDataRepositoryPort,
 )
-from infrastructure.config import Config
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.utils.id_generator import IdGenerator
 
@@ -17,12 +17,11 @@ class SyncNSDUseCase:
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         repository: NSDRepositoryPort,
         company_repo: SqlAlchemyCompanyDataRepositoryPort,
         scraper: NSDSourcePort,
-
     ) -> None:
         """Store dependencies required for synchronization."""
         self.config = config
@@ -63,7 +62,9 @@ class SyncNSDUseCase:
     def _save_batch(self, buffer: list[NsdDTO]) -> None:
         """Persist a batch of raw data after converting to domain DTOs."""
 
-        flat_items = ListFlattener.flatten(buffer)  # recebe nested lists, devolve flat list
+        flat_items = ListFlattener.flatten(
+            buffer
+        )  # recebe nested lists, devolve flat list
 
         # Transform raw DTOs from the scraper to domain DTOs.
         dtos = [NsdDTO.from_raw(item) for item in flat_items]
@@ -71,7 +72,10 @@ class SyncNSDUseCase:
         names = {dto.company_name for dto in dtos if dto.company_name}
         # → busca os já cadastrados
         existing_companies = {
-            company_name for (company_name,) in self.company_repo.get_existing_by_columns("company_name")
+            company_name
+            for (company_name,) in self.company_repo.get_existing_by_columns(
+                "company_name"
+            )
         }
         missing = names - existing_companies
         if missing:
@@ -79,9 +83,8 @@ class SyncNSDUseCase:
 
             to_create = [
                 CompanyDataDTO(
-                    cvm_code=self.id_generator.create_id(size=6),
-                    company_name=name
-                    )
+                    cvm_code=self.id_generator.create_id(size=6), company_name=name
+                )
                 for name in missing
             ]
             # insere todas as empresas faltantes de uma vez

--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -6,10 +6,9 @@ from typing import List
 
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
-from domain.ports import LoggerPort
+from domain.ports import ConfigPort, LoggerPort
 from domain.utils.validation_utils import validate_quarter_completeness
 from domain.utils.version_utils import filter_latest_versions
-from infrastructure.config import Config
 
 
 class TransformStatementsUseCase:
@@ -19,7 +18,7 @@ class TransformStatementsUseCase:
         self,
         math_transformer: StatementTransformerPort,
         intel_transformer: StatementTransformerPort,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
     ) -> None:
         self.math_transformer = math_transformer

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -4,7 +4,10 @@ from .base_repository_port import SqlAlchemyRepositoryBasePort
 from .base_scraper_port import BaseScraperPort
 from .company_data_scraper_port import CompanyDataScraperPort
 from .company_repository_port import SqlAlchemyCompanyDataRepositoryPort
+from .config_port import ConfigPort
 from .data_cleaner_port import DataCleanerPort
+from .domain_config_port import DomainConfigPort
+from .global_settings_config_port import GlobalSettingsConfigPort
 from .logger_port import LoggerPort
 from .metrics_collector_port import MetricsCollectorPort
 from .nsd_repository_port import NSDRepositoryPort
@@ -12,12 +15,17 @@ from .nsd_source_port import NSDSourcePort
 from .parsed_statement_repository_port import SqlAlchemyParsedStatementRepositoryPort
 from .raw_statement_repository_port import SqlAlchemyRawStatementRepositoryPort
 from .raw_statement_scraper_port import RawStatementScraperPort
+from .transformers_config_port import TransformersConfigPort
 from .worker_pool_port import WorkerPoolPort
 
 __all__ = [
     "WorkerPoolPort",
     "LoggerPort",
     "DataCleanerPort",
+    "ConfigPort",
+    "DomainConfigPort",
+    "GlobalSettingsConfigPort",
+    "TransformersConfigPort",
     "SqlAlchemyRepositoryBasePort",
     "BaseScraperPort",
     "SqlAlchemyCompanyDataRepositoryPort",

--- a/domain/ports/config_port.py
+++ b/domain/ports/config_port.py
@@ -1,0 +1,17 @@
+"""Aggregate protocol for application configuration."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .domain_config_port import DomainConfigPort
+from .global_settings_config_port import GlobalSettingsConfigPort
+from .transformers_config_port import TransformersConfigPort
+
+
+class ConfigPort(Protocol):
+    """Expose configuration sections required by the application."""
+
+    domain: DomainConfigPort
+    global_settings: GlobalSettingsConfigPort
+    transformers: TransformersConfigPort

--- a/domain/ports/domain_config_port.py
+++ b/domain/ports/domain_config_port.py
@@ -1,0 +1,12 @@
+"""Port definition for domain configuration settings."""
+
+from __future__ import annotations
+
+from typing import Protocol, Tuple
+
+
+class DomainConfigPort(Protocol):
+    """Expose domain-level configuration values."""
+
+    words_to_remove: Tuple[str, ...]
+    statements_types: Tuple[str, ...]

--- a/domain/ports/global_settings_config_port.py
+++ b/domain/ports/global_settings_config_port.py
@@ -1,0 +1,17 @@
+"""Port definition for global settings configuration."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class GlobalSettingsConfigPort(Protocol):
+    """Expose application-wide configuration values."""
+
+    app_name: str
+    wait: int
+    threshold: int
+    max_linear_holes: int
+    max_workers: int
+    batch_size: int
+    queue_size: int

--- a/domain/ports/transformers_config_port.py
+++ b/domain/ports/transformers_config_port.py
@@ -1,0 +1,16 @@
+"""Port definition for transformer configuration values."""
+
+from __future__ import annotations
+
+from typing import Iterable, Protocol, Tuple
+
+
+class TransformersConfigPort(Protocol):
+    """Expose settings for statement transformers."""
+
+    math_year_end_prefixes: Tuple[str, ...]
+    math_cumulative_prefixes: Tuple[str, ...]
+    math_target_accounts: Tuple[str, ...]
+    intel_year_end_prefixes: Tuple[str, ...]
+    intel_cumulative_prefixes: Tuple[str, ...]
+    intel_section_criteria: Tuple[Tuple[str, Iterable[dict]], ...]

--- a/infrastructure/config/domain.py
+++ b/infrastructure/config/domain.py
@@ -1,43 +1,33 @@
 from dataclasses import dataclass, field
+from typing import Tuple
 
-WORDS_TO_REMOVE = [
+WORDS_TO_REMOVE: Tuple[str, ...] = (
     "EM LIQUIDACAO",
     "EM LIQUIDACAO EXTRAJUDICIAL",
     "EXTRAJUDICIAL",
     "EM RECUPERACAO JUDICIAL",
     "EM REC JUDICIAL",
     "EMPRESA FALIDA",
-    "MASSA FALIDA DA", 
-]
+    "MASSA FALIDA DA",
+)
 
-STATEMENTS_TYPES = [
+STATEMENTS_TYPES: Tuple[str, ...] = (
     "DEMONSTRACOES FINANCEIRAS PADRONIZADAS",
     "INFORMACOES TRIMESTRAIS",
-]
+)
 
 
 @dataclass(frozen=True)
 class DomainConfig:
-    """GlobalSettingsConfig holds global configuration settings for the
-    application.
+    """Domain-specific configuration settings."""
 
-    Attributes:
-        words_to_remove (list): A list of words to be removed, initialized with the default value from WORDS_TO_REMOVE.
-    """
-
-    # Configuration attributes with defaults from WORDS_TO_REMOVE
-    words_to_remove: list = field(default_factory=lambda: WORDS_TO_REMOVE.copy())
-    statements_types: list = field(default_factory=lambda: STATEMENTS_TYPES.copy())
+    words_to_remove: Tuple[str, ...] = field(default_factory=lambda: WORDS_TO_REMOVE)
+    statements_types: Tuple[str, ...] = field(default_factory=lambda: STATEMENTS_TYPES)
 
 
 def load_domain_config() -> DomainConfig:
-    """Loads the global domain configuration settings.
+    """Load the domain configuration settings."""
 
-    Returns:
-        GlobalSettingsConfig: An instance of GlobalSettingsConfig initialized with default constants for wait and threshold.
-    """
-
-    # Run domain settings using default constants
     return DomainConfig(
         words_to_remove=WORDS_TO_REMOVE,
         statements_types=STATEMENTS_TYPES,

--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Callable, Generic, List, Optional, TypeVar
 
-from infrastructure.config import Config
+from domain.ports import ConfigPort
 
 T = TypeVar("T")
 
@@ -17,7 +17,7 @@ class SaveStrategy(Generic[T]):
         self,
         save_callback: Optional[Callable[[List[T]], None]] = None,
         threshold: Optional[int] = None,
-        config: Optional[Config] = None,
+        config: Optional[ConfigPort] = None,
     ) -> None:
         """Create a new strategy instance.
 

--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -8,8 +8,7 @@ from queue import Queue
 from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar
 
 from domain.dto import ExecutionResultDTO, WorkerTaskDTO
-from domain.ports import LoggerPort, MetricsCollectorPort, WorkerPoolPort
-from infrastructure.config import Config
+from domain.ports import ConfigPort, LoggerPort, MetricsCollectorPort, WorkerPoolPort
 from infrastructure.helpers.byte_formatter import ByteFormatter
 
 T = WorkerTaskDTO
@@ -22,7 +21,7 @@ class WorkerPool(WorkerPoolPort):
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         metrics_collector: MetricsCollectorPort,
         max_workers: Optional[int] = None,
     ) -> None:

--- a/infrastructure/transformers/intel_statement_transformer.py
+++ b/infrastructure/transformers/intel_statement_transformer.py
@@ -7,9 +7,8 @@ from typing import Dict, Iterable, List, Tuple
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
+from domain.ports import ConfigPort
 from domain.services import StatementClassificationService
-from domain.utils import parse_quarter
-from infrastructure.config import Config
 from infrastructure.config.intel_criteria import load_intel_criteria_nodes
 
 
@@ -18,7 +17,7 @@ class IntelStatementTransformerAdapter(StatementTransformerPort):
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         classification_service: StatementClassificationService,
     ) -> None:
         self.classification_service = classification_service
@@ -29,13 +28,16 @@ class IntelStatementTransformerAdapter(StatementTransformerPort):
     def transform(self, rows: List[RawStatementDTO]) -> List[ParsedStatementDTO]:
         """Run the Intel transformation pipeline."""
         from infrastructure.utils.csv_utils import save_dtos_to_csv
+
         save_dtos_to_csv(rows, "raws_statements_stage_4_0.csv")
 
         transformed1 = self.classification_service.classify(rows, self.criteria_tree)
         save_dtos_to_csv(transformed1, "raws_statements_stage_4_1_standardized.csv")
 
         transformed2 = self.detect_and_correct_outliers(transformed1)
-        save_dtos_to_csv(transformed2, "raws_statements_stage_4_2_corrected_outliers.csv")
+        save_dtos_to_csv(
+            transformed2, "raws_statements_stage_4_2_corrected_outliers.csv"
+        )
 
         return transformed2
 
@@ -82,7 +84,7 @@ class IntelStatementTransformerAdapter(StatementTransformerPort):
 
                 # Listas de vizinhos
                 vals_prev = [r.value for r in items[window_start:i]]
-                vals_next = [r.value for r in items[i+1:window_end]]
+                vals_next = [r.value for r in items[i + 1 : window_end]]
 
                 # Se não houver nenhum vizinho, mantém valor
                 if not vals_prev and not vals_next:
@@ -90,7 +92,7 @@ class IntelStatementTransformerAdapter(StatementTransformerPort):
                     continue
 
                 # Vamos testar janelas regressivamente (maior -> menor)
-                windows_max = min(neighbor_count, len(items)-1)
+                windows_max = min(neighbor_count, len(items) - 1)
                 new_val = val
 
                 for n in range(windows_max, 0, -1):
@@ -118,4 +120,3 @@ class IntelStatementTransformerAdapter(StatementTransformerPort):
             results.extend(corrected)
 
         return results
-

--- a/infrastructure/transformers/math_statement_transformer.py
+++ b/infrastructure/transformers/math_statement_transformer.py
@@ -6,13 +6,13 @@ from typing import Dict, List, Tuple
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
-from infrastructure.config import Config
+from domain.ports import ConfigPort
 
 
 class MathStatementTransformerAdapter(StatementTransformerPort):
     """Adjust quarterly statement values."""
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: ConfigPort) -> None:
         self.year_end_prefixes = tuple(config.transformers.math_year_end_prefixes)
         self.cumulative_prefixes = tuple(config.transformers.math_cumulative_prefixes)
         self.target_accounts = set(config.transformers.math_target_accounts)
@@ -25,7 +25,7 @@ class MathStatementTransformerAdapter(StatementTransformerPort):
             row.grupo,
             row.quadro,
             str(year),
-            "" # row.version or "",
+            "",  # row.version or "",
         )
 
     def _parse(self, quarter: str | None) -> datetime | None:

--- a/infrastructure/utils/id_generator.py
+++ b/infrastructure/utils/id_generator.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from typing import Optional
 
-from infrastructure.config import Config
+from domain.ports import ConfigPort
 
 
 class IdGenerator:
@@ -21,7 +21,7 @@ class IdGenerator:
     hex pseudo-aleatórios do UUID-4
     """
 
-    def __init__(self, config: Config, logger_name: str = "FLY") -> None:
+    def __init__(self, config: ConfigPort, logger_name: str = "FLY") -> None:
         self.config = config
         self.logger_name = logger_name or self.config.global_settings.app_name or "FLY"
 


### PR DESCRIPTION
## Summary
- add ConfigPort and related protocol types
- convert domain config lists to immutable tuples
- refactor processors and helpers to depend on ConfigPort

## Testing
- `ruff format application/processors/fetch_statements_processor.py application/processors/parse_statements_processor.py application/processors/transform_statements_processor.py application/services/company_data_service.py application/services/nsd_service.py application/usecases/fetch_statements.py application/usecases/parse_and_classify_statements.py application/usecases/sync_nsd.py application/usecases/transform_statements.py domain/ports/__init__.py domain/ports/config_port.py domain/ports/domain_config_port.py domain/ports/global_settings_config_port.py domain/ports/transformers_config_port.py infrastructure/config/domain.py infrastructure/helpers/save_strategy.py infrastructure/helpers/worker_pool.py infrastructure/transformers/intel_statement_transformer.py infrastructure/transformers/math_statement_transformer.py infrastructure/utils/id_generator.py`
- `ruff check application/processors/fetch_statements_processor.py application/processors/parse_statements_processor.py application/processors/transform_statements_processor.py application/services/company_data_service.py application/services/nsd_service.py application/usecases/fetch_statements.py application/usecases/parse_and_classify_statements.py application/usecases/sync_nsd.py application/usecases/transform_statements.py domain/ports/__init__.py domain/ports/config_port.py domain/ports/domain_config_port.py domain/ports/global_settings_config_port.py domain/ports/transformers_config_port.py infrastructure/config/domain.py infrastructure/helpers/save_strategy.py infrastructure/helpers/worker_pool.py infrastructure/transformers/intel_statement_transformer.py infrastructure/transformers/math_statement_transformer.py infrastructure/utils/id_generator.py --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place application/processors/fetch_statements_processor.py application/processors/parse_statements_processor.py application/processors/transform_statements_processor.py application/services/company_data_service.py application/services/nsd_service.py application/usecases/fetch_statements.py application/usecases/parse_and_classify_statements.py application/usecases/sync_nsd.py application/usecases/transform_statements.py domain/ports/__init__.py domain/ports/config_port.py domain/ports/domain_config_port.py domain/ports/global_settings_config_port.py domain/ports/transformers_config_port.py infrastructure/config/domain.py infrastructure/helpers/save_strategy.py infrastructure/helpers/worker_pool.py infrastructure/transformers/intel_statement_transformer.py infrastructure/transformers/math_statement_transformer.py infrastructure/utils/id_generator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689667febc64832ea8cb6ee874e42465