### PR TITLE
feat: share affinity http client across scrapers

### DIFF
--- a/infrastructure/config/__init__.py
+++ b/infrastructure/config/__init__.py
@@ -2,4 +2,7 @@
 
 from .adapter import ConfigAdapter
 
-__all__ = ["ConfigAdapter"]
+# Backward-compatible alias expected by some tests
+Config = ConfigAdapter
+
+__all__ = ["ConfigAdapter", "Config"]

--- a/infrastructure/scrapers/company_data_exchange_scraper.py
+++ b/infrastructure/scrapers/company_data_exchange_scraper.py
@@ -21,9 +21,10 @@ from domain.ports import (
     MetricsCollectorPort,
     WorkerPoolPort,
 )
-from infrastructure.helpers import FetchUtils, SaveStrategy
+from infrastructure.helpers import SaveStrategy
 from infrastructure.helpers.byte_formatter import ByteFormatter
 from infrastructure.helpers.data_cleaner import DataCleaner
+from infrastructure.http.affinity_port import AffinityHttpClient
 from infrastructure.scrapers.company_data_processors import (
     CompanyDataDetailProcessor,
     CompanyDataMerger,
@@ -47,6 +48,7 @@ class CompanyDataScraper(CompanyDataScraperPort):
         mapper: CompanyDataMapper,
         worker_pool_executor: WorkerPoolPort,
         metrics_collector: MetricsCollectorPort,
+        http_client: AffinityHttpClient,
     ):
         """Set up configuration, logger and helper utilities for the scraper.
 
@@ -57,12 +59,10 @@ class CompanyDataScraper(CompanyDataScraperPort):
         Attributes:
             config (Config): Stored configuration instance.
             logger (Logger): Stored logger instance.
-            fetch_utils (FetchUtils): Utility for HTTP requests with retries.
             language (str): Language code for API requests.
             endpoint_companies_list (str): URL for the companies list endpoint.
             endpoint_detail (str): URL for the company detail endpoint.
             endpoint_financial (str): URL for the financial data endpoint.
-            session (requests.Session): Reusable HTTP session.
 
         Returns:
             None
@@ -80,17 +80,14 @@ class CompanyDataScraper(CompanyDataScraperPort):
         self.worker_pool_executor = worker_pool_executor
         self._metrics_collector = metrics_collector
 
-        # Initialize FetchUtils for HTTP request utilities
-        self.fetch_utils = FetchUtils(config, logger)
+        # Shared HTTP client providing connection reuse, limiter and cache
+        self.http_client = http_client
 
         # Set language and API company_data_endpoint from configuration
         self.language = config.exchange.language
         self.endpoint_companies_list = config.exchange.company_data_endpoint["initial"]
         self.endpoint_detail = config.exchange.company_data_endpoint["detail"]
         self.endpoint_financial = config.exchange.company_data_endpoint["financial"]
-
-        # Initialize a requests session for HTTP requests
-        self.session = self.fetch_utils.create_scraper()
 
         self.byte_formatter = ByteFormatter()
 
@@ -99,12 +96,9 @@ class CompanyDataScraper(CompanyDataScraperPort):
 
         self.entry_cleaner = EntryCleaner(self.data_cleaner)
         self.detail_fetcher = DetailFetcher(
-            fetch_utils=self.fetch_utils,
-            session=self.session,
+            http_client=self.http_client,
             endpoint_detail=self.endpoint_detail,
             language=self.language,
-            metrics_collector=self.metrics_collector,
-            data_cleaner=self.data_cleaner,
         )
         self.company_data_merger = CompanyDataMerger(self.mapper, self.logger)
         self.detail_processor = CompanyDataDetailProcessor(
@@ -424,13 +418,10 @@ class CompanyDataScraper(CompanyDataScraperPort):
         token = self._encode_payload(payload)
 
         url = self.endpoint_companies_list + token
-        response, self.session = self.fetch_utils.fetch_with_retry(
-            self.session, url, cache_bypass=False
-        )
-
-        bytes_downloaded = len(response.content if response else b"")
-        self.metrics_collector.record_network_bytes(bytes_downloaded)
-        data = response.json()
+        with self.http_client.borrow_session() as session:
+            body = self.http_client.fetch_with(session, url)
+        bytes_downloaded = len(body)
+        data = json.loads(body.decode("utf-8"))
 
         results = data.get("results", [])
         total_pages = data.get("page", {}).get("totalPages", 1)

--- a/infrastructure/scrapers/company_data_processors.py
+++ b/infrastructure/scrapers/company_data_processors.py
@@ -8,9 +8,9 @@ from typing import Dict, List, Optional, Type, Union, cast
 
 from application import CompanyDataMapper
 from domain.dto import CompanyDataDetailDTO, CompanyDataListingDTO, CompanyDataRawDTO
-from domain.ports import LoggerPort, MetricsCollectorPort
-from infrastructure.helpers import FetchUtils
+from domain.ports import LoggerPort
 from infrastructure.helpers.data_cleaner import DataCleaner
+from infrastructure.http.affinity_port import AffinityHttpClient
 
 
 class EntryCleaner:
@@ -36,37 +36,27 @@ class EntryCleaner:
 
 
 class DetailFetcher:
-    """Fetch and clean detailed company information."""
+    """Fetch and clean detailed company information using an HTTP client."""
 
     def __init__(
         self,
-        fetch_utils: FetchUtils,
-        session,
+        http_client: AffinityHttpClient,
         endpoint_detail: str,
         language: str,
-        metrics_collector: MetricsCollectorPort,
-        data_cleaner: DataCleaner,
     ) -> None:
-        """Store HTTP utilities and configuration."""
-        self.fetch_utils = fetch_utils
-        self.session = session
+        """Store HTTP client and configuration."""
+        self.http_client = http_client
         self.endpoint_detail = endpoint_detail
         self.language = language
-        self.metrics_collector = metrics_collector
-        self.data_cleaner = data_cleaner
 
-    def fetch_detail(self, cvm_code: str) -> Dict:
-        """Fetch detail JSON and normalize fields."""
+    def fetch_detail(self, session, cvm_code: str) -> Dict:
+        """Fetch detail JSON and return the raw dict."""
         payload = {"codeCVM": cvm_code, "language": self.language}
         token = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
 
         url = self.endpoint_detail + token
-        response, self.session = self.fetch_utils.fetch_with_retry(
-            self.session, url, cache_bypass=False
-        )
-
-        self.metrics_collector.record_network_bytes(len(response.content))
-        raw = response.json()
+        body = self.http_client.fetch_with(session, url)
+        raw = json.loads(body.decode("utf-8"))
 
         return raw
 
@@ -127,7 +117,8 @@ class CompanyDataDetailProcessor:
                 ),
             )
 
-            detail = self.fetcher.fetch_detail(str(listing.cvm_code))
+            with self.fetcher.http_client.borrow_session() as session:
+                detail = self.fetcher.fetch_detail(session, str(listing.cvm_code))
             text_keys = [
                 "issuingCompany",
                 "companyName",

--- a/infrastructure/scrapers/nsd_scraper.py
+++ b/infrastructure/scrapers/nsd_scraper.py
@@ -18,8 +18,9 @@ from domain.ports import (
     NSDSourcePort,
     WorkerPoolPort,
 )
-from infrastructure.helpers import ByteFormatter, FetchUtils, SaveStrategy
+from infrastructure.helpers import ByteFormatter, SaveStrategy
 from infrastructure.helpers.data_cleaner import DataCleaner
+from infrastructure.http.affinity_port import AffinityHttpClient
 
 
 class NsdScraper(NSDSourcePort):
@@ -33,6 +34,7 @@ class NsdScraper(NSDSourcePort):
         worker_pool_executor: WorkerPoolPort,
         metrics_collector: MetricsCollectorPort,
         repository: NSDRepositoryPort,
+        http_client: AffinityHttpClient,
     ):
         """Set up configuration, logger, and helper utilities for the
         scraper."""
@@ -44,10 +46,8 @@ class NsdScraper(NSDSourcePort):
         self._metrics_collector = metrics_collector
         self.repository = repository
 
-        self.fetch_utils = FetchUtils(config, logger)
-        self.session = self.fetch_utils.create_scraper()
-
         self.nsd_endpoint = self.config.exchange.nsd_endpoint
+        self.http_client = http_client
 
         # self.logger.log(f"Load Class {self.__class__.__name__}", level="info")
 
@@ -115,16 +115,9 @@ class NsdScraper(NSDSourcePort):
             url = self.nsd_endpoint.format(nsd=nsd)
 
             try:
-                response, self.session = self.fetch_utils.fetch_with_retry(
-                    self.session, url
-                )
-                self.metrics_collector.record_network_bytes(len(response.content))
-
-                # self.logger.log(
-                #     "Call Method controller.run()._nsd_service().run().sync_nsd_usecase.run().processor()_parse_html()",
-                #     level="info",
-                # )
-                parsed = self._parse_html(nsd, response.text)
+                with self.http_client.borrow_session() as session:
+                    body = self.http_client.fetch_with(session, url)
+                parsed = self._parse_html(nsd, body.decode("utf-8"))
                 # we now persist by company_name, no CVM lookup needed
             # ————————————————————————————————————————————————————————————————
 
@@ -142,10 +135,8 @@ class NsdScraper(NSDSourcePort):
                 return None
 
             if parsed:
-                download_bytes = len(response.content)
-                self.metrics_collector.record_network_bytes(download_bytes)
+                download_bytes = len(body)
                 extra_info = [
-                    # f"{parsed.get('nsd', nsd)}",
                     parsed["sent_date"].strftime("%Y-%m-%d %H:%M:%S")
                     if parsed.get("sent_date") is not None
                     else "",
@@ -341,10 +332,8 @@ class NsdScraper(NSDSourcePort):
         try:
             # Request the NSD page and parse its HTML
             url = self.nsd_endpoint.format(nsd=nsd)
-            response, self.session = self.fetch_utils.fetch_with_retry(
-                self.session, url
-            )
-            parsed = self._parse_html(nsd, response.text)
+            body = self.http_client.fetch(url)
+            parsed = self._parse_html(nsd, body.decode("utf-8"))
 
             # Only return results if the page contains a "sent_date" field
             return parsed if parsed.get("sent_date") else None

--- a/presentation/cli.py
+++ b/presentation/cli.py
@@ -67,7 +67,7 @@ class CLIAdapter:
             burst=self.config.http.burst,
         )
         limited = RateLimitedScraper(base_scraper, bucket, self.logger)
-        self.breaker = CircuitBreakerScraper(
+        self.http_client = CircuitBreakerScraper(
             limited,
             self.logger,
             policy=BreakerPolicy(
@@ -75,7 +75,6 @@ class CLIAdapter:
                 open_seconds=self.config.http.circuit_open_seconds,
             ),
         )
-        # self.http_client = breaker
 
     def start_fly(self) -> None:
         """Trigger all main processing pipelines for the FLY system."""
@@ -94,6 +93,7 @@ class CLIAdapter:
             mapper=mapper,
             worker_pool_executor=self.worker_pool_executor,
             metrics_collector=self.collector,
+            http_client=self.http_client,
         )
         company_service = CompanyDataService(
             config=self.config,
@@ -115,9 +115,10 @@ class CLIAdapter:
             config=self.config,
             logger=self.logger,
             data_cleaner=self.data_cleaner,
-            repository=nsd_repo,
             worker_pool_executor=self.worker_pool_executor,
             metrics_collector=self.collector,
+            repository=nsd_repo,
+            http_client=self.http_client,
         )
         nsd_service = NsdService(
             config=self.config,
@@ -153,7 +154,7 @@ class CLIAdapter:
             logger=self.logger,
             data_cleaner=self.data_cleaner,
             metrics_collector=self.collector,
-            http_client=self.breaker,
+            http_client=self.http_client,
             worker_pool_executor=self.worker_pool_executor,
         )
 


### PR DESCRIPTION
## Summary
- route all scrapers through a single affinity-aware HTTP client with rate limiting and circuit breaking
- switch company and NSD scrapers to session-leased fetches that honor cache and backoff rules
- expose backward-compatible Config alias for infrastructure config package

## Testing
- `ruff format infrastructure/config/__init__.py infrastructure/scrapers/company_data_exchange_scraper.py infrastructure/scrapers/company_data_processors.py infrastructure/scrapers/nsd_scraper.py presentation/cli.py`
- `ruff check infrastructure/config/__init__.py infrastructure/scrapers/company_data_exchange_scraper.py infrastructure/scrapers/company_data_processors.py infrastructure/scrapers/nsd_scraper.py presentation/cli.py --fix`
- `pydocstyle --convention=google .`
- `docformatter --in-place --recursive infrastructure/config/__init__.py infrastructure/scrapers/company_data_exchange_scraper.py infrastructure/scrapers/company_data_processors.py infrastructure/scrapers/nsd_scraper.py presentation/cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d48eee480832ea84f86aa55660221