### PR TITLE
Add streaming iterator for existing column values

### DIFF
--- a/application/processors/fetch_statements_processor.py
+++ b/application/processors/fetch_statements_processor.py
@@ -79,10 +79,9 @@ class FetchStatementsProcessor(
         if not company_names:
             return []
 
-        raw_statement_existing = self.raw_statement_repo.get_existing_by_columns(
-            column_names="nsd"
-        )
-        nsd_rows_processed = {row[0] for row in raw_statement_existing}
+        nsd_rows_processed = {
+            row[0] for row in self.raw_statement_repo.iter_existing_by_columns("nsd")
+        }
         valid_types = set(self.config.domain.statements_types)
 
         results: List[NsdDTO] = []

--- a/application/processors/fetch_statements_processor.py
+++ b/application/processors/fetch_statements_processor.py
@@ -8,13 +8,13 @@ from application.usecases.fetch_statements import FetchStatementsUseCase
 from domain.dto import NsdDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
 from domain.ports import (
+    CompanyDataRepositoryPort,
     ConfigPort,
     LoggerPort,
     MetricsCollectorPort,
     NSDRepositoryPort,
-    SqlAlchemyCompanyDataRepositoryPort,
-    SqlAlchemyParsedStatementRepositoryPort,
-    SqlAlchemyRawStatementRepositoryPort,
+    ParsedStatementRepositoryPort,
+    RawStatementRepositoryPort,
     WorkerPoolPort,
 )
 from domain.ports.scraper_ports import RawStatementScraperPort
@@ -40,10 +40,10 @@ class FetchStatementsProcessor(
         logger: LoggerPort,
         config: ConfigPort,
         source: RawStatementScraperPort,
-        company_repo: SqlAlchemyCompanyDataRepositoryPort,
+        company_repo: CompanyDataRepositoryPort,
         nsd_repo: NSDRepositoryPort,
-        raw_statement_repo: SqlAlchemyRawStatementRepositoryPort,
-        parsed_statements_repo: SqlAlchemyParsedStatementRepositoryPort,
+        raw_statement_repo: RawStatementRepositoryPort,
+        parsed_statements_repo: ParsedStatementRepositoryPort,
         metrics_collector: MetricsCollectorPort,
         worker_pool_executor: WorkerPoolPort,
         max_workers: int = 1,

--- a/application/processors/parse_statements_processor.py
+++ b/application/processors/parse_statements_processor.py
@@ -13,7 +13,7 @@ from domain.ports import (
     ConfigPort,
     LoggerPort,
     MetricsCollectorPort,
-    SqlAlchemyParsedStatementRepositoryPort,
+    ParsedStatementRepositoryPort,
     WorkerPoolPort,
 )
 
@@ -26,7 +26,7 @@ class ParseStatementsProcessor(BaseProcessor):
     def __init__(
         self,
         logger: LoggerPort,
-        repository: SqlAlchemyParsedStatementRepositoryPort,
+        repository: ParsedStatementRepositoryPort,
         config: ConfigPort,
         worker_pool_executor: WorkerPoolPort,
         metrics_collector: MetricsCollectorPort,
@@ -42,7 +42,9 @@ class ParseStatementsProcessor(BaseProcessor):
             logger=self.logger, repository=repository, config=self.config
         )
 
-    def _parse_all(self, data: List[Tuple[NsdDTO, List[RawStatementDTO]]]) -> List[List[ParsedStatementDTO]]:
+    def _parse_all(
+        self, data: List[Tuple[NsdDTO, List[RawStatementDTO]]]
+    ) -> List[List[ParsedStatementDTO]]:
         tasks = list(enumerate(data))
 
         def processor(task: WorkerTaskDTO) -> List[ParsedStatementDTO]:
@@ -50,9 +52,7 @@ class ParseStatementsProcessor(BaseProcessor):
             return [self.parse_usecase.parse_and_store_row(r) for r in rows]
 
         result = self.worker_pool_executor.run(
-            tasks=tasks,
-            processor=processor,
-            logger=self.logger
+            tasks=tasks, processor=processor, logger=self.logger
         )
         return result.items
 
@@ -63,15 +63,15 @@ class ParseStatementsProcessor(BaseProcessor):
         return fetched
 
     def transform(
-        self, data : List[Tuple[NsdDTO, List[RawStatementDTO]]]
+        self, data: List[Tuple[NsdDTO, List[RawStatementDTO]]]
     ) -> List[List[ParsedStatementDTO]]:
         """Parse fetched rows in parallel."""
-        if not data :
+        if not data:
             return []
-        return self._parse_all(data )
+        return self._parse_all(data)
 
     def persist(
-        self, data : List[List[ParsedStatementDTO]]
+        self, data: List[List[ParsedStatementDTO]]
     ) -> List[List[ParsedStatementDTO]]:
         """Finalize parse use case and return parsed data."""
         self.parse_usecase.finalize()

--- a/application/processors/transform_statements_processor.py
+++ b/application/processors/transform_statements_processor.py
@@ -6,7 +6,7 @@ from typing import List
 
 from application.usecases.transform_statements import TransformStatementsUseCase
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
-from domain.ports import ConfigPort, LoggerPort, SqlAlchemyParsedStatementRepositoryPort
+from domain.ports import ConfigPort, LoggerPort, ParsedStatementRepositoryPort
 from domain.services import StatementClassificationService
 from infrastructure.transformers import (
     IntelStatementTransformerAdapter,
@@ -23,7 +23,7 @@ class TransformStatementsProcessor(BaseProcessor):
         self,
         config: ConfigPort,
         logger: LoggerPort,
-        parsed_repo: SqlAlchemyParsedStatementRepositoryPort,
+        parsed_repo: ParsedStatementRepositoryPort,
     ) -> None:
         """Create processor with repository and configuration."""
         self.logger = logger

--- a/application/services/company_data_service.py
+++ b/application/services/company_data_service.py
@@ -3,10 +3,10 @@
 from application.usecases.sync_companies import SyncCompanyDataUseCase
 from domain.dto import SyncCompanyDataResultDTO
 from domain.ports import (
+    CompanyDataRepositoryPort,
     CompanyDataScraperPort,
     ConfigPort,
     LoggerPort,
-    SqlAlchemyCompanyDataRepositoryPort,
 )
 
 
@@ -17,7 +17,7 @@ class CompanyDataService:
         self,
         config: ConfigPort,
         logger: LoggerPort,
-        repository: SqlAlchemyCompanyDataRepositoryPort,
+        repository: CompanyDataRepositoryPort,
         scraper: CompanyDataScraperPort,
     ):
         """Initialize dependencies for company synchronization."""

--- a/application/services/nsd_service.py
+++ b/application/services/nsd_service.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from application.usecases.sync_nsd import SyncNSDUseCase
 from domain.ports import (
+    CompanyDataRepositoryPort,
     ConfigPort,
     LoggerPort,
     NSDRepositoryPort,
     NSDSourcePort,
-    SqlAlchemyCompanyDataRepositoryPort,
 )
 
 
@@ -18,7 +18,7 @@ class NsdService:
         config: ConfigPort,
         logger: LoggerPort,
         repository: NSDRepositoryPort,
-        company_repo: SqlAlchemyCompanyDataRepositoryPort,
+        company_repo: CompanyDataRepositoryPort,
         scraper: NSDSourcePort,
     ) -> None:
         """Instantiate the service with its required dependencies."""

--- a/application/usecases/fetch_statements.py
+++ b/application/usecases/fetch_statements.py
@@ -12,8 +12,8 @@ from domain.ports import (
     ConfigPort,
     LoggerPort,
     MetricsCollectorPort,
-    SqlAlchemyParsedStatementRepositoryPort,
-    SqlAlchemyRawStatementRepositoryPort,
+    ParsedStatementRepositoryPort,
+    RawStatementRepositoryPort,
     WorkerPoolPort,
 )
 from domain.ports.scraper_ports import RawStatementScraperPort
@@ -27,8 +27,8 @@ class FetchStatementsUseCase:
         self,
         logger: LoggerPort,
         source: RawStatementScraperPort,
-        raw_statement_repository: SqlAlchemyRawStatementRepositoryPort,
-        parsed_statements_repo: SqlAlchemyParsedStatementRepositoryPort,
+        raw_statement_repository: RawStatementRepositoryPort,
+        parsed_statements_repo: ParsedStatementRepositoryPort,
         metrics_collector: MetricsCollectorPort,
         worker_pool_executor: WorkerPoolPort,
         config: ConfigPort,

--- a/application/usecases/parse_and_classify_statements.py
+++ b/application/usecases/parse_and_classify_statements.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from domain.dto import ParsedStatementDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
-from domain.ports import ConfigPort, LoggerPort, SqlAlchemyParsedStatementRepositoryPort
+from domain.ports import ConfigPort, LoggerPort, ParsedStatementRepositoryPort
 from infrastructure.helpers import SaveStrategy
 
 
@@ -12,7 +12,7 @@ class ParseAndClassifyStatementsUseCase:
     def __init__(
         self,
         logger: LoggerPort,
-        repository: SqlAlchemyParsedStatementRepositoryPort,
+        repository: ParsedStatementRepositoryPort,
         config: ConfigPort,
     ) -> None:
         self.logger = logger

--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -46,9 +46,9 @@ class SyncCompanyDataUseCase:
         start = time.perf_counter()
 
         # busca todos os company_name que já estão na tabela
-        raw = self.repository.get_existing_by_columns("company_name")
-        # get_existing_by_columns devolve List[Tuple], ex: [("900049",),("900642",)…]
-        skip_codes = [code for (code,) in raw]
+        skip_codes = [
+            code for (code,) in self.repository.iter_existing_by_columns("company_name")
+        ]
 
         # self.logger.log("Call Method sync_companies_usecase.run().fetch_all(save_callback, max_workers)", level="info")
         # Fetch all companies from the scraper and persist them batch-wise.
@@ -74,7 +74,9 @@ class SyncCompanyDataUseCase:
     def _save_batch(self, buffer: List[CompanyDataRawDTO]) -> None:
         """Convert raw companies to domain DTOs before saving."""
         # primeiro “desembrulha” qualquer nível de listas aninhadas
-        flat_items = ListFlattener.flatten(buffer)  # recebe nested lists, devolve flat list
+        flat_items = ListFlattener.flatten(
+            buffer
+        )  # recebe nested lists, devolve flat list
 
         # Transform raw DTOs from the scraper to domain DTOs.
         dtos = [CompanyDataDTO.from_raw(item) for item in flat_items]

--- a/application/usecases/sync_companies.py
+++ b/application/usecases/sync_companies.py
@@ -7,9 +7,9 @@ from domain.dto import SyncCompanyDataResultDTO
 from domain.dto.company_data_dto import CompanyDataDTO
 from domain.dto.raw_company_data_dto import CompanyDataRawDTO
 from domain.ports import (
+    CompanyDataRepositoryPort,
     CompanyDataScraperPort,
     LoggerPort,
-    SqlAlchemyCompanyDataRepositoryPort,
 )
 from infrastructure.helpers.list_flattener import ListFlattener
 
@@ -20,7 +20,7 @@ class SyncCompanyDataUseCase:
     def __init__(
         self,
         logger: LoggerPort,
-        repository: SqlAlchemyCompanyDataRepositoryPort,
+        repository: CompanyDataRepositoryPort,
         scraper: CompanyDataScraperPort,
         max_workers: int = 1,
     ):

--- a/application/usecases/sync_nsd.py
+++ b/application/usecases/sync_nsd.py
@@ -39,9 +39,9 @@ class SyncNSDUseCase:
         # self.logger.log("Run  Method controller.run()._nsd_service().run().sync_nsd_usecase.run()", level="info")
 
         # busca todos os cvm_code que já estão na tabela
-        raw = self.repository.get_existing_by_columns("nsd")
-        # get_existing_by_columns devolve List[Tuple], ex: [("900049",),("900642",)…]
-        existing_nsd = [code for (code,) in raw]
+        existing_nsd = [
+            code for (code,) in self.repository.iter_existing_by_columns("nsd")
+        ]
 
         # Fetch all documents from the scraper, persisting them in batches.
         # self.logger.log("Call Method controller.run()._nsd_service().run().sync_nsd_usecase.run().fetch_all()", level="info")
@@ -73,7 +73,7 @@ class SyncNSDUseCase:
         # → busca os já cadastrados
         existing_companies = {
             company_name
-            for (company_name,) in self.company_repo.get_existing_by_columns(
+            for (company_name,) in self.company_repo.iter_existing_by_columns(
                 "company_name"
             )
         }

--- a/application/usecases/sync_nsd.py
+++ b/application/usecases/sync_nsd.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from domain.dto.nsd_dto import NsdDTO
 from domain.ports import (
+    CompanyDataRepositoryPort,
     ConfigPort,
     LoggerPort,
     NSDRepositoryPort,
     NSDSourcePort,
-    SqlAlchemyCompanyDataRepositoryPort,
 )
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.utils.id_generator import IdGenerator
@@ -20,7 +20,7 @@ class SyncNSDUseCase:
         config: ConfigPort,
         logger: LoggerPort,
         repository: NSDRepositoryPort,
-        company_repo: SqlAlchemyCompanyDataRepositoryPort,
+        company_repo: CompanyDataRepositoryPort,
         scraper: NSDSourcePort,
     ) -> None:
         """Store dependencies required for synchronization."""

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -1,17 +1,17 @@
 """Exports for domain port interfaces."""
 
-from .base_repository_port import SqlAlchemyRepositoryBasePort
+from .base_repository_port import RepositoryBasePort
 from .base_scraper_port import BaseScraperPort
 from .company_data_scraper_port import CompanyDataScraperPort
-from .company_repository_port import SqlAlchemyCompanyDataRepositoryPort
+from .company_repository_port import CompanyDataRepositoryPort
 from .config_port import ConfigPort
 from .data_cleaner_port import DataCleanerPort
 from .logger_port import LoggerPort
 from .metrics_collector_port import MetricsCollectorPort
 from .nsd_repository_port import NSDRepositoryPort
 from .nsd_source_port import NSDSourcePort
-from .parsed_statement_repository_port import SqlAlchemyParsedStatementRepositoryPort
-from .raw_statement_repository_port import SqlAlchemyRawStatementRepositoryPort
+from .parsed_statement_repository_port import ParsedStatementRepositoryPort
+from .raw_statement_repository_port import RawStatementRepositoryPort
 from .raw_statement_scraper_port import RawStatementScraperPort
 from .statement_transformer_port import StatementTransformerPort
 from .worker_pool_port import WorkerPoolPort
@@ -20,17 +20,16 @@ __all__ = [
     "WorkerPoolPort",
     "LoggerPort",
     "DataCleanerPort",
-    "SqlAlchemyRepositoryBasePort",
+    "RepositoryBasePort",
     "BaseScraperPort",
-    "SqlAlchemyCompanyDataRepositoryPort",
+    "CompanyDataRepositoryPort",
     "CompanyDataScraperPort",
     "MetricsCollectorPort",
     "NSDRepositoryPort",
     "NSDSourcePort",
     "RawStatementScraperPort",
-    "SqlAlchemyRawStatementRepositoryPort",
-    "SqlAlchemyParsedStatementRepositoryPort",
+    "RawStatementRepositoryPort",
+    "ParsedStatementRepositoryPort",
     "ConfigPort",
     "StatementTransformerPort",
-    "RawStatementScraperPort",
 ]

--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Generator, Generic, List, Sequence, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Generator,
+    Generic,
+    Iterator,
+    List,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 T = TypeVar("T")  # DTO type
 K = TypeVar("K")  # Key type (e.g., str, int)
 
 
-class SqlAlchemyRepositoryBasePort(ABC, Generic[T, K]):
+class RepositoryBasePort(ABC, Generic[T, K]):
     """Generic interface (port) for basic repository operations.
 
     This abstract base class defines the standard CRUD-like operations
@@ -74,18 +84,17 @@ class SqlAlchemyRepositoryBasePort(ABC, Generic[T, K]):
 
     @abstractmethod
     def iter_existing_by_columns(
-        self, column_names: Union[str, List[str]], batch_size: int | None = None
-    ) -> Generator[Tuple, None, None]:
-        """Yield existing values for given columns in batches.
+        self,
+        column_names: Union[str, List[str]],
+        *,
+        batch_size: int | None = None,
+        include_nulls: bool = False,
+    ) -> Iterator[Tuple]:
+        """Yield distinct tuples ordered by the given columns.
 
-        Args:
-            column_names: Single column name or list of column names to fetch.
-            batch_size: Optional number of rows to fetch per batch. Falls back
-                to configuration when ``None``.
-
-        Returns:
-            Generator[Tuple, None, None]: Distinct tuples ordered by the
-            specified columns.
+        The default excludes rows where ANY selected column is NULL.
+        Ordering must be stable and exactly by the requested column(s).
+        The iterator must not materialize the full result set.
         """
         raise NotImplementedError
 

--- a/domain/ports/base_repository_port.py
+++ b/domain/ports/base_repository_port.py
@@ -73,6 +73,23 @@ class SqlAlchemyRepositoryBasePort(ABC, Generic[T, K]):
         raise NotImplementedError
 
     @abstractmethod
+    def iter_existing_by_columns(
+        self, column_names: Union[str, List[str]], batch_size: int | None = None
+    ) -> Generator[Tuple, None, None]:
+        """Yield existing values for given columns in batches.
+
+        Args:
+            column_names: Single column name or list of column names to fetch.
+            batch_size: Optional number of rows to fetch per batch. Falls back
+                to configuration when ``None``.
+
+        Returns:
+            Generator[Tuple, None, None]: Distinct tuples ordered by the
+            specified columns.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def has_item(self, identifier: K) -> bool:
         """Check whether an item with the given identifier exists.
 

--- a/domain/ports/company_repository_port.py
+++ b/domain/ports/company_repository_port.py
@@ -6,12 +6,10 @@ from abc import abstractmethod
 
 from domain.dto.company_data_dto import CompanyDataDTO
 
-from .base_repository_port import SqlAlchemyRepositoryBasePort
+from .base_repository_port import RepositoryBasePort
 
 
-class SqlAlchemyCompanyDataRepositoryPort(
-    SqlAlchemyRepositoryBasePort[CompanyDataDTO, int]
-):
+class CompanyDataRepositoryPort(RepositoryBasePort[CompanyDataDTO, int]):
     """Interface (port) for persistence operations related to CompanyData
     entities.
 
@@ -19,10 +17,11 @@ class SqlAlchemyCompanyDataRepositoryPort(
     company-related data storage, decoupling it from the actual database
     implementation.
     """
+
     @abstractmethod
     def get_cvm_by_name(self, company_name: str) -> str:
-        """
-        Dado o nome da empresa, retorna o código CVM único associado.
+        """Dado o nome da empresa, retorna o código CVM único associado.
+
         Levanta ValueError se não encontrar.
         """
         raise NotImplementedError

--- a/domain/ports/nsd_repository_port.py
+++ b/domain/ports/nsd_repository_port.py
@@ -7,10 +7,10 @@ from typing import List, Set
 
 from domain.dto.nsd_dto import NsdDTO
 
-from .base_repository_port import SqlAlchemyRepositoryBasePort
+from .base_repository_port import RepositoryBasePort
 
 
-class NSDRepositoryPort(SqlAlchemyRepositoryBasePort[NsdDTO, int]):
+class NSDRepositoryPort(RepositoryBasePort[NsdDTO, int]):
     """Port for NSD persistence operations."""
 
     @abstractmethod

--- a/domain/ports/parsed_statement_repository_port.py
+++ b/domain/ports/parsed_statement_repository_port.py
@@ -4,12 +4,10 @@ from typing import List
 
 from domain.dto import ParsedStatementDTO
 
-from .base_repository_port import SqlAlchemyRepositoryBasePort
+from .base_repository_port import RepositoryBasePort
 
 
-class SqlAlchemyParsedStatementRepositoryPort(
-    SqlAlchemyRepositoryBasePort[ParsedStatementDTO, int]
-):
+class ParsedStatementRepositoryPort(RepositoryBasePort[ParsedStatementDTO, int]):
     """Port for persisting parsed statement rows."""
 
     def exists_with_hash(self, company_name: str, hash_: str) -> bool:

--- a/domain/ports/raw_statement_repository_port.py
+++ b/domain/ports/raw_statement_repository_port.py
@@ -5,12 +5,10 @@ from typing import List
 
 from domain.dto.raw_statement_dto import RawStatementDTO
 
-from .base_repository_port import SqlAlchemyRepositoryBasePort
+from .base_repository_port import RepositoryBasePort
 
 
-class SqlAlchemyRawStatementRepositoryPort(
-    SqlAlchemyRepositoryBasePort[RawStatementDTO, int], ABC
-):
+class RawStatementRepositoryPort(RepositoryBasePort[RawStatementDTO, int], ABC):
     """Port for persisting raw statement rows."""
 
     def get_by_company_name(self, company_name: str) -> List[RawStatementDTO]:

--- a/infrastructure/repositories/company_repository.py
+++ b/infrastructure/repositories/company_repository.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 from sqlalchemy.dialects.sqlite import insert
 
 from domain.dto.company_data_dto import CompanyDataDTO
-from domain.ports import ConfigPort, LoggerPort, SqlAlchemyCompanyDataRepositoryPort
+from domain.ports import CompanyDataRepositoryPort, ConfigPort, LoggerPort
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.company_data_model import CompanyDataModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
@@ -17,7 +17,7 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 
 class SqlAlchemyCompanyDataRepository(
     SqlAlchemyRepositoryBase[CompanyDataDTO, int],
-    SqlAlchemyCompanyDataRepositoryPort,
+    CompanyDataRepositoryPort,
 ):
     """Concrete repository implementation for CompanyDataDTO using SQLite and
     SQLAlchemy.

--- a/infrastructure/repositories/parsed_statement_repository.py
+++ b/infrastructure/repositories/parsed_statement_repository.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from sqlalchemy.dialects.sqlite import insert
 
 from domain.dto import ParsedStatementDTO
-from domain.ports import ConfigPort, LoggerPort, SqlAlchemyParsedStatementRepositoryPort
+from domain.ports import ConfigPort, LoggerPort, ParsedStatementRepositoryPort
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.parsed_statement_model import ParsedStatementModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
@@ -18,7 +18,7 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 
 class SqlAlchemyParsedStatementRepository(
     SqlAlchemyRepositoryBase[ParsedStatementDTO, int],
-    SqlAlchemyParsedStatementRepositoryPort,
+    ParsedStatementRepositoryPort,
 ):
     """SQLite-backed repository for ``ParsedStatementDTO`` objects."""
 

--- a/infrastructure/repositories/raw_statement_repository.py
+++ b/infrastructure/repositories/raw_statement_repository.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 from sqlalchemy.dialects.sqlite import insert
 
 from domain.dto.raw_statement_dto import RawStatementDTO
-from domain.ports import ConfigPort, LoggerPort, SqlAlchemyRawStatementRepositoryPort
+from domain.ports import ConfigPort, LoggerPort, RawStatementRepositoryPort
 from infrastructure.helpers.list_flattener import ListFlattener
 from infrastructure.models.raw_statement_model import RawStatementModel
 from infrastructure.repositories.sqlalchemy_repository_base import (
@@ -17,7 +17,7 @@ from infrastructure.repositories.sqlalchemy_repository_base import (
 
 class SqlAlchemyRawStatementRepository(
     SqlAlchemyRepositoryBase[RawStatementDTO, int],
-    SqlAlchemyRawStatementRepositoryPort,
+    RawStatementRepositoryPort,
 ):
     """SQLite-backed repository for ``RawStatementDTO`` objects."""
 

--- a/infrastructure/repositories/sqlalchemy_repository_base.py
+++ b/infrastructure/repositories/sqlalchemy_repository_base.py
@@ -288,6 +288,39 @@ class SqlAlchemyRepositoryBase(
             # Ensure session is always closed
             session.close()
 
+    def iter_existing_by_columns(
+        self, column_names: Union[str, List[str]], batch_size: int | None = None
+    ) -> Generator[Tuple, None, None]:
+        """Yield distinct column values in a streaming fashion.
+
+        Args:
+            column_names: Single column name or list of column names to fetch.
+            batch_size: Optional number of rows to fetch per batch. Falls back
+                to configuration when ``None``.
+
+        Yields:
+            Tuple: Distinct values ordered by the specified columns.
+        """
+        size = batch_size or self.config.global_settings.batch_size
+        model, _ = self.get_model_class()
+        if isinstance(column_names, str):
+            column_names = [column_names]
+        columns = [getattr(model, col) for col in column_names]
+
+        with self.Session() as session:
+            base_q = (
+                session.query(*columns)
+                .distinct()
+                .order_by(*columns)
+                .yield_per(size)
+                .execution_options(stream_results=True)
+                .enable_eagerloads(False)
+            )
+            for row in base_q:
+                if any(field is None for field in row):
+                    continue
+                yield tuple(row)
+
     def get_existing_by_columns(
         self, column_names: Union[str, List[str]]
     ) -> List[Tuple]:

--- a/infrastructure/repositories/sqlalchemy_repository_base.py
+++ b/infrastructure/repositories/sqlalchemy_repository_base.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Generator,
     Generic,
+    Iterator,
     List,
     Optional,
     Sequence,
@@ -14,7 +15,7 @@ from typing import (
 from sqlalchemy import tuple_ as sa_tuple
 
 from domain.ports import ConfigPort, LoggerPort
-from domain.ports.base_repository_port import SqlAlchemyRepositoryBasePort
+from domain.ports.base_repository_port import RepositoryBasePort
 from infrastructure.adapters.sqlalchemy_engine_mixin import SqlAlchemyEngineMixin
 from infrastructure.helpers.list_flattener import ListFlattener
 
@@ -23,7 +24,7 @@ K = TypeVar("K")  # Primary key type (e.g., str, int)
 
 
 class SqlAlchemyRepositoryBase(
-    SqlAlchemyRepositoryBasePort[T, K], SqlAlchemyEngineMixin, ABC, Generic[T, K]
+    RepositoryBasePort[T, K], SqlAlchemyEngineMixin, ABC, Generic[T, K]
 ):
     """
     Contract - Interface genérica para repositórios de leitura/escrita.
@@ -289,17 +290,17 @@ class SqlAlchemyRepositoryBase(
             session.close()
 
     def iter_existing_by_columns(
-        self, column_names: Union[str, List[str]], batch_size: int | None = None
-    ) -> Generator[Tuple, None, None]:
-        """Yield distinct column values in a streaming fashion.
+        self,
+        column_names: Union[str, List[str]],
+        *,
+        batch_size: int | None = None,
+        include_nulls: bool = False,
+    ) -> Iterator[Tuple]:
+        """Stream distinct column values in deterministic order.
 
-        Args:
-            column_names: Single column name or list of column names to fetch.
-            batch_size: Optional number of rows to fetch per batch. Falls back
-                to configuration when ``None``.
-
-        Yields:
-            Tuple: Distinct values ordered by the specified columns.
+        Chunked iteration relies on SQLAlchemy's ``yield_per`` to limit rows
+        loaded into memory. ``stream_results=True`` is retained for
+        compatibility but does not enable server-side cursors on SQLite.
         """
         size = batch_size or self.config.global_settings.batch_size
         model, _ = self.get_model_class()
@@ -308,17 +309,16 @@ class SqlAlchemyRepositoryBase(
         columns = [getattr(model, col) for col in column_names]
 
         with self.Session() as session:
-            base_q = (
-                session.query(*columns)
-                .distinct()
-                .order_by(*columns)
-                .yield_per(size)
+            query = session.query(*columns).distinct().order_by(*columns)
+            if not include_nulls:
+                for col in columns:
+                    query = query.filter(col.isnot(None))
+            query = (
+                query.yield_per(size)
                 .execution_options(stream_results=True)
                 .enable_eagerloads(False)
             )
-            for row in base_q:
-                if any(field is None for field in row):
-                    continue
+            for row in query:
                 yield tuple(row)
 
     def get_existing_by_columns(

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -378,7 +378,7 @@ class NsdScraper(NSDSourcePort):
         if not self.skip_codes:
             return start
 
-        dates = [d for (d,) in self.repository.get_existing_by_columns("sent_date")]
+        dates = [d for (d,) in self.repository.iter_existing_by_columns("sent_date")]
 
         first_date = min(dates)
         last_date = max(dates)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 """Command-line entry point for the FLY application."""
-print(f"Start")
+
 from infrastructure.config import ConfigAdapter
 from infrastructure.factories import create_data_cleaner
 from infrastructure.logging import Logger
@@ -16,6 +16,7 @@ def main() -> None:
     - Instantiates the CLI controller with injected dependencies.
     - Starts the application logic by calling ``controller.start_fly()``.
     """
+    print("Start")
     # Inicializa a configuração
     config = ConfigAdapter()
     logger = Logger(config)

--- a/tests/application/test_company_service.py
+++ b/tests/application/test_company_service.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 # from application.services.company_services import CompanyDataService
 from application.services.company_data_service import CompanyDataService
 from application.usecases.sync_companies import SyncCompanyDataUseCase
-from domain.ports import CompanyDataScraperPort, SqlAlchemyCompanyDataRepositoryPort
+from domain.ports import CompanyDataRepositoryPort, CompanyDataScraperPort
 from tests.conftest import DummyConfig, DummyLogger
 
 
@@ -19,7 +19,7 @@ def test_sync_companies_calls_usecase(monkeypatch):
         mock_usecase_cls,
     )
 
-    repo = MagicMock(spec=SqlAlchemyCompanyDataRepositoryPort)
+    repo = MagicMock(spec=CompanyDataRepositoryPort)
     scraper = MagicMock(spec=CompanyDataScraperPort)
 
     service = CompanyDataService(

--- a/tests/application/test_fetch_statements_processor.py
+++ b/tests/application/test_fetch_statements_processor.py
@@ -4,12 +4,12 @@ from application.processors.fetch_statements_processor import FetchStatementsPro
 from application.usecases.fetch_statements import FetchStatementsUseCase
 from domain.dto.nsd_dto import NsdDTO
 from domain.ports import (
+    CompanyDataRepositoryPort,
     NSDRepositoryPort,
-    SqlAlchemyCompanyDataRepositoryPort,
-    SqlAlchemyParsedStatementRepositoryPort,
+    ParsedStatementRepositoryPort,
+    RawStatementRepositoryPort,
 )
 from domain.ports.scraper_ports import RawStatementScraperPort
-from infrastructure.repositories import SqlAlchemyRawStatementRepository
 from tests.conftest import DummyConfig, DummyLogger
 
 
@@ -24,10 +24,10 @@ def test_fetch_statements_calls_usecase(monkeypatch):
         mock_usecase_cls,
     )
 
-    company_repo = MagicMock(spec=SqlAlchemyCompanyDataRepositoryPort)
+    company_repo = MagicMock(spec=CompanyDataRepositoryPort)
     nsd_repo = MagicMock(spec=NSDRepositoryPort)
-    stmt_repo = MagicMock(spec=SqlAlchemyRawStatementRepository)
-    rows_repo = MagicMock(spec=SqlAlchemyParsedStatementRepositoryPort)
+    stmt_repo = MagicMock(spec=RawStatementRepositoryPort)
+    rows_repo = MagicMock(spec=ParsedStatementRepositoryPort)
     source = MagicMock(spec=RawStatementScraperPort)
     collector = MagicMock()
     worker_pool = MagicMock()

--- a/tests/application/test_fetch_statements_use_case.py
+++ b/tests/application/test_fetch_statements_use_case.py
@@ -2,9 +2,8 @@ from unittest.mock import MagicMock
 
 from application.usecases.fetch_statements import FetchStatementsUseCase
 from domain.dto.nsd_dto import NsdDTO
-from domain.ports import SqlAlchemyParsedStatementRepositoryPort
+from domain.ports import ParsedStatementRepositoryPort, RawStatementRepositoryPort
 from domain.ports.scraper_ports import RawStatementScraperPort
-from infrastructure.repositories import SqlAlchemyRawStatementRepository
 from tests.conftest import DummyConfig, DummyLogger
 
 
@@ -26,8 +25,8 @@ def _make_nsd(nsd: int) -> NsdDTO:
 
 def test_fetch_statement_rows_skips_existing(monkeypatch):
     source = MagicMock(spec=RawStatementScraperPort)
-    rows_repo = MagicMock(spec=SqlAlchemyParsedStatementRepositoryPort)
-    stmt_repo = MagicMock(spec=SqlAlchemyRawStatementRepository)
+    rows_repo = MagicMock(spec=ParsedStatementRepositoryPort)
+    stmt_repo = MagicMock(spec=RawStatementRepositoryPort)
     stmt_repo.get_all_primary_keys = MagicMock(return_value={1})
 
     collector = MagicMock()

--- a/tests/application/test_parse_statements_processor.py
+++ b/tests/application/test_parse_statements_processor.py
@@ -6,7 +6,7 @@ from application.usecases.parse_and_classify_statements import (
 )
 from domain.dto import NsdDTO
 from domain.dto.raw_statement_dto import RawStatementDTO
-from infrastructure.repositories import SqlAlchemyParsedStatementRepository
+from domain.ports import ParsedStatementRepositoryPort
 from tests.conftest import DummyConfig, DummyLogger
 
 
@@ -21,7 +21,7 @@ def test_parse_statements_invokes_usecase_and_finalize(monkeypatch):
         mock_usecase_cls,
     )
 
-    repository = MagicMock(spec=SqlAlchemyParsedStatementRepository)
+    repository = MagicMock(spec=ParsedStatementRepositoryPort)
     worker_pool = MagicMock()
     collector = MagicMock()
 

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -6,12 +6,12 @@ from domain.dto.company_data_dto import CompanyDataDTO
 from domain.dto.execution_result_dto import ExecutionResultDTO
 from domain.dto.metrics_dto import MetricsDTO
 from domain.dto.sync_companies_result_dto import SyncCompanyDataResultDTO
-from domain.ports import CompanyDataScraperPort, SqlAlchemyCompanyDataRepositoryPort
+from domain.ports import CompanyDataRepositoryPort, CompanyDataScraperPort
 from tests.conftest import DummyLogger
 
 
 def test_execute_converts_and_saves():
-    repo = MagicMock(spec=SqlAlchemyCompanyDataRepositoryPort)
+    repo = MagicMock(spec=CompanyDataRepositoryPort)
     repo.iter_existing_by_columns = MagicMock(return_value=iter([("SKIP",)]))
 
     raw = types.SimpleNamespace(

--- a/tests/application/test_sync_companies_use_case.py
+++ b/tests/application/test_sync_companies_use_case.py
@@ -12,7 +12,7 @@ from tests.conftest import DummyLogger
 
 def test_execute_converts_and_saves():
     repo = MagicMock(spec=SqlAlchemyCompanyDataRepositoryPort)
-    repo.get_existing_by_columns = MagicMock(return_value=[("SKIP",)])
+    repo.iter_existing_by_columns = MagicMock(return_value=iter([("SKIP",)]))
 
     raw = types.SimpleNamespace(
         cvm_code="001",
@@ -76,7 +76,7 @@ def test_execute_converts_and_saves():
 
     result = usecase.synchronize_companies()
 
-    repo.get_existing_by_columns.assert_called_once()
+    repo.iter_existing_by_columns.assert_called_once()
     scraper.fetch_all.assert_called_once()
     repo.save_all.assert_called_once()
     saved = repo.save_all.call_args.args[0]

--- a/tests/application/test_transform_statements_processor.py
+++ b/tests/application/test_transform_statements_processor.py
@@ -4,12 +4,12 @@ from application.processors.transform_statements_processor import (
     TransformStatementsProcessor,
 )
 from domain.dto.parsed_statement_dto import ParsedStatementDTO
-from domain.ports import SqlAlchemyParsedStatementRepositoryPort
+from domain.ports import ParsedStatementRepositoryPort
 from tests.conftest import DummyConfig, DummyLogger
 
 
 def test_transform_processes_groups(monkeypatch):
-    parsed_repo = MagicMock(spec=SqlAlchemyParsedStatementRepositoryPort)
+    parsed_repo = MagicMock(spec=ParsedStatementRepositoryPort)
 
     monkeypatch.setattr(
         "application.processors.transform_statements_processor.MathStatementTransformerAdapter",
@@ -45,7 +45,7 @@ def test_transform_processes_groups(monkeypatch):
 
 
 def test_transform_returns_empty_when_no_groups(monkeypatch):
-    parsed_repo = MagicMock(spec=SqlAlchemyParsedStatementRepositoryPort)
+    parsed_repo = MagicMock(spec=ParsedStatementRepositoryPort)
 
     monkeypatch.setattr(
         "application.processors.transform_statements_processor.MathStatementTransformerAdapter",

--- a/tests/infrastructure/test_iter_existing_by_columns.py
+++ b/tests/infrastructure/test_iter_existing_by_columns.py
@@ -17,14 +17,14 @@ from tests.conftest import DummyConfig, DummyLogger
 @dataclass(frozen=True)
 class DummyDTO:
     id: int | None
-    name: str
+    name: str | None
 
 
 class DummyModel(BaseModel):
     __tablename__ = "dummy_model_iter_existing"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
-    name: Mapped[str] = mapped_column(String)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
 
     @staticmethod
     def from_dto(dto: DummyDTO) -> "DummyModel":
@@ -117,3 +117,37 @@ def test_iter_existing_by_columns_closes_session_on_break(SessionLocal, engine) 
     for _ in repo.iter_existing_by_columns("id", batch_size=1):
         break
     assert closed["value"]
+
+
+def test_iter_existing_by_columns_null_policy(SessionLocal, engine) -> None:
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    repo.save_all(
+        [
+            DummyDTO(id=1, name="a"),
+            DummyDTO(id=2, name=None),
+            DummyDTO(id=3, name="b"),
+        ]
+    )
+
+    result = list(repo.iter_existing_by_columns("name"))
+    assert result == [("a",), ("b",)]
+
+
+def test_iter_existing_by_columns_include_nulls(SessionLocal, engine) -> None:
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    repo.save_all(
+        [
+            DummyDTO(id=1, name="a"),
+            DummyDTO(id=2, name=None),
+            DummyDTO(id=3, name="b"),
+        ]
+    )
+
+    result = list(
+        repo.iter_existing_by_columns("name", include_nulls=True, batch_size=2)
+    )
+    assert result == [(None,), ("a",), ("b",)]

--- a/tests/infrastructure/test_iter_existing_by_columns.py
+++ b/tests/infrastructure/test_iter_existing_by_columns.py
@@ -1,0 +1,119 @@
+"""Tests for iter_existing_by_columns method."""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, sessionmaker
+from sqlalchemy.orm import Session as SASession
+
+from infrastructure.models.base_model import BaseModel
+from infrastructure.repositories.sqlalchemy_repository_base import (
+    SqlAlchemyRepositoryBase,
+)
+from tests.conftest import DummyConfig, DummyLogger
+
+
+@dataclass(frozen=True)
+class DummyDTO:
+    id: int | None
+    name: str
+
+
+class DummyModel(BaseModel):
+    __tablename__ = "dummy_model_iter_existing"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
+    name: Mapped[str] = mapped_column(String)
+
+    @staticmethod
+    def from_dto(dto: DummyDTO) -> "DummyModel":
+        return DummyModel(id=dto.id, name=dto.name)
+
+    def to_dto(self) -> DummyDTO:
+        return DummyDTO(id=self.id, name=self.name)
+
+
+class DummyRepository(SqlAlchemyRepositoryBase[DummyDTO, int]):
+    def get_model_class(self) -> Tuple[type, tuple]:
+        return DummyModel, (DummyModel.id,)
+
+
+@dataclass(frozen=True)
+class CompositeDTO:
+    part1: int
+    part2: int
+    value: str
+
+
+class CompositeModel(BaseModel):
+    __tablename__ = "composite_model_iter_existing"
+
+    part1: Mapped[int] = mapped_column(Integer, primary_key=True)
+    part2: Mapped[int] = mapped_column(Integer, primary_key=True)
+    value: Mapped[str] = mapped_column(String)
+
+    @staticmethod
+    def from_dto(dto: CompositeDTO) -> "CompositeModel":
+        return CompositeModel(part1=dto.part1, part2=dto.part2, value=dto.value)
+
+    def to_dto(self) -> CompositeDTO:
+        return CompositeDTO(part1=self.part1, part2=self.part2, value=self.value)
+
+
+class CompositeRepository(SqlAlchemyRepositoryBase[CompositeDTO, tuple[int, int]]):
+    def get_model_class(self) -> Tuple[type, tuple]:
+        return CompositeModel, (CompositeModel.part1, CompositeModel.part2)
+
+
+def _setup_repo(repo, engine, SessionLocal) -> None:
+    repo.engine = engine
+    repo.Session = SessionLocal
+    BaseModel.metadata.drop_all(engine)
+    BaseModel.metadata.create_all(engine)
+
+
+def test_iter_existing_by_columns_simple(SessionLocal, engine) -> None:
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    items = [DummyDTO(id=i, name=str(i)) for i in range(1, 6)]
+    repo.save_all(items)
+
+    result = list(repo.iter_existing_by_columns("id", batch_size=2))
+    assert result == [(1,), (2,), (3,), (4,), (5,)]
+
+
+def test_iter_existing_by_columns_composite(SessionLocal, engine) -> None:
+    cfg = DummyConfig()
+    repo = CompositeRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    items = [
+        CompositeDTO(part1=1, part2=1, value="a"),
+        CompositeDTO(part1=1, part2=2, value="b"),
+        CompositeDTO(part1=2, part2=1, value="c"),
+    ]
+    repo.save_all(items)
+
+    result = list(repo.iter_existing_by_columns(["part1", "part2"], batch_size=1))
+    assert result == [(1, 1), (1, 2), (2, 1)]
+
+
+def test_iter_existing_by_columns_closes_session_on_break(SessionLocal, engine) -> None:
+    cfg = DummyConfig()
+    repo = DummyRepository(cfg.database.connection_string, cfg, DummyLogger())
+    _setup_repo(repo, engine, SessionLocal)
+    repo.save_all([DummyDTO(id=1, name="a"), DummyDTO(id=2, name="b")])
+
+    closed = {"value": False}
+
+    class TrackingSession(SASession):
+        def close(self) -> None:  # type: ignore[override]
+            closed["value"] = True
+            super().close()
+
+    repo.Session = sessionmaker(bind=engine, class_=TrackingSession)
+
+    for _ in repo.iter_existing_by_columns("id", batch_size=1):
+        break
+    assert closed["value"]


### PR DESCRIPTION
## Summary
- extend repository port with `iter_existing_by_columns` for streaming column queries
- implement streaming query in `SqlAlchemyRepositoryBase`
- update application code to consume iterator and add tests

## Testing
- `ruff format application/usecases/sync_companies.py application/usecases/sync_nsd.py application/processors/fetch_statements_processor.py infrastructure/repositories/sqlalchemy_repository_base.py domain/ports/base_repository_port.py infrastructure/scrapers/nsd_scraper.py tests/application/test_sync_companies_use_case.py tests/infrastructure/test_iter_existing_by_columns.py main.py`
- `ruff check application/usecases/sync_companies.py application/usecases/sync_nsd.py application/processors/fetch_statements_processor.py infrastructure/repositories/sqlalchemy_repository_base.py domain/ports/base_repository_port.py infrastructure/scrapers/nsd_scraper.py tests/application/test_sync_companies_use_case.py tests/infrastructure/test_iter_existing_by_columns.py main.py --fix`
- `pydocstyle --convention=google .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a551687c8832e81a12d94ecbcd88b