### PR TITLE
Add streaming iterator for existing column values

### DIFF
--- a/application/processors/fetch_statements_processor.py
+++ b/application/processors/fetch_statements_processor.py
@@ -79,10 +79,9 @@ class FetchStatementsProcessor(
         if not company_names:
             return []
 
-        raw_statement_existing = self.raw_statement_repo.get_existing_by_columns(
-            column_names="nsd"
-        )
-        nsd_rows_processed = {row[0] for row in raw_statement_existing}
+        nsd_rows_processed = {
+            row[0] for row in self.raw_statement_repo.iter_existing_by_columns("nsd")
+        }
         valid_types = set(self.config.domain.statements_types)
 
         results: List[NsdDTO] = []

--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -46,9 +46,9 @@ class SyncCompanyDataUseCase:
         start = time.perf_counter()
 
         # busca todos os company_name que já estão na tabela
-        raw = self.repository.get_existing_by_columns("company_name")
-        # get_existing_by_columns devolve List[Tuple], ex: [("900049",),("900642",)…]
-        skip_codes = [code for (code,) in raw]
+        skip_codes = [
+            code for (code,) in self.repository.iter_existing_by_columns("company_name")
+        ]
 
         # self.logger.log("Call Method sync_companies_usecase.run().fetch_all(save_callback, max_workers)", level="info")
         # Fetch all companies from the scraper and persist them batch-wise.
@@ -74,7 +74,9 @@ class SyncCompanyDataUseCase:
     def _save_batch(self, buffer: List[CompanyDataRawDTO]) -> None:
         """Convert raw companies to domain DTOs before saving."""
         # primeiro “desembrulha” qualquer nível de listas aninhadas
-        flat_items = ListFlattener.flatten(buffer)  # recebe nested lists, devolve flat list
+        flat_items = ListFlattener.flatten(
+            buffer
+        )  # recebe nested lists, devolve flat list
 
         # Transform raw DTOs from the scraper to domain DTOs.
         dtos = [CompanyDataDTO.from_raw(item) for item in flat_items]

--- a/application/usecases/sync_nsd.py
+++ b/application/usecases/sync_nsd.py
@@ -39,9 +39,9 @@ class SyncNSDUseCase:
         # self.logger.log("Run  Method controller.run()._nsd_service().run().sync_nsd_usecase.run()", level="info")
 
         # busca todos os cvm_code que já estão na tabela
-        raw = self.repository.get_existing_by_columns("nsd")
-        # get_existing_by_columns devolve List[Tuple], ex: [("900049",),("900642",)…]
-        existing_nsd = [code for (code,) in raw]
+        existing_nsd = [
+            code for (code,) in self.repository.iter_existing_by_columns("nsd")
+        ]
 
         # Fetch all documents from the scraper, persisting them in batches.
         # self.logger.log("Call Method controller.run()._nsd_service().run().sync_nsd_usecase.run().fetch_all()", level="info")
@@ -73,7 +73,7 @@ class SyncNSDUseCase:
         # → busca os já cadastrados
         existing_companies = {
             company_name
-            for (company_name,) in self.company_repo.get_existing_by_columns(
+            for (company_name,) in self.company_repo.iter_existing_by_columns(
                 "company_name"
             )
         }

--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -73,6 +73,23 @@ class SqlAlchemyRepositoryBasePort(ABC, Generic[T, K]):
         raise NotImplementedError
 
     @abstractmethod
+    def iter_existing_by_columns(
+        self, column_names: Union[str, List[str]], batch_size: int | None = None
+    ) -> Generator[Tuple, None, None]:
+        """Yield existing values for given columns in batches.
+
+        Args:
+            column_names: Single column name or list of column names to fetch.
+            batch_size: Optional number of rows to fetch per batch. Falls back
+                to configuration when ``None``.
+
+        Returns:
+            Generator[Tuple, None, None]: Distinct tuples ordered by the
+            specified columns.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def has_item(self, identifier: K) -> bool:
         """Check whether an item with the given identifier exists.
 

--- a/infrastructure/repositories/sqlalchemy_repository_base.py
+++ b/infrastructure/repositories/sqlalchemy_repository_base.py
@@ -288,6 +288,39 @@ class SqlAlchemyRepositoryBase(
             # Ensure session is always closed
             session.close()
 
+    def iter_existing_by_columns(
+        self, column_names: Union[str, List[str]], batch_size: int | None = None
+    ) -> Generator[Tuple, None, None]:
+        """Yield distinct column values in a streaming fashion.
+
+        Args:
+            column_names: Single column name or list of column names to fetch.
+            batch_size: Optional number of rows to fetch per batch. Falls back
+                to configuration when ``None``.
+
+        Yields:
+            Tuple: Distinct values ordered by the specified columns.
+        """
+        size = batch_size or self.config.global_settings.batch_size
+        model, _ = self.get_model_class()
+        if isinstance(column_names, str):
+            column_names = [column_names]
+        columns = [getattr(model, col) for col in column_names]
+
+        with self.Session() as session:
+            base_q = (
+                session.query(*columns)
+                .distinct()
+                .order_by(*columns)
+                .yield_per(size)
+                .execution_options(stream_results=True)
+                .enable_eagerloads(False)
+            )
+            for row in base_q:
+                if any(field is None for field in row):
+                    continue
+                yield tuple(row)
+
     def get_existing_by_columns(
         self, column_names: Union[str, List[str]]
     ) -> List[Tuple]:

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -378,7 +378,7 @@ class NsdScraper(NSDSourcePort):
         if not self.skip_codes:
             return start
 
-        dates = [d for (d,) in self.repository.get_existing_by_columns("sent_date")]
+        dates = [d for (d,) in self.repository.iter_existing_by_columns("sent_date")]
 
         first_date = min(dates)
         last_date = max(dates)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 """Command-line entry point for the FLY application."""
-print(f"Start")
+
 from infrastructure.config import ConfigAdapter
 from infrastructure.factories import create_data_cleaner
 from infrastructure.logging import Logger
@@ -16,6 +16,7 @@ def main() -> None:
     - Instantiates the CLI controller with injected dependencies.
     - Starts the application logic by calling ``controller.start_fly()``.
     """
+    print("Start")
     # Inicializa a configuração
     config = ConfigAdapter()
     logger = Logger(config)

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -12,7 +12,7 @@ from tests.conftest import DummyLogger
 
 def test_execute_converts_and_saves():
     repo = MagicMock(spec=SqlAlchemyCompanyDataRepositoryPort)
-    repo.get_existing_by_columns = MagicMock(return_value=[("SKIP",)])
+    repo.iter_existing_by_columns = MagicMock(return_value=iter([("SKIP",)]))
 
     raw = types.SimpleNamespace(
         cvm_code="001",
@@ -76,7 +76,7 @@ def test_execute_converts_and_saves():
 
     result = usecase.synchronize_companies()
 
-    repo.get_existing_by_columns.assert_called_once()
+    repo.iter_existing_by_columns.assert_called_once()
     scraper.fetch_all.assert_called_once()
     repo.save_all.assert_called_once()
     saved = repo.save_all.call_args.args[0]

--- a/tests/infrastructure/test_iter_existing_by_columns.py
+++ b/tests/infrastructure/test_iter_existing_by_columns.py
@@ -1,0 +1,119 @@
+"""Tests for iter_existing_by_columns method."""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, sessionmaker
+from sqlalchemy.orm import Session as SASession
+
+from infrastructure.models.base_model import BaseModel
+from infrastructure.repositories.sqlalchemy_repository_base import (
+    SqlAlchemyRepositoryBase,
+)
+from tests.conftest import DummyConfig, DummyLogger
+
+
+@dataclass(frozen=True)
+class DummyDTO:
+    id: int | None
+    name: str
+
+
+class DummyModel(BaseModel):
+    __tablename__ = "dummy_model_iter_existing"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
+    name: Mapped[str] = mapped_column(String)
+
+    @staticmethod
+    def from_dto(dto: DummyDTO) -> "DummyModel":
+        return DummyModel(id=dto.id, name=dto.name)
+
+    def to_dto(self) -> DummyDTO:
+        return DummyDTO(id=self.id, name=self.name)
+
+
+class DummyRepository(SqlAlchemyRepositoryBase[DummyDTO, int]):
+    def get_model_class(self) -> Tuple[type, tuple]:
+        return DummyModel, (DummyModel.id,)
+
+
+@dataclass(frozen=True)
+class CompositeDTO:
+    part1: int
+    part2: int
+    value: str
+
+
+class CompositeModel(BaseModel):
+    __tablename__ = "composite_model_iter_existing"
+
+    part1: Mapped[int] = mapped_column(Integer, primary_key=True)
+    part2: Mapped[int] = mapped_column(Integer, primary_key=True)
+    value: Mapped[str] = mapped_column(String)
+
+    @staticmethod
+    def from_dto(dto: CompositeDTO) -> "CompositeModel":
+        return CompositeModel(part1=dto.part1, part2=dto.part2, value=dto.value)
+
+    def to_dto(self) -> CompositeDTO:
+        return CompositeDTO(part1=self.part1, part2=self.part2, value=self.value)
+
+
+class CompositeRepository(SqlAlchemyRepositoryBase[CompositeDTO, tuple[int, int]]):
+    def get_model_class(self) -> Tuple[type, tuple]:
+        return CompositeModel, (CompositeModel.part1, CompositeModel.part2)
+
+
+def _setup_repo(repo, engine, SessionLocal) -> None:
+    repo.engine = engine
+    repo.Session = SessionLocal
+    BaseModel.metadata.drop_all(engine)
+    BaseModel.metadata.create_all(engine)
+
+
+def test_iter_existing_by_columns_simple(SessionLocal, engine) -> None:
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    items = [DummyDTO(id=i, name=str(i)) for i in range(1, 6)]
+    repo.save_all(items)
+
+    result = list(repo.iter_existing_by_columns("id", batch_size=2))
+    assert result == [(1,), (2,), (3,), (4,), (5,)]
+
+
+def test_iter_existing_by_columns_composite(SessionLocal, engine) -> None:
+    cfg = DummyConfig()
+    repo = CompositeRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    items = [
+        CompositeDTO(part1=1, part2=1, value="a"),
+        CompositeDTO(part1=1, part2=2, value="b"),
+        CompositeDTO(part1=2, part2=1, value="c"),
+    ]
+    repo.save_all(items)
+
+    result = list(repo.iter_existing_by_columns(["part1", "part2"], batch_size=1))
+    assert result == [(1, 1), (1, 2), (2, 1)]
+
+
+def test_iter_existing_by_columns_closes_session_on_break(SessionLocal, engine) -> None:
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    repo.save_all([DummyDTO(id=1, name="a"), DummyDTO(id=2, name="b")])
+
+    closed = {"value": False}
+
+    class TrackingSession(SASession):
+        def close(self) -> None:  # type: ignore[override]
+            closed["value"] = True
+            super().close()
+
+    repo.Session = sessionmaker(bind=engine, class_=TrackingSession)
+
+    for _ in repo.iter_existing_by_columns("id", batch_size=1):
+        break
+    assert closed["value"]


### PR DESCRIPTION
## Summary
- extend repository port with `iter_existing_by_columns` for streaming column queries
- implement streaming query in `SqlAlchemyRepositoryBase`
- update application code to consume iterator and add tests

## Testing
- `ruff format application/usecases/sync_companies.py application/usecases/sync_nsd.py application/processors/fetch_statements_processor.py infrastructure/repositories/sqlalchemy_repository_base.py domain/ports/base_repository_port.py infrastructure/scrapers/nsd_scraper.py tests/application/test_sync_companies_use_case.py tests/infrastructure/test_iter_existing_by_columns.py main.py`
- `ruff check application/usecases/sync_companies.py application/usecases/sync_nsd.py application/processors/fetch_statements_processor.py infrastructure/repositories/sqlalchemy_repository_base.py domain/ports/base_repository_port.py infrastructure/scrapers/nsd_scraper.py tests/application/test_sync_companies_use_case.py tests/infrastructure/test_iter_existing_by_columns.py main.py --fix`
- `pydocstyle --convention=google .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a551687c8832e81a12d94ecbcd88b