### PR TITLE
feat: add streaming iteration for repositories

### DIFF
--- a/application/processors/fetch_statements_processor.py
+++ b/application/processors/fetch_statements_processor.py
@@ -73,26 +73,28 @@ class FetchStatementsProcessor(
 
     def _build_targets(self) -> List[NsdDTO]:
         """Return NSD identifiers that still need fetching."""
-        company_records = self.company_repo.get_all()
-        nsd_records = self.nsd_repo.get_all()
-        raw_statement_existing = self.raw_statement_repo.get_existing_by_columns(
-                column_names="nsd"
-            )
-        if not company_records or not nsd_records:
-            return []
-        nsd_rows_processed = {
-            row[0]
-            for row in raw_statement_existing
+        company_names = {
+            c.company_name for c in self.company_repo.iter_all() if c.company_name
         }
-        valid_types = set(self.config.domain.statements_types)
-        company_names = {c.company_name for c in company_records if c.company_name}
-        nsd_company_names = {n.company_name for n in nsd_records if n.company_name}
-        common_company_names = set(company_names.intersection(nsd_company_names))
-        results = self.nsd_repo.get_all_pending(
-            company_names=common_company_names,
-            valid_types=valid_types,
-            exclude_nsd=nsd_rows_processed,
+        if not company_names:
+            return []
+
+        raw_statement_existing = self.raw_statement_repo.get_existing_by_columns(
+            column_names="nsd"
         )
+        nsd_rows_processed = {row[0] for row in raw_statement_existing}
+        valid_types = set(self.config.domain.statements_types)
+
+        results: List[NsdDTO] = []
+        for nsd in self.nsd_repo.iter_all():
+            if (
+                nsd.company_name
+                and nsd.company_name in company_names
+                and nsd.nsd_type in valid_types
+                and nsd.nsd not in nsd_rows_processed
+            ):
+                results.append(nsd)
+
         return results
 
     def run(

--- a/application/services/nsd_prediction_service.py
+++ b/application/services/nsd_prediction_service.py
@@ -1,3 +1,5 @@
+"""Utilities for predicting upcoming NSD identifiers."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -28,22 +30,56 @@ def _find_next_probable_nsd(
         A list of sequential NSD values likely to have been published
         after the last stored record.
     """
-    records = [r for r in repository.get_all() if r.sent_date]
-    if not records:
+    last_nsd = None
+    max_date = None
+    window_start = None
+    recent_by_date: dict[datetime, int] = {}
+    recent_count = 0
+    min_date = None
+    total_count = 0
+    overall_min_date = None
+
+    for record in repository.iter_all():
+        nsd_int = int(record.nsd)
+        if last_nsd is None or nsd_int > last_nsd:
+            last_nsd = nsd_int
+
+        if record.sent_date is None:
+            continue
+
+        total_count += 1
+        if overall_min_date is None or record.sent_date < overall_min_date:
+            overall_min_date = record.sent_date
+
+        if max_date is None or record.sent_date > max_date:
+            max_date = record.sent_date
+            window_start = max_date - timedelta(days=window_days)
+            outdated = [d for d in recent_by_date if d < window_start]
+            for d in outdated:
+                recent_count -= recent_by_date.pop(d)
+                if d == min_date:
+                    min_date = min(recent_by_date) if recent_by_date else None
+
+        if window_start is not None and record.sent_date >= window_start:
+            recent_by_date[record.sent_date] = (
+                recent_by_date.get(record.sent_date, 0) + 1
+            )
+            recent_count += 1
+            if min_date is None or record.sent_date < min_date:
+                min_date = record.sent_date
+
+    if last_nsd is None or max_date is None:
         return []
 
-    last_nsd = max(int(r.nsd) for r in records)
-    max_date = max(r.sent_date for r in records if r.sent_date is not None)
-    window_start = max_date - timedelta(days=window_days)
+    if recent_count == 0:
+        recent_count = total_count
+        min_date = overall_min_date
 
-    recent = [r for r in records if r.sent_date is not None and r.sent_date >= window_start]
-    if not recent:
-        recent = records
+    if recent_count == 0 or min_date is None:
+        return []
 
-    min_date = min(r.sent_date for r in recent if r.sent_date is not None)
     days_span = max((max_date - min_date).days, 1)
-    daily_avg = len(recent) / days_span
-
+    daily_avg = recent_count / days_span
     days_since_last = max((datetime.utcnow() - max_date).days, 0)
     estimate = int(daily_avg * days_since_last * safety_factor)
 

--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Generic, List, Sequence, Tuple, TypeVar, Union
+from typing import Any, Generator, Generic, List, Sequence, Tuple, TypeVar, Union
 
 T = TypeVar("T")  # DTO type
 K = TypeVar("K")  # Key type (e.g., str, int)
@@ -36,6 +36,19 @@ class SqlAlchemyRepositoryBasePort(ABC, Generic[T, K]):
 
         Returns:
             List[T]: All items stored in the repository.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def iter_all(self, batch_size: int | None = None) -> Generator[T, None, None]:
+        """Return a generator over all persisted items ordered by primary key.
+
+        Args:
+            batch_size: Optional number of rows to fetch per batch. Falls back
+                to configuration when ``None``.
+
+        Returns:
+            Generator[T, None, None]: Sequential DTOs from the repository.
         """
         raise NotImplementedError
 

--- a/infrastructure/repositories/sqlalchemy_repository_base.py
+++ b/infrastructure/repositories/sqlalchemy_repository_base.py
@@ -1,5 +1,17 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Generator,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+from sqlalchemy import tuple_ as sa_tuple
 
 from domain.ports import ConfigPort, LoggerPort
 from domain.ports.base_repository_port import SqlAlchemyRepositoryBasePort
@@ -176,6 +188,76 @@ class SqlAlchemyRepositoryBase(
             return all_results
         finally:
             session.close()
+
+    def iter_all(self, batch_size: int | None = None) -> Generator[T, None, None]:
+        """Yield all DTOs sequentially using keyset pagination over the PK."""
+        size = batch_size or self.config.global_settings.batch_size
+        model, pk_columns = self.get_model_class()
+        self.logger.log(
+            f"iter_all start batch_size={size}",
+            level="info",
+        )
+        yielded = 0
+        try:
+            if len(pk_columns) == 1:
+                gen = self._iter_all_simple(size)
+            else:
+                gen = self._iter_all_composite(size)
+            for dto in gen:
+                yielded += 1
+                yield dto
+        finally:
+            self.logger.log(
+                f"iter_all finished total={yielded}",
+                level="info",
+            )
+
+    def _iter_all_simple(self, size: int) -> Generator[T, None, None]:
+        model, pk_columns = self.get_model_class()
+        col = pk_columns[0]
+        last_key: Optional[Any] = None
+        with self.Session() as session:
+            base_q = (
+                session.query(model)
+                .order_by(col)
+                .yield_per(size)
+                .execution_options(stream_results=True)
+                .enable_eagerloads(False)
+            )
+            while True:
+                q = base_q
+                if last_key is not None:
+                    q = q.filter(col > last_key)
+                count = 0
+                for m in q.limit(size):
+                    yield m.to_dto()
+                    last_key = getattr(m, col.key)
+                    count += 1
+                if count == 0:
+                    break
+
+    def _iter_all_composite(self, size: int) -> Generator[T, None, None]:
+        model, pk_columns = self.get_model_class()
+        last_key: Optional[Tuple] = None
+        with self.Session() as session:
+            base_q = (
+                session.query(model)
+                .order_by(*pk_columns)
+                .yield_per(size)
+                .execution_options(stream_results=True)
+                .enable_eagerloads(False)
+            )
+            while True:
+                q = base_q
+                if last_key is not None:
+                    q = q.filter(sa_tuple(*pk_columns) > sa_tuple(*last_key))
+                count = 0
+                for m in q.limit(size):
+                    yield m.to_dto()
+                    last_key = tuple(getattr(m, c.key) for c in pk_columns)
+                    count += 1
+                if count == 0:
+                    break
 
     def get_all_primary_keys(self) -> List[str]:
         """Retrieve all unique primary keys from the database.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 """Command-line entry point for the FLY application."""
-print("Start: Command Line Interface")
+
 from infrastructure.config import ConfigAdapter
 from infrastructure.factories import create_data_cleaner
 from infrastructure.logging import Logger

--- a/tests/application/test_nsd_prediction_service.py
+++ b/tests/application/test_nsd_prediction_service.py
@@ -28,28 +28,30 @@ def test_find_next_probable_nsd_returns_sequence():
                 reason=None,
             )
         )
-    repo.get_all.return_value = items
 
+    repo.iter_all.side_effect = lambda: (item for item in items)
+
+    materialized = list(repo.iter_all())
     result = _find_next_probable_nsd(
         repository=repo,
         window_days=20,
         safety_factor=1.0,
     )
 
-    max_date = start + timedelta(days=9)
-    min_date = start
+    max_date = max(r.sent_date for r in materialized if r.sent_date is not None)
+    min_date = min(r.sent_date for r in materialized if r.sent_date is not None)
     days_span = (max_date - min_date).days
-    daily_avg = len(items) / days_span
+    daily_avg = len(materialized) / days_span
     days_since_last = (now - max_date).days
     expected_count = int(daily_avg * days_since_last * 1.0)
-    expected = [len(items) + i for i in range(1, expected_count + 1)]
+    expected = [len(materialized) + i for i in range(1, expected_count + 1)]
 
     assert result == expected
 
 
 def test_find_next_probable_nsd_empty():
     repo = MagicMock(spec=NSDRepositoryPort)
-    repo.get_all.return_value = []
+    repo.iter_all.return_value = iter([])
 
     result = _find_next_probable_nsd(repo)
     assert result == []

--- a/tests/application/test_parse_statements_processor.py
+++ b/tests/application/test_parse_statements_processor.py
@@ -22,11 +22,15 @@ def test_parse_statements_invokes_usecase_and_finalize(monkeypatch):
     )
 
     repository = MagicMock(spec=SqlAlchemyParsedStatementRepository)
+    worker_pool = MagicMock()
+    collector = MagicMock()
 
     processor = ParseStatementsProcessor(
         logger=DummyLogger(),
         repository=repository,
         config=dummy_config,
+        worker_pool_executor=worker_pool,
+        metrics_collector=collector,
         max_workers=2,
     )
 

--- a/tests/application/test_statement_pipeline_integration.py
+++ b/tests/application/test_statement_pipeline_integration.py
@@ -90,7 +90,11 @@ def test_full_statement_pipeline(monkeypatch):
     raw_rows = fetch_processor.run()
 
     parse_processor = ParseStatementsProcessor(
-        logger=logger, repository=parsed_repo, config=config
+        logger=logger,
+        repository=parsed_repo,
+        config=config,
+        worker_pool_executor=worker_pool,
+        metrics_collector=collector,
     )
     parsed_dto = ParsedStatementDTO(
         nsd="1",
@@ -107,6 +111,7 @@ def test_full_statement_pipeline(monkeypatch):
     parse_processor.parse_usecase.parse_and_store_row = MagicMock(
         return_value=parsed_dto
     )
+    worker_pool.run = MagicMock(return_value=MagicMock(items=[[parsed_dto]]))
     monkeypatch.setattr(parse_processor.parse_usecase, "finalize", lambda: None)
 
     parsed_groups = parse_processor.run(raw_rows)

--- a/tests/infrastructure/test_iter_all.py
+++ b/tests/infrastructure/test_iter_all.py
@@ -1,0 +1,146 @@
+from dataclasses import dataclass
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import (
+    Mapped,
+    mapped_column,
+    sessionmaker,
+)
+from sqlalchemy.orm import (
+    Session as SASession,
+)
+
+from infrastructure.models.base_model import BaseModel
+from infrastructure.repositories.sqlalchemy_repository_base import (
+    SqlAlchemyRepositoryBase,
+)
+from tests.conftest import DummyConfig, DummyLogger
+
+
+@dataclass(frozen=True)
+class DummyDTO:
+    id: int | None
+    name: str
+
+
+class DummyModel(BaseModel):
+    __tablename__ = "dummy_model"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
+    name: Mapped[str] = mapped_column(String)
+
+    @staticmethod
+    def from_dto(dto: DummyDTO) -> "DummyModel":
+        return DummyModel(id=dto.id, name=dto.name)
+
+    def to_dto(self) -> DummyDTO:
+        return DummyDTO(id=self.id, name=self.name)
+
+
+class DummyRepository(SqlAlchemyRepositoryBase[DummyDTO, int]):
+    def get_model_class(self):
+        return DummyModel, (DummyModel.id,)
+
+
+@dataclass(frozen=True)
+class CompositeDTO:
+    part1: int
+    part2: int
+    value: str
+
+
+class CompositeModel(BaseModel):
+    __tablename__ = "composite_model"
+
+    part1: Mapped[int] = mapped_column(Integer, primary_key=True)
+    part2: Mapped[int] = mapped_column(Integer, primary_key=True)
+    value: Mapped[str] = mapped_column(String)
+
+    @staticmethod
+    def from_dto(dto: CompositeDTO) -> "CompositeModel":
+        return CompositeModel(part1=dto.part1, part2=dto.part2, value=dto.value)
+
+    def to_dto(self) -> CompositeDTO:
+        return CompositeDTO(part1=self.part1, part2=self.part2, value=self.value)
+
+
+class CompositeRepository(SqlAlchemyRepositoryBase[CompositeDTO, tuple[int, int]]):
+    def get_model_class(self):
+        return CompositeModel, (CompositeModel.part1, CompositeModel.part2)
+
+
+def _setup_repo(repo, engine, SessionLocal):
+    repo.engine = engine
+    repo.Session = SessionLocal
+    BaseModel.metadata.drop_all(engine)
+    BaseModel.metadata.create_all(engine)
+
+
+def test_iter_all_simple_pk(SessionLocal, engine):
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    items = [DummyDTO(id=i, name=str(i)) for i in range(1, 6)]
+    repo.save_all(items)
+
+    result = list(repo.iter_all(batch_size=2))
+    assert [d.id for d in result] == [1, 2, 3, 4, 5]
+
+
+def test_iter_all_empty(SessionLocal, engine):
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    assert list(repo.iter_all()) == []
+
+
+def test_iter_all_closes_session_on_break(SessionLocal, engine):
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    repo.save_all([DummyDTO(id=1, name="a"), DummyDTO(id=2, name="b")])
+
+    closed = {"value": False}
+
+    class TrackingSession(SASession):
+        def close(self):  # type: ignore[override]
+            closed["value"] = True
+            super().close()
+
+    repo.Session = sessionmaker(bind=engine, class_=TrackingSession)
+
+    for _ in repo.iter_all(batch_size=1):
+        break
+    assert closed["value"]
+
+
+def test_iter_all_composite_pk(SessionLocal, engine):
+    cfg = DummyConfig()
+    repo = CompositeRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    items = [
+        CompositeDTO(part1=1, part2=1, value="a"),
+        CompositeDTO(part1=1, part2=2, value="b"),
+        CompositeDTO(part1=2, part2=1, value="c"),
+    ]
+    repo.save_all(items)
+
+    result = list(repo.iter_all(batch_size=1))
+    keys = [(d.part1, d.part2) for d in result]
+    assert keys == [(1, 1), (1, 2), (2, 1)]
+
+
+def test_iter_all_full_and_partial_iteration(SessionLocal, engine):
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    items = [DummyDTO(id=i, name=str(i)) for i in range(1, 6)]
+    repo.save_all(items)
+
+    all_list = list(repo.iter_all())
+    from_iter = []
+    for idx, dto in enumerate(repo.iter_all()):
+        if idx >= 3:
+            break
+        from_iter.append(dto)
+    assert all_list[:3] == from_iter


### PR DESCRIPTION
## Summary
- stream NSD prediction with a single pass over `iter_all`
- compute NSD parity in tests using only the streaming iterator
- drop duplicate startup print from the CLI entry point

## Testing
- `ruff format tests/application/test_nsd_prediction_service.py application/services/nsd_prediction_service.py main.py`
- `ruff check tests/application/test_nsd_prediction_service.py application/services/nsd_prediction_service.py main.py --fix`
- `pydocstyle --convention=google tests/application/test_nsd_prediction_service.py application/services/nsd_prediction_service.py main.py`
- `docformatter --in-place tests/application/test_nsd_prediction_service.py application/services/nsd_prediction_service.py main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a17848b64832ebe60deaed8f14e0d