### PR TITLE
refactor: depend on configuration ports

### DIFF
--- a/application/ports/config_ports.py
+++ b/application/ports/config_ports.py
@@ -4,6 +4,17 @@ from typing import Mapping, Protocol, Sequence, runtime_checkable
 
 
 @runtime_checkable
+class DatabaseConfigPort(Protocol):
+    """Database configuration values required by infrastructure."""
+
+    @property
+    def connection_string(self) -> str: ...
+
+    @property
+    def tables(self) -> Mapping[str, str]: ...
+
+
+@runtime_checkable
 class GlobalSettingsPort(Protocol):
     """Minimal subset of global runtime settings used by the application."""
 
@@ -96,3 +107,6 @@ class ConfigPort(Protocol):
 
     @property
     def transformers(self) -> TransformersConfigPort: ...
+
+    @property
+    def database(self) -> DatabaseConfigPort: ...

--- a/infrastructure/helpers/data_cleaner.py
+++ b/infrastructure/helpers/data_cleaner.py
@@ -3,9 +3,9 @@
 from datetime import datetime
 from typing import List, Optional
 
+from application.ports.config_ports import ConfigPort
 from domain.ports import LoggerPort
 from domain.ports.data_cleaner_port import DataCleanerPort
-from infrastructure.config import Config
 from infrastructure.utils.normalization import (
     clean_date as util_clean_date,
 )
@@ -26,7 +26,7 @@ class DataCleaner(DataCleanerPort):
     Requires external configuration (e.g. words to remove) and a logger.
     """
 
-    def __init__(self, config: Config, logger: LoggerPort) -> None:
+    def __init__(self, config: ConfigPort, logger: LoggerPort) -> None:
         """Store configuration and logger."""
         self.config = config
         self.logger = logger

--- a/infrastructure/helpers/fetch_utils.py
+++ b/infrastructure/helpers/fetch_utils.py
@@ -12,8 +12,8 @@ import urllib3
 from requests.adapters import HTTPAdapter
 from requests.structures import CaseInsensitiveDict
 
+from application.ports.config_ports import ConfigPort
 from domain.ports import LoggerPort
-from infrastructure.config import Config
 from infrastructure.helpers.time_utils import TimeUtils
 from infrastructure.utils.id_generator import IdGenerator
 
@@ -21,7 +21,7 @@ from infrastructure.utils.id_generator import IdGenerator
 class FetchUtils:
     """Utility class for HTTP operations with retry and randomized headers."""
 
-    def __init__(self, config: Config, logger: LoggerPort) -> None:
+    def __init__(self, config: ConfigPort, logger: LoggerPort) -> None:
         self.config = config
         self.logger = logger
         self.time_util = TimeUtils(self.config)
@@ -183,7 +183,9 @@ class FetchUtils:
                     self.time_util.sleep_dynamic(multiplier=atmpt)
                     end_time = time.perf_counter() - start_time
                     dur += end_time
-                    self.logger.log(f'Retry {atmpt + 1}: {response.status_code}, {end_time:.2f}s, {dur:.2f}s')
+                    self.logger.log(
+                        f"Retry {atmpt + 1}: {response.status_code}, {end_time:.2f}s, {dur:.2f}s"
+                    )
 
                 if response.status_code == 200:
                     # On success, log the total block time if any

--- a/infrastructure/helpers/save_strategy.py
+++ b/infrastructure/helpers/save_strategy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Callable, Generic, List, Optional, TypeVar
 
-from infrastructure.config import Config
+from application.ports.config_ports import ConfigPort
 
 T = TypeVar("T")
 
@@ -17,7 +17,7 @@ class SaveStrategy(Generic[T]):
         self,
         save_callback: Optional[Callable[[List[T]], None]] = None,
         threshold: Optional[int] = None,
-        config: Optional[Config] = None,
+        config: Optional[ConfigPort] = None,
     ) -> None:
         """Create a new strategy instance.
 

--- a/infrastructure/helpers/thread_utils.py
+++ b/infrastructure/helpers/thread_utils.py
@@ -1,6 +1,6 @@
 import threading
 
-from infrastructure.config import Config
+from application.ports.config_ports import ConfigPort
 
 
 class WorkerThreadIdentifier:
@@ -9,7 +9,7 @@ class WorkerThreadIdentifier:
     Example identifiers: ``"W1"``, ``"W2"``, up to the ``max_workers`` limit from ``Config``.
     """
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: ConfigPort) -> None:
         """Initialize the generator using the configured ``max_workers`` value.
 
         Args:

--- a/infrastructure/helpers/time_utils.py
+++ b/infrastructure/helpers/time_utils.py
@@ -4,18 +4,21 @@ from typing import Optional
 
 import psutil
 
-from infrastructure.config import Config
+from application.ports.config_ports import ConfigPort
 
 
 class TimeUtils:
     """Helper for dynamic sleep intervals based on CPU usage."""
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: ConfigPort) -> None:
         self.config = config
 
     def sleep_dynamic(
-        self, wait: Optional[float] = None, cpu_interval: Optional[float] = None,
-        multiplier: Optional[int] = 1) -> None:
+        self,
+        wait: Optional[float] = None,
+        cpu_interval: Optional[float] = None,
+        multiplier: Optional[int] = 1,
+    ) -> None:
         """Sleep for a dynamically adjusted time based on CPU utilization.
 
         The logic adjusts the delay as follows:
@@ -37,7 +40,7 @@ class TimeUtils:
         else:
             wait *= random.uniform(0.1, 0.5)
 
-        wait_multiplier = wait ** multiplier if multiplier else wait
+        wait_multiplier = wait**multiplier if multiplier else wait
         wait_multiplier = wait * multiplier if multiplier else wait
 
         time.sleep(wait_multiplier)

--- a/infrastructure/helpers/worker_pool.py
+++ b/infrastructure/helpers/worker_pool.py
@@ -7,9 +7,9 @@ from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
 from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar
 
+from application.ports.config_ports import ConfigPort
 from domain.dto import ExecutionResultDTO, WorkerTaskDTO
 from domain.ports import LoggerPort, MetricsCollectorPort, WorkerPoolPort
-from infrastructure.config import Config
 from infrastructure.helpers.byte_formatter import ByteFormatter
 
 T = WorkerTaskDTO
@@ -22,7 +22,7 @@ class WorkerPool(WorkerPoolPort):
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         metrics_collector: MetricsCollectorPort,
         max_workers: Optional[int] = None,
     ) -> None:

--- a/infrastructure/scrapers/company_data_exchange_scraper.py
+++ b/infrastructure/scrapers/company_data_exchange_scraper.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import base64
 import json
 import time
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional
 
 from application import CompanyDataMapper
+from application.ports.config_ports import ConfigPort
 from domain.dto import (
     CompanyDataRawDTO,
     ExecutionResultDTO,
@@ -20,7 +21,6 @@ from domain.ports import (
     MetricsCollectorPort,
     WorkerPoolPort,
 )
-from infrastructure.config import Config
 from infrastructure.helpers import FetchUtils, SaveStrategy
 from infrastructure.helpers.byte_formatter import ByteFormatter
 from infrastructure.helpers.data_cleaner import DataCleaner
@@ -41,7 +41,7 @@ class CompanyDataScraper(CompanyDataScraperPort):
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         data_cleaner: DataCleaner,
         mapper: CompanyDataMapper,
@@ -205,8 +205,10 @@ class CompanyDataScraper(CompanyDataScraperPort):
 
         extra_info = {
             "Download": self.byte_formatter.format_bytes(download_bytes_pos),
-            "Total download": self.byte_formatter.format_bytes(self.metrics_collector.network_bytes),
-            }
+            "Total download": self.byte_formatter.format_bytes(
+                self.metrics_collector.network_bytes
+            ),
+        }
         self.logger.log(
             f"Page {page}/{total_pages}",
             level="info",
@@ -229,11 +231,15 @@ class CompanyDataScraper(CompanyDataScraperPort):
                 fetch = self._fetch_page(task.data)
                 # self.logger.log("End  Method CompanyDataScraper._fetch_companies_list().processor()_fetch_page()", level="info")
 
-                download_bytes_pos = self._metrics_collector.network_bytes - download_bytes_pre
+                download_bytes_pos = (
+                    self._metrics_collector.network_bytes - download_bytes_pre
+                )
 
                 extra_info = {
                     "Download": self.byte_formatter.format_bytes(download_bytes_pos),
-                    "Total download": self.byte_formatter.format_bytes(self.metrics_collector.network_bytes),
+                    "Total download": self.byte_formatter.format_bytes(
+                        self.metrics_collector.network_bytes
+                    ),
                 }
                 self.logger.log(
                     f"Page {task.data}/{total_pages}",
@@ -300,8 +306,8 @@ class CompanyDataScraper(CompanyDataScraperPort):
         strategy: SaveStrategy[CompanyDataRawDTO] = SaveStrategy(
             save_callback, self.threshold, config=self.config
         )
-        detail_exec: ExecutionResultDTO[Optional[CompanyDataRawDTO]] = ExecutionResultDTO(
-            items=[], metrics=self.metrics_collector.get_metrics(0)
+        detail_exec: ExecutionResultDTO[Optional[CompanyDataRawDTO]] = (
+            ExecutionResultDTO(items=[], metrics=self.metrics_collector.get_metrics(0))
         )
 
         # Pair each company dict with its index for progress logging
@@ -325,7 +331,7 @@ class CompanyDataScraper(CompanyDataScraperPort):
                     "trading_name": entry["tradingName"],
                     # "Download": self.byte_formatter.format_bytes(download_bytes_pos),
                     # "Total download": self.byte_formatter.format_bytes(self.metrics_collector.network_bytes),
-                    }
+                }
                 self.logger.log(
                     f"{entry.get('codeCVM')}",
                     level="info",
@@ -346,7 +352,9 @@ class CompanyDataScraper(CompanyDataScraperPort):
             result = self.detail_processor.process_entry(entry)
             # self.logger.log("End  Method CompanyDataScraper._fetch_companies_details().processor().self.detail_processor.run(entry)", level="info")
 
-            download_bytes_pos = self._metrics_collector.network_bytes - download_bytes_pre
+            download_bytes_pos = (
+                self._metrics_collector.network_bytes - download_bytes_pre
+            )
 
             issuingCompany = entry.get("issuingCompany")
             tradingName = entry.get("tradingName")
@@ -416,7 +424,9 @@ class CompanyDataScraper(CompanyDataScraperPort):
         token = self._encode_payload(payload)
 
         url = self.endpoint_companies_list + token
-        response, self.session = self.fetch_utils.fetch_with_retry(self.session, url, cache_bypass=False)
+        response, self.session = self.fetch_utils.fetch_with_retry(
+            self.session, url, cache_bypass=False
+        )
 
         bytes_downloaded = len(response.content if response else b"")
         self.metrics_collector.record_network_bytes(bytes_downloaded)
@@ -438,4 +448,3 @@ class CompanyDataScraper(CompanyDataScraperPort):
         """Metrics collector used by the scraper."""
 
         return self._metrics_collector
-

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, List, Optional
 
 from bs4 import BeautifulSoup
 
+from application.ports.config_ports import ConfigPort
 from domain.dto import ExecutionResultDTO, NsdDTO, WorkerTaskDTO
 from domain.ports import (
     LoggerPort,
@@ -17,7 +18,6 @@ from domain.ports import (
     NSDSourcePort,
     WorkerPoolPort,
 )
-from infrastructure.config import Config
 from infrastructure.helpers import ByteFormatter, FetchUtils, SaveStrategy
 from infrastructure.helpers.data_cleaner import DataCleaner
 
@@ -27,7 +27,7 @@ class NsdScraper(NSDSourcePort):
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         data_cleaner: DataCleaner,
         worker_pool_executor: WorkerPoolPort,

--- a/infrastructure/scrapers/requests_raw_statement_scraper.py
+++ b/infrastructure/scrapers/requests_raw_statement_scraper.py
@@ -17,7 +17,6 @@ from domain.dto.nsd_dto import NsdDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.ports import LoggerPort, MetricsCollectorPort
 from infrastructure.adapters.sqlalchemy_engine_mixin import SqlAlchemyEngineMixin
-from infrastructure.config import Config
 from infrastructure.helpers import WorkerPool
 from infrastructure.helpers.data_cleaner import DataCleaner
 from infrastructure.helpers.fetch_utils import FetchUtils
@@ -30,7 +29,7 @@ class RawStatementScraper(SqlAlchemyEngineMixin, RawStatementScraperPort):
 
     def __init__(
         self,
-        config: Config,
+        config: ConfigPort,
         logger: LoggerPort,
         data_cleaner: DataCleaner,
         metrics_collector: MetricsCollectorPort,

--- a/infrastructure/utils/id_generator.py
+++ b/infrastructure/utils/id_generator.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from typing import Optional
 
-from infrastructure.config import ConfigAdapter
+from application.ports.config_ports import ConfigPort
 
 
 class IdGenerator:
@@ -21,7 +21,7 @@ class IdGenerator:
     hex pseudo-aleatórios do UUID-4
     """
 
-    def __init__(self, config: ConfigAdapter, logger_name: str = "FLY") -> None:
+    def __init__(self, config: ConfigPort, logger_name: str = "FLY") -> None:
         self.config = config
         self.logger_name = logger_name or self.config.global_settings.app_name or "FLY"
 


### PR DESCRIPTION
## Summary
- introduce `DatabaseConfigPort` and expose `database` in `ConfigPort`
- refactor worker pool, scrapers, and helpers to accept `ConfigPort`

## Testing
- `ruff format application/ports/config_ports.py infrastructure/helpers/data_cleaner.py infrastructure/helpers/fetch_utils.py infrastructure/helpers/save_strategy.py infrastructure/helpers/thread_utils.py infrastructure/helpers/time_utils.py infrastructure/helpers/worker_pool.py infrastructure/scrapers/company_data_exchange_scraper.py infrastructure/scrapers/nsd_scraper.py infrastructure/scrapers/requests_raw_statement_scraper.py infrastructure/utils/id_generator.py`
- `ruff check application/ports/config_ports.py infrastructure/helpers/data_cleaner.py infrastructure/helpers/fetch_utils.py infrastructure/helpers/save_strategy.py infrastructure/helpers/thread_utils.py infrastructure/helpers/time_utils.py infrastructure/helpers/worker_pool.py infrastructure/scrapers/company_data_exchange_scraper.py infrastructure/scrapers/nsd_scraper.py infrastructure/scrapers/requests_raw_statement_scraper.py infrastructure/utils/id_generator.py --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place application/ports/config_ports.py infrastructure/helpers/data_cleaner.py infrastructure/helpers/fetch_utils.py infrastructure/helpers/save_strategy.py infrastructure/helpers/thread_utils.py infrastructure/helpers/time_utils.py infrastructure/helpers/worker_pool.py infrastructure/scrapers/company_data_exchange_scraper.py infrastructure/scrapers/nsd_scraper.py infrastructure/scrapers/requests_raw_statement_scraper.py infrastructure/utils/id_generator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b6924a28832eaa87f7781ec742fd