### PR TITLE
refactor: inject runtime config and database url

### DIFF
--- a/application/processors/fetch_statements_processor.py
+++ b/application/processors/fetch_statements_processor.py
@@ -8,6 +8,7 @@ from application.usecases.fetch_statements import FetchStatementsUseCase
 from domain.dto import NsdDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     MetricsCollectorPort,
     NSDRepositoryPort,
@@ -16,7 +17,6 @@ from domain.ports import (
     SqlAlchemyParsedStatementRepositoryPort,
     SqlAlchemyRawStatementRepositoryPort,
 )
-from infrastructure.config import Config
 from infrastructure.helpers import WorkerPool
 
 from .base_processor import BaseProcessor
@@ -24,7 +24,11 @@ from .base_processor import BaseProcessor
 
 class FetchStatementsProcessor(
     BaseProcessor[
-        Tuple[List[NsdDTO], Optional[Callable[[List[RawStatementDTO]], None]], Optional[int]],  # TypeVar("L")
+        Tuple[
+            List[NsdDTO],
+            Optional[Callable[[List[RawStatementDTO]], None]],
+            Optional[int],
+        ],  # TypeVar("L")
         List[Tuple[NsdDTO, List[RawStatementDTO]]],  # TypeVar("T")
         List[Tuple[NsdDTO, List[RawStatementDTO]]],  # TypeVar("P")
     ]
@@ -34,7 +38,7 @@ class FetchStatementsProcessor(
     def __init__(
         self,
         logger: LoggerPort,
-        config: Config,
+        config: ConfigPort,
         source: RawStatementScraperPort,
         company_repo: SqlAlchemyCompanyDataRepositoryPort,
         nsd_repo: NSDRepositoryPort,
@@ -130,4 +134,3 @@ class FetchStatementsProcessor(
     ) -> List[Tuple[NsdDTO, List[RawStatementDTO]]]:
         """No-op persist step; the use case already saves rows."""
         return data
-

--- a/application/processors/parse_statements_processor.py
+++ b/application/processors/parse_statements_processor.py
@@ -9,8 +9,11 @@ from application.usecases.parse_and_classify_statements import (
 )
 from domain.dto import NsdDTO, ParsedStatementDTO, WorkerTaskDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
-from domain.ports import LoggerPort, SqlAlchemyParsedStatementRepositoryPort
-from infrastructure.config import Config
+from domain.ports import (
+    ConfigPort,
+    LoggerPort,
+    SqlAlchemyParsedStatementRepositoryPort,
+)
 from infrastructure.helpers import MetricsCollector, WorkerPool
 
 from .base_processor import BaseProcessor
@@ -23,7 +26,7 @@ class ParseStatementsProcessor(BaseProcessor):
         self,
         logger: LoggerPort,
         repository: SqlAlchemyParsedStatementRepositoryPort,
-        config: Config,
+        config: ConfigPort,
         max_workers: int = 1,
     ) -> None:
         """Store dependencies for the processor."""

--- a/application/processors/transform_statements_processor.py
+++ b/application/processors/transform_statements_processor.py
@@ -6,9 +6,8 @@ from typing import List
 
 from application.usecases.transform_statements import TransformStatementsUseCase
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
-from domain.ports import LoggerPort, SqlAlchemyParsedStatementRepositoryPort
+from domain.ports import ConfigPort, LoggerPort, SqlAlchemyParsedStatementRepositoryPort
 from domain.services import StatementClassificationService
-from infrastructure.config import Config
 from infrastructure.transformers import (
     IntelStatementTransformerAdapter,
     MathStatementTransformerAdapter,
@@ -22,7 +21,7 @@ class TransformStatementsProcessor(BaseProcessor):
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         parsed_repo: SqlAlchemyParsedStatementRepositoryPort,
     ) -> None:

--- a/application/services/company_data_service.py
+++ b/application/services/company_data_service.py
@@ -4,10 +4,10 @@ from application.usecases.sync_companies import SyncCompanyDataUseCase
 from domain.dto import SyncCompanyDataResultDTO
 from domain.ports import (
     CompanyDataScraperPort,
+    ConfigPort,
     LoggerPort,
     SqlAlchemyCompanyDataRepositoryPort,
 )
-from infrastructure.config import Config
 
 
 class CompanyDataService:
@@ -15,7 +15,7 @@ class CompanyDataService:
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         repository: SqlAlchemyCompanyDataRepositoryPort,
         scraper: CompanyDataScraperPort,

--- a/application/services/nsd_service.py
+++ b/application/services/nsd_service.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from application.usecases.sync_nsd import SyncNSDUseCase
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     NSDRepositoryPort,
     NSDSourcePort,
     SqlAlchemyCompanyDataRepositoryPort,
 )
-from infrastructure.config import Config
-from infrastructure.utils.id_generator import IdGenerator
 
 
 class NsdService:
@@ -16,7 +15,7 @@ class NsdService:
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         repository: NSDRepositoryPort,
         company_repo: SqlAlchemyCompanyDataRepositoryPort,
@@ -31,7 +30,7 @@ class NsdService:
             logger=logger,
             repository=repository,
             company_repo=company_repo,
-            scraper=scraper
+            scraper=scraper,
         )
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")

--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -9,13 +9,13 @@ from domain.dto.nsd_dto import NsdDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.dto.worker_class_dto import WorkerTaskDTO
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     MetricsCollectorPort,
     RawStatementScraperPort,
     SqlAlchemyParsedStatementRepositoryPort,
     SqlAlchemyRawStatementRepositoryPort,
 )
-from infrastructure.config import Config
 from infrastructure.helpers import ByteFormatter, SaveStrategy, WorkerPool
 
 
@@ -30,7 +30,7 @@ class FetchStatementsUseCase:
         parsed_statements_repo: SqlAlchemyParsedStatementRepositoryPort,
         metrics_collector: MetricsCollectorPort,
         worker_pool_executor: WorkerPool,
-        config: Config,
+        config: ConfigPort,
         max_workers: int = 1,
     ) -> None:
         """Store dependencies for fetching and saving raw rows."""

--- a/application/usecases/parse_and_classify_statements.py
+++ b/application/usecases/parse_and_classify_statements.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from domain.dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     SqlAlchemyParsedStatementRepositoryPort,
 )
 from domain.utils.statement_processing import classify_section
-from infrastructure.config import Config
 from infrastructure.helpers import SaveStrategy
 
 
@@ -18,7 +18,7 @@ class ParseAndClassifyStatementsUseCase:
         self,
         logger: LoggerPort,
         repository: SqlAlchemyParsedStatementRepositoryPort,
-        config: Config,
+        config: ConfigPort,
     ) -> None:
         self.logger = logger
         self.repository = repository

--- a/application/usecases/sync_nsd.py
+++ b/application/usecases/sync_nsd.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from domain.dto.nsd_dto import NsdDTO
 from domain.ports import (
+    ConfigPort,
     LoggerPort,
     NSDRepositoryPort,
     NSDSourcePort,
     SqlAlchemyCompanyDataRepositoryPort,
 )
-from infrastructure.config import Config
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.utils.id_generator import IdGenerator
 
@@ -17,12 +17,11 @@ class SyncNSDUseCase:
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         repository: NSDRepositoryPort,
         company_repo: SqlAlchemyCompanyDataRepositoryPort,
         scraper: NSDSourcePort,
-
     ) -> None:
         """Store dependencies required for synchronization."""
         self.config = config
@@ -63,7 +62,9 @@ class SyncNSDUseCase:
     def _save_batch(self, buffer: list[NsdDTO]) -> None:
         """Persist a batch of raw data after converting to domain DTOs."""
 
-        flat_items = ListFlattener.flatten(buffer)  # recebe nested lists, devolve flat list
+        flat_items = ListFlattener.flatten(
+            buffer
+        )  # recebe nested lists, devolve flat list
 
         # Transform raw DTOs from the scraper to domain DTOs.
         dtos = [NsdDTO.from_raw(item) for item in flat_items]
@@ -71,7 +72,10 @@ class SyncNSDUseCase:
         names = {dto.company_name for dto in dtos if dto.company_name}
         # → busca os já cadastrados
         existing_companies = {
-            company_name for (company_name,) in self.company_repo.get_existing_by_columns("company_name")
+            company_name
+            for (company_name,) in self.company_repo.get_existing_by_columns(
+                "company_name"
+            )
         }
         missing = names - existing_companies
         if missing:
@@ -79,9 +83,8 @@ class SyncNSDUseCase:
 
             to_create = [
                 CompanyDataDTO(
-                    cvm_code=self.id_generator.create_id(size=6),
-                    company_name=name
-                    )
+                    cvm_code=self.id_generator.create_id(size=6), company_name=name
+                )
                 for name in missing
             ]
             # insere todas as empresas faltantes de uma vez

--- a/application/usecases/transform_statements.py
+++ b/application/usecases/transform_statements.py
@@ -6,10 +6,9 @@ from typing import List
 
 from application.ports import StatementTransformerPort
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
-from domain.ports import LoggerPort
+from domain.ports import ConfigPort, LoggerPort
 from domain.utils.validation_utils import validate_quarter_completeness
 from domain.utils.version_utils import filter_latest_versions
-from infrastructure.config import Config
 
 
 class TransformStatementsUseCase:
@@ -19,7 +18,7 @@ class TransformStatementsUseCase:
         self,
         math_transformer: StatementTransformerPort,
         intel_transformer: StatementTransformerPort,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
     ) -> None:
         self.math_transformer = math_transformer

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -4,6 +4,7 @@ from .base_repository_port import SqlAlchemyRepositoryBasePort
 from .base_scraper_port import BaseScraperPort
 from .company_data_scraper_port import CompanyDataScraperPort
 from .company_repository_port import SqlAlchemyCompanyDataRepositoryPort
+from .config_port import ConfigPort
 from .data_cleaner_port import DataCleanerPort
 from .logger_port import LoggerPort
 from .metrics_collector_port import MetricsCollectorPort
@@ -28,4 +29,5 @@ __all__ = [
     "RawStatementScraperPort",
     "SqlAlchemyRawStatementRepositoryPort",
     "SqlAlchemyParsedStatementRepositoryPort",
+    "ConfigPort",
 ]

--- a/domain/ports/config_port.py
+++ b/domain/ports/config_port.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Protocol, Sequence
+
+
+class GlobalSettingsPort(Protocol):
+    """Minimal subset of global runtime settings used by the application."""
+
+    max_workers: int
+    # Optional additional settings like batch_size can be added here
+
+
+class DomainConfigPort(Protocol):
+    """Domain-specific configuration values."""
+
+    statements_types: Sequence[str]
+
+
+class TransformersConfigPort(Protocol):
+    """Configuration for statement transformers."""
+
+    math_target_accounts: Sequence[str]
+
+
+class ConfigPort(Protocol):
+    """Structural contract for configuration objects used across layers."""
+
+    global_settings: GlobalSettingsPort
+    domain: DomainConfigPort
+    transformers: TransformersConfigPort
+    # Additional sections can be included as needed

--- a/infrastructure/adapters/sqlalchemy_engine_mixin.py
+++ b/infrastructure/adapters/sqlalchemy_engine_mixin.py
@@ -2,30 +2,25 @@
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-from infrastructure.config import Config
 from domain.ports import LoggerPort
 from infrastructure.models.base_model import BaseModel
 
-class SqlAlchemyEngineMixin:
-    """Reusable mixin for adapters that need SQLAlchemy engine + session setup."""
-    def __init__(self, config: Config, logger: LoggerPort) -> None:
-        """Initialize the repository infrastructure: engine, session, and schema.
 
-        This constructor sets up the SQLite engine with threading support,
-        configures the session factory for ORM transactions, and ensures
-        that all declared models are created in the database.
+class SqlAlchemyEngineMixin:
+    """Reusable mixin for adapters that need SQLAlchemy engine setup."""
+
+    def __init__(self, database_url: str, logger: LoggerPort) -> None:
+        """Initialize engine, session factory and schema.
 
         Args:
-            config (Config): Application configuration containing the database connection string.
-            logger (LoggerPort): Logger used for emitting repository lifecycle messages.
+            database_url: Connection string for the target database.
+            logger: Logger adapter for emitting lifecycle messages.
         """
-        # Store configuration and logger for use throughout the repository
-        self.config = config
         self.logger = logger
 
         # Create SQLAlchemy engine for SQLite with thread-safe settings
         self.engine = create_engine(
-            config.database.connection_string,
+            database_url,
             connect_args={
                 "check_same_thread": False
             },  # allow usage from multiple threads

--- a/infrastructure/config/__init__.py
+++ b/infrastructure/config/__init__.py
@@ -1,3 +1,8 @@
-from .config import Config
+"""Public interface for infrastructure configuration adapters."""
 
-__all__ = ["Config",]
+from .adapter import ConfigAdapter
+
+# Backwards compatibility alias
+Config = ConfigAdapter
+
+__all__ = ["ConfigAdapter", "Config"]

--- a/infrastructure/config/adapter.py
+++ b/infrastructure/config/adapter.py
@@ -14,7 +14,7 @@ from .transformers import (
 )
 
 
-class Config:
+class ConfigAdapter:
     """Aggregates all specialized configurations into a single object.
 
     Each attribute is an immutable and validated instance of its

--- a/infrastructure/logging/logger.py
+++ b/infrastructure/logging/logger.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, MutableMapping, Optional
 
 from domain.ports.logger_port import LoggerPort
-from infrastructure.config.config import Config
+from infrastructure.config import ConfigAdapter
 from infrastructure.logging.context_tracker import ContextTracker
 from infrastructure.logging.progress_formatter import ProgressFormatter
 from infrastructure.utils.id_generator import IdGenerator
@@ -12,7 +12,10 @@ class Logger(LoggerPort):
     """Application logger wrapping Python's ``logging`` module."""
 
     def __init__(
-        self, config: Config, level: str = "DEBUG", logger_name: Optional[str] = None
+        self,
+        config: ConfigAdapter,
+        level: str = "DEBUG",
+        logger_name: Optional[str] = None,
     ) -> None:
         self.config = config
         self.logger_name = logger_name or self.config.global_settings.app_name or "FLY"

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -7,8 +7,7 @@ from typing import List, Tuple
 from sqlalchemy.dialects.sqlite import insert
 
 from domain.dto.company_data_dto import CompanyDataDTO
-from domain.ports import LoggerPort, SqlAlchemyCompanyDataRepositoryPort
-from infrastructure.config import Config
+from domain.ports import ConfigPort, LoggerPort, SqlAlchemyCompanyDataRepositoryPort
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.company_data_model import CompanyDataModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
@@ -33,14 +32,11 @@ class SqlAlchemyCompanyDataRepository(
         Write-Ahead Logging (WAL) mode is enabled to improve concurrent read/write behavior.
     """
 
-    def __init__(self, config: Config, logger: LoggerPort) -> None:
-        """Initialize the SQLite-backed company repository.
-
-        Args:
-            config (Config): Application configuration with database connection details.
-            logger (LoggerPort): Logging adapter used for tracking internal behavior.
-        """
-        super().__init__(config, logger)
+    def __init__(
+        self, database_url: str, config: ConfigPort, logger: LoggerPort
+    ) -> None:
+        """Initialize the SQLite-backed company repository."""
+        super().__init__(database_url, config, logger)
 
         self.config = config
         self.logger = logger

--- a/infrastructure/repositories/nsd_repository.py
+++ b/infrastructure/repositories/nsd_repository.py
@@ -7,8 +7,7 @@ from typing import List, Set, Tuple
 from sqlalchemy.dialects.sqlite import insert
 
 from domain.dto.nsd_dto import NsdDTO
-from domain.ports import LoggerPort, NSDRepositoryPort
-from infrastructure.config import Config
+from domain.ports import ConfigPort, LoggerPort, NSDRepositoryPort
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.nsd_model import NSDModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
@@ -19,8 +18,10 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 class SqlAlchemyNsdRepository(SqlAlchemyRepositoryBase[NsdDTO, int], NSDRepositoryPort):
     """Concrete repository for NsdDTO using SQLite via SQLAlchemy."""
 
-    def __init__(self, config: Config, logger: LoggerPort) -> None:
-        super().__init__(config, logger)
+    def __init__(
+        self, database_url: str, config: ConfigPort, logger: LoggerPort
+    ) -> None:
+        super().__init__(database_url, config, logger)
 
         self.config = config
         self.logger = logger

--- a/infrastructure/repositories/parsed_statement_repository.py
+++ b/infrastructure/repositories/parsed_statement_repository.py
@@ -8,8 +8,7 @@ from typing import List, Tuple
 from sqlalchemy.dialects.sqlite import insert
 
 from domain.dto import ParsedStatementDTO
-from domain.ports import LoggerPort, SqlAlchemyParsedStatementRepositoryPort
-from infrastructure.config import Config
+from domain.ports import ConfigPort, LoggerPort, SqlAlchemyParsedStatementRepositoryPort
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.parsed_statement_model import ParsedStatementModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
@@ -23,9 +22,11 @@ class SqlAlchemyParsedStatementRepository(
 ):
     """SQLite-backed repository for ``ParsedStatementDTO`` objects."""
 
-    def __init__(self, config: Config, logger: LoggerPort) -> None:
+    def __init__(
+        self, database_url: str, config: ConfigPort, logger: LoggerPort
+    ) -> None:
         """Initialize repository with ``config`` and ``logger``."""
-        super().__init__(config, logger)
+        super().__init__(database_url, config, logger)
 
         self.config = config
         self.logger = logger

--- a/infrastructure/repositories/raw_statement_repository.py
+++ b/infrastructure/repositories/raw_statement_repository.py
@@ -7,8 +7,7 @@ from typing import List, Tuple
 from sqlalchemy.dialects.sqlite import insert
 
 from domain.dto.raw_statement_dto import RawStatementDTO
-from domain.ports import LoggerPort, SqlAlchemyRawStatementRepositoryPort
-from infrastructure.config import Config
+from domain.ports import ConfigPort, LoggerPort, SqlAlchemyRawStatementRepositoryPort
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.raw_statement_model import RawStatementModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
@@ -22,9 +21,11 @@ class SqlAlchemyRawStatementRepository(
 ):
     """SQLite-backed repository for ``RawStatementDTO`` objects."""
 
-    def __init__(self, config: Config, logger: LoggerPort) -> None:
+    def __init__(
+        self, database_url: str, config: ConfigPort, logger: LoggerPort
+    ) -> None:
         """Initialize repository with ``config`` and ``logger``."""
-        super().__init__(config, logger)
+        super().__init__(database_url, config, logger)
         self.config = config
         self.logger = logger
 

--- a/infrastructure/repositories/sqlalchemy_repository_base.py
+++ b/infrastructure/repositories/sqlalchemy_repository_base.py
@@ -1,24 +1,28 @@
-import time
 from abc import ABC, abstractmethod
-from typing import Any, Generic, List, Sequence, Tuple, TypeVar, Union, Optional
+from typing import Any, Generic, List, Optional, Sequence, Tuple, TypeVar, Union
 
-from domain.ports import LoggerPort
+from domain.ports import ConfigPort, LoggerPort
 from domain.ports.base_repository_port import SqlAlchemyRepositoryBasePort
 from infrastructure.adapters.sqlalchemy_engine_mixin import SqlAlchemyEngineMixin
-from infrastructure.config import Config
 from infrastructure.helpers.list_flattener import ListFlattener
 
 T = TypeVar("T")  # T any DTO.
 K = TypeVar("K")  # Primary key type (e.g., str, int)
 
 
-class SqlAlchemyRepositoryBase(SqlAlchemyRepositoryBasePort[T, K], SqlAlchemyEngineMixin, ABC, Generic[T, K]):
+class SqlAlchemyRepositoryBase(
+    SqlAlchemyRepositoryBasePort[T, K], SqlAlchemyEngineMixin, ABC, Generic[T, K]
+):
     """
     Contract - Interface genérica para repositórios de leitura/escrita.
     Pode ser especializada para qualquer tipo de DTO.
     """
-    def __init__(self, config: Config, logger: LoggerPort) -> None:
-        super().__init__(config, logger)
+
+    def __init__(
+        self, database_url: str, config: ConfigPort, logger: LoggerPort
+    ) -> None:
+        self.config = config
+        super().__init__(database_url, logger)
 
     @abstractmethod
     def get_model_class(self) -> Tuple[type, tuple]:
@@ -113,8 +117,8 @@ class SqlAlchemyRepositoryBase(SqlAlchemyRepositoryBasePort[T, K], SqlAlchemyEng
             session.close()
 
     def get_all(self, batch_size: int = 100) -> List[T]:
-        """
-        Retrieve all DTOs from the database using paginated cursor-based fetching.
+        """Retrieve all DTOs from the database using paginated cursor-based
+        fetching.
 
         This method fetches all records incrementally using the 'id' field to
         avoid loading the entire dataset into memory at once.
@@ -164,11 +168,7 @@ class SqlAlchemyRepositoryBase(SqlAlchemyRepositoryBasePort[T, K], SqlAlchemyEng
                 q = session.query(model)
                 if last_key is not None:
                     q = q.filter(col > last_key)
-                batch = (
-                    q.order_by(col)
-                     .limit(batch_size)
-                     .all()
-                )
+                batch = q.order_by(col).limit(batch_size).all()
                 if not batch:
                     break
                 all_results.extend(m.to_dto() for m in batch)

--- a/infrastructure/utils/id_generator.py
+++ b/infrastructure/utils/id_generator.py
@@ -9,20 +9,19 @@ import time
 import uuid
 from typing import Optional
 
-from infrastructure.config.config import Config
+from infrastructure.config import ConfigAdapter
 
 
 class IdGenerator:
-    """
-    Responsável por criar identificadores curtos, únicos e legíveis
-    para threads ou processos de trabalho.
+    """Responsável por criar identificadores curtos, únicos e legíveis para
+    threads ou processos de trabalho.
 
-    • prefixo: nome da aplicação em maiúsculas (p.ex. “FLY”)
-    • ts_part: timestamp em milissegundos, codificado em hexadecimal
-    • rand_part: 8 hex pseudo-aleatórios do UUID-4
+    • prefixo: nome da aplicação em maiúsculas (p.ex. “FLY”) • ts_part:
+    timestamp em milissegundos, codificado em hexadecimal • rand_part: 8
+    hex pseudo-aleatórios do UUID-4
     """
 
-    def __init__(self, config: Config, logger_name: str = "FLY") -> None:
+    def __init__(self, config: ConfigAdapter, logger_name: str = "FLY") -> None:
         self.config = config
         self.logger_name = logger_name or self.config.global_settings.app_name or "FLY"
 
@@ -50,9 +49,7 @@ class IdGenerator:
 
             base = composite_str.encode("utf-8")
 
-
         digest = hashlib.sha256(base).hexdigest()
         # digest = hashlib.sha512(full_id).hexdigest()
-
 
         return digest[:size] if size else digest

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 """Command-line entry point for the FLY application."""
 
-from infrastructure.config import Config
+from infrastructure.config import ConfigAdapter
 from infrastructure.factories import create_data_cleaner
 from infrastructure.logging import Logger
 from presentation import CLIAdapter
@@ -17,11 +17,10 @@ def main() -> None:
     - Starts the application logic by calling ``controller.start_fly()``.
     """
     # Inicializa a configuração
-    config = Config()
+    config = ConfigAdapter()
     logger = Logger(config)
 
     try:
-
         # Load CLI
         logger.log(
             "Run Project FLY",

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -47,7 +47,9 @@ class CLIAdapter:
         """Build and execute the company data synchronization flow."""
         mapper = CompanyDataMapper(self.data_cleaner)
         company_repo = SqlAlchemyCompanyDataRepository(
-            config=self.config, logger=self.logger
+            database_url=self.config.database.connection_string,
+            config=self.config,
+            logger=self.logger,
         )
         company_scraper = CompanyDataScraper(
             config=self.config,
@@ -68,9 +70,15 @@ class CLIAdapter:
     def _nsd_service(self) -> None:
         """Build and execute the NSD data synchronization flow."""
         company_repo = SqlAlchemyCompanyDataRepository(
-            config=self.config, logger=self.logger
-            )
-        nsd_repo = SqlAlchemyNsdRepository(config=self.config, logger=self.logger)
+            database_url=self.config.database.connection_string,
+            config=self.config,
+            logger=self.logger,
+        )
+        nsd_repo = SqlAlchemyNsdRepository(
+            database_url=self.config.database.connection_string,
+            config=self.config,
+            logger=self.logger,
+        )
         nsd_scraper = NsdScraper(
             config=self.config,
             logger=self.logger,
@@ -92,14 +100,24 @@ class CLIAdapter:
     def _statement_service(self) -> None:
         """Build and execute the financial statement pipeline."""
         company_repo = SqlAlchemyCompanyDataRepository(
-            config=self.config, logger=self.logger
+            database_url=self.config.database.connection_string,
+            config=self.config,
+            logger=self.logger,
         )
-        nsd_repo = SqlAlchemyNsdRepository(config=self.config, logger=self.logger)
+        nsd_repo = SqlAlchemyNsdRepository(
+            database_url=self.config.database.connection_string,
+            config=self.config,
+            logger=self.logger,
+        )
         raw_statement_repo = SqlAlchemyRawStatementRepository(
-            config=self.config, logger=self.logger
+            database_url=self.config.database.connection_string,
+            config=self.config,
+            logger=self.logger,
         )
         parsed_statement_repo = SqlAlchemyParsedStatementRepository(
-            config=self.config, logger=self.logger
+            database_url=self.config.database.connection_string,
+            config=self.config,
+            logger=self.logger,
         )
 
         raw_statements_scraper = RawStatementScraper(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,3 +58,8 @@ class DummyConfig:
         math_target_accounts = ("01",)
 
     transformers = Transformers()
+
+    class Domain:
+        statements_types = ("dre",)
+
+    domain = Domain()

--- a/tests/infrastructure/test_company_repository.py
+++ b/tests/infrastructure/test_company_repository.py
@@ -9,7 +9,12 @@ from tests.conftest import DummyConfig, DummyLogger
 
 
 def test_save_all(SessionLocal, engine):
-    repo = SqlAlchemyCompanyDataRepository(config=DummyConfig(), logger=DummyLogger())
+    cfg = DummyConfig()
+    repo = SqlAlchemyCompanyDataRepository(
+        database_url=cfg.database.connection_string,
+        config=cfg,
+        logger=DummyLogger(),
+    )
     # use shared engine
     repo.engine = engine
     repo.Session = SessionLocal
@@ -27,7 +32,12 @@ def test_save_all(SessionLocal, engine):
 
 
 def test_save_all_json_string(SessionLocal, engine):
-    repo = SqlAlchemyCompanyDataRepository(config=DummyConfig(), logger=DummyLogger())
+    cfg = DummyConfig()
+    repo = SqlAlchemyCompanyDataRepository(
+        database_url=cfg.database.connection_string,
+        config=cfg,
+        logger=DummyLogger(),
+    )
     repo.engine = engine
     repo.Session = SessionLocal
     BaseModel.metadata.drop_all(engine)
@@ -35,7 +45,13 @@ def test_save_all_json_string(SessionLocal, engine):
 
     json_codes = '[{"code": "AAA", "isin": "123"}]'
     companies = [
-        CompanyDataDTO.from_dict({"issuing_company": "AAA", "other_codes": json_codes})
+        CompanyDataDTO.from_dict(
+            {
+                "issuing_company": "AAA",
+                "company_name": "Alpha",
+                "other_codes": json_codes,
+            }
+        )
     ]
 
     repo.save_all(companies)
@@ -47,27 +63,36 @@ def test_save_all_json_string(SessionLocal, engine):
 
 
 def test_save_all_upserts(SessionLocal, engine):
-    repo = SqlAlchemyCompanyDataRepository(config=DummyConfig(), logger=DummyLogger())
+    cfg = DummyConfig()
+    repo = SqlAlchemyCompanyDataRepository(
+        database_url=cfg.database.connection_string,
+        config=cfg,
+        logger=DummyLogger(),
+    )
     repo.engine = engine
     repo.Session = SessionLocal
     BaseModel.metadata.drop_all(engine)
     BaseModel.metadata.create_all(engine)
 
     first = [
-        CompanyDataDTO.from_dict({"issuing_company": "AAA", "company_name": "Alpha"})
+        CompanyDataDTO.from_dict(
+            {"issuing_company": "AAA", "company_name": "Alpha", "cnpj": "1"}
+        )
     ]
     repo.save_all(first)
 
     second = [
-        CompanyDataDTO.from_dict({"issuing_company": "AAA", "company_name": "Updated"})
+        CompanyDataDTO.from_dict(
+            {"issuing_company": "AAA", "company_name": "Alpha", "cnpj": "2"}
+        )
     ]
     repo.save_all(second)
 
     with engine.connect() as conn:
         result = conn.execute(text("SELECT COUNT(*) FROM tbl_company")).scalar()
-        name = conn.execute(
-            text("SELECT company_name FROM tbl_company WHERE cvm_code='AAA'")
+        cnpj = conn.execute(
+            text("SELECT cnpj FROM tbl_company WHERE cvm_code='AAA'")
         ).scalar()
 
     assert result == 1
-    assert name == "Updated"
+    assert cnpj == "2"

--- a/tests/infrastructure/test_context_tracker_import_path.py
+++ b/tests/infrastructure/test_context_tracker_import_path.py
@@ -1,11 +1,11 @@
 import re
 
-from infrastructure.config.config import Config
+from infrastructure.config import ConfigAdapter
 from infrastructure.logging.context_tracker import ContextTracker
 
 
 def sample_function():
-    tracker = ContextTracker(Config().paths.root_dir)
+    tracker = ContextTracker(ConfigAdapter().paths.root_dir)
     return tracker.get_import_path()
 
 

--- a/tests/infrastructure/test_nsd_repository.py
+++ b/tests/infrastructure/test_nsd_repository.py
@@ -7,7 +7,12 @@ from tests.conftest import DummyConfig, DummyLogger
 
 
 def test_save_all_upserts(SessionLocal, engine):
-    repo = SqlAlchemyNsdRepository(config=DummyConfig(), logger=DummyLogger())
+    cfg = DummyConfig()
+    repo = SqlAlchemyNsdRepository(
+        database_url=cfg.database.connection_string,
+        config=cfg,
+        logger=DummyLogger(),
+    )
     repo.engine = engine
     repo.Session = SessionLocal
     BaseModel.metadata.drop_all(engine)

--- a/tests/infrastructure/test_parsed_statement_repository.py
+++ b/tests/infrastructure/test_parsed_statement_repository.py
@@ -11,8 +11,11 @@ from tests.conftest import DummyConfig, DummyLogger
 
 
 def test_replace_and_exists(SessionLocal, engine):
+    cfg = DummyConfig()
     repo = SqlAlchemyParsedStatementRepository(
-        config=DummyConfig(), logger=DummyLogger()
+        database_url=cfg.database.connection_string,
+        config=cfg,
+        logger=DummyLogger(),
     )
     repo.engine = engine
     repo.Session = SessionLocal
@@ -62,8 +65,11 @@ def test_replace_and_exists(SessionLocal, engine):
 
 
 def test_save_all_upserts(SessionLocal, engine):
+    cfg = DummyConfig()
     repo = SqlAlchemyParsedStatementRepository(
-        config=DummyConfig(), logger=DummyLogger()
+        database_url=cfg.database.connection_string,
+        config=cfg,
+        logger=DummyLogger(),
     )
     repo.engine = engine
     repo.Session = SessionLocal

--- a/tests/infrastructure/test_raw_statement_repository.py
+++ b/tests/infrastructure/test_raw_statement_repository.py
@@ -9,7 +9,12 @@ from tests.conftest import DummyConfig, DummyLogger
 
 
 def test_save_all_upserts(SessionLocal, engine):
-    repo = SqlAlchemyRawStatementRepository(config=DummyConfig(), logger=DummyLogger())
+    cfg = DummyConfig()
+    repo = SqlAlchemyRawStatementRepository(
+        database_url=cfg.database.connection_string,
+        config=cfg,
+        logger=DummyLogger(),
+    )
     repo.engine = engine
     repo.Session = SessionLocal
     BaseModel.metadata.drop_all(engine)


### PR DESCRIPTION
## Summary
- introduce `ConfigPort` protocol and `ConfigAdapter` to decouple configuration from core layers
- inject configuration and database URLs into services, processors and repositories
- update CLI and tests to pass runtime config values

## Testing
- `ruff format infrastructure/repositories/company_repository.py tests/infrastructure/test_company_repository.py`
- `ruff check application/processors/fetch_statements_processor.py application/processors/parse_statements_processor.py application/processors/transform_statements_processor.py application/services/company_data_service.py application/services/nsd_service.py application/usecases/fetch_statements.py application/usecases/parse_and_classify_statements.py application/usecases/sync_nsd.py application/usecases/transform_statements.py domain/ports/__init__.py domain/ports/config_port.py infrastructure/adapters/sqlalchemy_engine_mixin.py infrastructure/config/__init__.py infrastructure/config/adapter.py infrastructure/logging/logger.py infrastructure/repositories/company_repository.py infrastructure/repositories/nsd_repository.py infrastructure/repositories/parsed_statement_repository.py infrastructure/repositories/raw_statement_repository.py infrastructure/repositories/sqlalchemy_repository_base.py infrastructure/utils/id_generator.py main.py presentation/cli.py tests/conftest.py tests/infrastructure/test_company_repository.py tests/infrastructure/test_context_tracker_import_path.py tests/infrastructure/test_nsd_repository.py tests/infrastructure/test_parsed_statement_repository.py tests/infrastructure/test_raw_statement_repository.py --fix`
- `pydocstyle --convention=google application/processors/fetch_statements_processor.py application/processors/parse_statements_processor.py application/processors/transform_statements_processor.py application/services/company_data_service.py application/services/nsd_service.py application/usecases/fetch_statements.py application/usecases/parse_and_classify_statements.py application/usecases/sync_nsd.py application/usecases/transform_statements.py domain/ports/__init__.py domain/ports/config_port.py infrastructure/adapters/sqlalchemy_engine_mixin.py infrastructure/config/__init__.py infrastructure/config/adapter.py infrastructure/logging/logger.py infrastructure/repositories/company_repository.py infrastructure/repositories/nsd_repository.py infrastructure/repositories/parsed_statement_repository.py infrastructure/repositories/raw_statement_repository.py infrastructure/repositories/sqlalchemy_repository_base.py infrastructure/utils/id_generator.py main.py presentation/cli.py tests/conftest.py tests/infrastructure/test_company_repository.py tests/infrastructure/test_context_tracker_import_path.py tests/infrastructure/test_nsd_repository.py tests/infrastructure/test_parsed_statement_repository.py tests/infrastructure/test_raw_statement_repository.py`
- `docformatter --in-place application/processors/fetch_statements_processor.py application/processors/parse_statements_processor.py application/processors/transform_statements_processor.py application/services/company_data_service.py application/services/nsd_service.py application/usecases/fetch_statements.py application/usecases/parse_and_classify_statements.py application/usecases/sync_nsd.py application/usecases/transform_statements.py domain/ports/__init__.py domain/ports/config_port.py infrastructure/adapters/sqlalchemy_engine_mixin.py infrastructure/config/__init__.py infrastructure/config/adapter.py infrastructure/logging/logger.py infrastructure/repositories/company_repository.py infrastructure/repositories/nsd_repository.py infrastructure/repositories/parsed_statement_repository.py infrastructure/repositories/raw_statement_repository.py infrastructure/repositories/sqlalchemy_repository_base.py infrastructure/utils/id_generator.py main.py presentation/cli.py tests/conftest.py tests/infrastructure/test_company_repository.py tests/infrastructure/test_context_tracker_import_path.py tests/infrastructure/test_nsd_repository.py tests/infrastructure/test_parsed_statement_repository.py tests/infrastructure/test_raw_statement_repository.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689677bb5558832eaa4e0c9bcd7fabbc