### PR TITLE
refactor: align config with ports

### DIFF
--- a/infrastructure/config/config.py
+++ b/infrastructure/config/config.py
@@ -1,17 +1,20 @@
 """Aggregate configuration object that loads all config sections."""
 
+from domain.ports import (
+    DomainConfigPort,
+    GlobalSettingsConfigPort,
+    TransformersConfigPort,
+)
+
 from .database import DatabaseConfig, load_database_config
-from .domain import DomainConfig, load_domain_config
+from .domain import load_domain_config
 from .exchange_api import ExchangeApiConfig, load_exchange_api_config
-from .global_settings import GlobalSettingsConfig, load_global_settings_config
+from .global_settings import load_global_settings_config
 from .logging import LoggingConfig, load_logging_config
 from .paths import PathConfig, load_paths
 from .scraping import ScrapingConfig, load_scraping_config
 from .statements import StatementsConfig, load_statements_config
-from .transformers import (
-    TransformersConfig,
-    load_transformers_config,
-)
+from .transformers import load_transformers_config
 
 
 class Config:
@@ -29,7 +32,7 @@ class Config:
         self.exchange: ExchangeApiConfig = load_exchange_api_config()
         self.scraping: ScrapingConfig = load_scraping_config()
         self.logging: LoggingConfig = load_logging_config()
-        self.global_settings: GlobalSettingsConfig = load_global_settings_config()
-        self.domain: DomainConfig = load_domain_config()
+        self.global_settings: GlobalSettingsConfigPort = load_global_settings_config()
+        self.domain: DomainConfigPort = load_domain_config()
         self.statements: StatementsConfig = load_statements_config()
-        self.transformers: TransformersConfig = load_transformers_config()
+        self.transformers: TransformersConfigPort = load_transformers_config()

--- a/infrastructure/config/domain.py
+++ b/infrastructure/config/domain.py
@@ -1,43 +1,44 @@
-from dataclasses import dataclass, field
+"""Domain-related configuration values."""
 
-WORDS_TO_REMOVE = [
+from dataclasses import dataclass, field
+from typing import Tuple
+
+WORDS_TO_REMOVE: Tuple[str, ...] = (
     "EM LIQUIDACAO",
     "EM LIQUIDACAO EXTRAJUDICIAL",
     "EXTRAJUDICIAL",
     "EM RECUPERACAO JUDICIAL",
     "EM REC JUDICIAL",
     "EMPRESA FALIDA",
-    "MASSA FALIDA DA", 
-]
+    "MASSA FALIDA DA",
+)
 
-STATEMENTS_TYPES = [
+STATEMENTS_TYPES: Tuple[str, ...] = (
     "DEMONSTRACOES FINANCEIRAS PADRONIZADAS",
     "INFORMACOES TRIMESTRAIS",
-]
+)
 
 
 @dataclass(frozen=True)
 class DomainConfig:
-    """GlobalSettingsConfig holds global configuration settings for the
-    application.
+    """Domain configuration values.
 
     Attributes:
-        words_to_remove (list): A list of words to be removed, initialized with the default value from WORDS_TO_REMOVE.
+        words_to_remove: Words to strip from company names.
+        statements_types: Allowed statement categories.
     """
 
-    # Configuration attributes with defaults from WORDS_TO_REMOVE
-    words_to_remove: list = field(default_factory=lambda: WORDS_TO_REMOVE.copy())
-    statements_types: list = field(default_factory=lambda: STATEMENTS_TYPES.copy())
+    # Configuration attributes with immutable defaults
+    words_to_remove: Tuple[str, ...] = field(default_factory=lambda: WORDS_TO_REMOVE)
+    statements_types: Tuple[str, ...] = field(default_factory=lambda: STATEMENTS_TYPES)
 
 
 def load_domain_config() -> DomainConfig:
-    """Loads the global domain configuration settings.
+    """Load the domain configuration settings.
 
     Returns:
-        GlobalSettingsConfig: An instance of GlobalSettingsConfig initialized with default constants for wait and threshold.
+        DomainConfig: An instance initialized with default constants.
     """
-
-    # Run domain settings using default constants
     return DomainConfig(
         words_to_remove=WORDS_TO_REMOVE,
         statements_types=STATEMENTS_TYPES,

--- a/infrastructure/config/global_settings.py
+++ b/infrastructure/config/global_settings.py
@@ -1,27 +1,24 @@
+"""Configuration values shared across the application."""
+
 from dataclasses import dataclass, field
 
-APP_NAME = "FLY" # Application name
+APP_NAME = "FLY"  # Application name
 
 WAIT = 2  # Default wait time in seconds
 THRESHOLD = 500  # Default threshold for saving data
 MAX_LINEAR_HOLES = 200  # Maximum number of linear holes allowed
 MAX_WORKERS = 1  # Default number of threads for sync operations
 BATCH_SIZE = 100  # Number of items per repository batch
-QUEUE_SIZE = 1 * MAX_WORKERS # Max queue size for producer/consumer pipeline
+QUEUE_SIZE = 1 * MAX_WORKERS  # Max queue size for producer/consumer pipeline
+
 
 @dataclass(frozen=True)
 class GlobalSettingsConfig:
-    """
-    GlobalSettingsConfig class holds global configuration settings.
+    """Global configuration settings.
 
     Attributes:
-        wait (int): The waiting time, initialized with the value of WAIT.
-        threshold (int): The threshold for saving, initialized with the value of THRESHOLD.
-
-    Logic Steps:
-    1. Define class attributes for configuration parameters. # Define attributes for wait and threshold
-    2. Use 'field' to set default values from external constants (WAIT, THRESHOLD). # Set defaults using WAIT and THRESHOLD
-    3. These settings can be used throughout the application for consistent configuration. # Use these settings app-wide
+        wait: Default wait time in seconds.
+        threshold: Threshold for saving data.
     """
 
     # Configuration attributes with defaults
@@ -29,25 +26,17 @@ class GlobalSettingsConfig:
     wait: int = field(default=WAIT)
     threshold: int = field(default=THRESHOLD)
     max_linear_holes: int = field(default=MAX_LINEAR_HOLES)
-    max_workers: int = field(default=MAX_WORKERS)
+    max_workers: int | None = field(default=MAX_WORKERS)
     batch_size: int = field(default=BATCH_SIZE)
     queue_size: int = field(default=QUEUE_SIZE)
 
 
-
 def load_global_settings_config() -> GlobalSettingsConfig:
-    """
-    Loads and returns a GlobalSettingsConfig instance with default global settings.
+    """Load and return the global settings configuration.
 
     Returns:
-        GlobalSettingsConfig: An instance initialized with the default WAIT and THRESHOLD values.
-
-    Logic Steps:
-    1. Use the WAIT and THRESHOLD constants as configuration values.
-    2. Create and return a GlobalSettingsConfig instance with these values.
+        GlobalSettingsConfig: Instance initialized with default values.
     """
-
-    # Run global settings using default constants
     return GlobalSettingsConfig(
         app_name=APP_NAME,
         wait=WAIT,
@@ -57,4 +46,3 @@ def load_global_settings_config() -> GlobalSettingsConfig:
         batch_size=BATCH_SIZE,
         queue_size=QUEUE_SIZE,
     )
-


### PR DESCRIPTION
## Summary
- ensure configuration uses domain ports for type safety
- switch domain settings to immutable tuples
- document global configuration and allow optional worker count

## Testing
- `ruff format infrastructure/config/config.py infrastructure/config/domain.py infrastructure/config/global_settings.py`
- `ruff check infrastructure/config/config.py infrastructure/config/domain.py infrastructure/config/global_settings.py --fix`
- `pydocstyle --convention=google infrastructure/config/config.py infrastructure/config/domain.py infrastructure/config/global_settings.py`
- `docformatter --in-place infrastructure/config/config.py infrastructure/config/domain.py infrastructure/config/global_settings.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68966dfcab14832e9639e9c44c8e7b00