### PR TITLE
fix: wire uow_factory through company data pipeline

### DIFF
--- a/domain/services/service_company_data.py
+++ b/domain/services/service_company_data.py
@@ -1,8 +1,10 @@
 from typing import Any
-from application.usecases import SyncCompanyDataUseCase
-from domain.dtos.sync_results_dto import SyncResultsDTO
+
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import UowFactoryPort
+from application.usecases import SyncCompanyDataUseCase
+from domain.dtos.sync_results_dto import SyncResultsDTO
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
 
@@ -16,6 +18,7 @@ class CompanyDataService:
         logger: LoggerPort,
         repository: RepositoryCompanyDataPort,
         scraper: ScraperCompanyDataPort,
+        uow_factory: UowFactoryPort,
     ):
         """Initialize the service with required dependencies.
 
@@ -29,19 +32,22 @@ class CompanyDataService:
         self.logger = logger
         self.config = config
 
+        self.uow_factory = uow_factory
+
         # Initialize the use case responsible for company synchronization
         self.sync_companies_usecase = SyncCompanyDataUseCase(
             config=self.config,
             logger=self.logger,
             repository=repository,
             scraper=scraper,
+            uow_factory=self.uow_factory,
             max_workers=self.config.worker_pool.max_workers,
         )
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         try:
             return self.run()
-        except Exception as e:
+        except Exception:
             pass
 
     def run(self) -> SyncResultsDTO:

--- a/infrastructure/factories/cli_factory.py
+++ b/infrastructure/factories/cli_factory.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from application.mappers.company_data_mapper import CompanyDataMapper
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
-
 from domain.polices.nsd_policy import NsdPolicy
 from domain.services.financial_normalizer import FinancialNormalizer
 from domain.services.ratios_calculator import RatiosCalculator
@@ -11,19 +10,21 @@ from domain.services.ratios_calculator import RatiosCalculator
 # from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
 # from domain.ports.repository_statements_raw_port import RepositoryStatementsRawPort
 from infrastructure.factories.datacleaner_factory import datacleaner_factory
+
 # from infrastructure.http.affinity_http_client import RequestsAffinityHttpClient
 from infrastructure.http.builders import build_http_client
 from infrastructure.repositories.repository_company_data import RepositoryCompanyData
 from infrastructure.repositories.repository_nsd import RepositoryNsd
+from infrastructure.repositories.repository_statements_fetched import (
+    StatementFetchedRepository,
+)
 from infrastructure.repositories.repository_statements_raw import StatementRawRepository
-from infrastructure.repositories.repository_statements_fetched import StatementFetchedRepository
 from infrastructure.scrapers.scraper_company_data import CompanyDataScraper
-from infrastructure.scrapers.scraper_statements_raw import ScraperStatementRaw
 from infrastructure.scrapers.scraper_nsd import NsdScraper
+from infrastructure.scrapers.scraper_statements_raw import ScraperStatementRaw
+from infrastructure.uow.uow import UowFactory
 from infrastructure.utils.metrics_collector import MetricsCollector
 from infrastructure.utils.worker_pool import WorkerPool
-from infrastructure.uow.uow import UowFactory
-
 from presentation.controllers.cli import Cli
 
 
@@ -47,7 +48,12 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
     company_repository = RepositoryCompanyData(config=config, logger=logger)
     nsd_repository = RepositoryNsd(config=config, logger=logger)
     raw_statements_repository = StatementRawRepository(config=config, logger=logger)
-    fetched_statements_repository = StatementFetchedRepository(config=config, logger=logger)
+    fetched_statements_repository = StatementFetchedRepository(
+        config=config, logger=logger
+    )
+
+    # Unit of Work
+    uow_factory = UowFactory(session_factory=nsd_repository.Session)
 
     # Compose the data-cleaning pipeline used before mapping/persisting
     datacleaner = datacleaner_factory(config, logger)
@@ -69,14 +75,13 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
         metrics_collector=metrics_collector,
         worker_pool=worker_pool,
         http_client=http_client,
+        uow_factory=uow_factory,
     )
 
     scraper_nsd = NsdScraper(
         config=config,
         logger=logger,
-
         nsd_repository=nsd_repository,
-
         datacleaner=datacleaner,
         metrics_collector=metrics_collector,
         worker_pool=worker_pool,
@@ -86,9 +91,7 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
     scraper_statements_raw = ScraperStatementRaw(
         config=config,
         logger=logger,
-
         # statements_raw_repository=raw_statements_repository,
-
         # datacleaner=datacleaner,
         # metrics_collector=metrics_collector,
         # worker_pool=worker_pool,
@@ -101,33 +104,26 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
         recency_year=config.domain.recency_year,
     )
 
-    # Unit of Work
-    uow_factory = UowFactory(session_factory=nsd_repository.Session)
-
     # Financial Normalizer
     financial_normalizer = FinancialNormalizer()
 
     # Ratios
     ratios_calculator = RatiosCalculator(
-            intel_module_path=(getattr(config.domain, "intel_module_path", None))
-        )
+        intel_module_path=(getattr(config.domain, "intel_module_path", None))
+    )
 
     # Return the CLI controller with its dependencies injected
     cli = Cli(
         config=config,
         logger=logger,
-
         company_repository=company_repository,
         nsd_repository=nsd_repository,
         statements_raw_repository=raw_statements_repository,
         statements_fetched_repository=fetched_statements_repository,
-
         scraper_company_data=scraper_company_data,
         scraper_nsd=scraper_nsd,
         scraper_statements_raw=scraper_statements_raw,
-        
         worker_pool=worker_pool,
-
         policy=policy,
         uow_factory=uow_factory,
         financial_normalizer=financial_normalizer,

--- a/infrastructure/scrapers/scraper_company_data.py
+++ b/infrastructure/scrapers/scraper_company_data.py
@@ -7,18 +7,19 @@ from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 from application.mappers.company_data_mapper import CompanyDataMapper
 from application.mappers.company_data_merger import CompanyDataMerger
+from application.ports.config_port import ConfigPort
+from application.ports.http_client_port import AffinityHttpClientPort
+from application.ports.logger_port import LoggerPort
+from application.ports.metrics_collector_port import MetricsCollectorPort
+from application.ports.uow_port import UowFactoryPort
+from application.ports.worker_pool_port import WorkerPoolPort
 from application.processors.company_detail_processor import CompanyDataDetailProcessor
 from application.processors.entry_cleaner import EntryCleaner
 from domain.dtos.company_data_dto import CompanyDataDTO
 from domain.dtos.fetch_results_dto import FetchResultDTO
 from domain.dtos.worker_task_dto import WorkerTaskDTO
-from application.ports.config_port import ConfigPort
-from application.ports.logger_port import LoggerPort
 from domain.ports.datacleaner_port import DataCleanerPort
-from application.ports.http_client_port import AffinityHttpClientPort
-from application.ports.metrics_collector_port import MetricsCollectorPort
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
-from application.ports.worker_pool_port import WorkerPoolPort
 from infrastructure.scrapers.scraper_company_detail import DetailFetcher
 
 # from infrastructure.scrapers.company_data_processors import (
@@ -69,6 +70,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         metrics_collector: MetricsCollectorPort,
         worker_pool: WorkerPoolPort,
         http_client: AffinityHttpClientPort,
+        uow_factory: UowFactoryPort,
     ):
         # Fixed pagination defaults used by the remote API
         self.PAGE_NUMBER = 1
@@ -81,6 +83,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         self.mapper = mapper
         self.worker_pool_executor = worker_pool
         self._metrics_collector = metrics_collector
+        self.uow_factory = uow_factory
 
         # Shared HTTP client for connection reuse, rate limiting and caching
         self.http_client = http_client
@@ -145,7 +148,9 @@ class CompanyDataScraper(ScraperCompanyDataPort):
             return None
 
         # 1) Fetch the initial list of companies (optionally flushing to storage)
-        companies_entries: List[Dict[str, Any]] = self._fetch_companies_list(save_callback=noop)
+        companies_entries: List[Dict[str, Any]] = self._fetch_companies_list(
+            save_callback=noop
+        )
         # with open("temp/companies_entries.json", "w", encoding="utf-8") as f:
         #     json.dump(companies_entries, f, ensure_ascii=False, indent=2)
         # with open("temp/companies_entries.json", "r", encoding="utf-8") as f:
@@ -182,7 +187,10 @@ class CompanyDataScraper(ScraperCompanyDataPort):
 
         # Build a save strategy to flush items while iterating pages
         strategy: SaveStrategy[Dict] = SaveStrategy.from_config(
-            save_callback, self.threshold, config=self.config
+            save_callback,
+            self.threshold,
+            config=self.config,
+            uow_factory=self.uow_factory,
         )
 
         # Accumulate all page results for the final merged list
@@ -203,7 +211,9 @@ class CompanyDataScraper(ScraperCompanyDataPort):
 
         # Extra diagnostic info for logging and progress observers
         extra_info = {
-            "Download": self.byte_formatter.format_bytes(self._metrics_collector.download_bytes),
+            "Download": self.byte_formatter.format_bytes(
+                self._metrics_collector.download_bytes
+            ),
             "Total download": self.byte_formatter.format_bytes(
                 self._metrics_collector.network_bytes
             ),
@@ -233,7 +243,9 @@ class CompanyDataScraper(ScraperCompanyDataPort):
 
                 # Prepare diagnostics for this worker's page
                 extra_info = {
-                    "Download": self.byte_formatter.format_bytes(self._metrics_collector.download_bytes),
+                    "Download": self.byte_formatter.format_bytes(
+                        self._metrics_collector.download_bytes
+                    ),
                     "Total download": self.byte_formatter.format_bytes(
                         self._metrics_collector.network_bytes
                     ),
@@ -249,7 +261,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
                         "start_time": start_time,  # noqa: F821
                     },
                     extra=extra_info,
-                    worker_id=worker_id,
+                    worker_id=task.worker_id,
                 )
 
                 # Return the page payload to be merged by the caller
@@ -302,8 +314,11 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         """
         # Build a save strategy that buffers detail DTOs and flushes on threshold
         strategy: SaveStrategy[CompanyDataDTO] = SaveStrategy.from_config(
-            save_callback, self.threshold, config=self.config
-            )
+            save_callback,
+            self.threshold,
+            config=self.config,
+            uow_factory=self.uow_factory,
+        )
 
         # Pair each entry with its index for progress reporting
         tasks = list(enumerate(companies_list))
@@ -341,15 +356,21 @@ class CompanyDataScraper(ScraperCompanyDataPort):
                 return None
 
             # Process one entry through fetch + clean + merge
-            result = self.detail_processor.process_entry(entry, metrics_collector=self._metrics_collector)
+            result = self.detail_processor.process_entry(
+                entry, metrics_collector=self._metrics_collector
+            )
 
             # Prepare diagnostic metadata for logs
-            issuingCompany = result.issuing_company if result else entry.get("issuingCompany")
+            issuingCompany = (
+                result.issuing_company if result else entry.get("issuingCompany")
+            )
             tradingName = result.trading_name if result else entry.get("tradingName")
             extra_info = {
                 "issuingCompany": issuingCompany,
                 "trading_name": tradingName,
-                "Download": self.byte_formatter.format_bytes(self._metrics_collector.download_bytes),
+                "Download": self.byte_formatter.format_bytes(
+                    self._metrics_collector.download_bytes
+                ),
                 "Total download": self.byte_formatter.format_bytes(
                     self._metrics_collector.network_bytes
                 ),

--- a/presentation/controllers/cli.py
+++ b/presentation/controllers/cli.py
@@ -1,23 +1,25 @@
-from domain.dtos.sync_results_dto import SyncResultsDTO
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
-
+from application.ports.uow_port import UowFactoryPort
+from application.ports.worker_pool_port import WorkerPoolPort
+from domain.dtos.sync_results_dto import SyncResultsDTO
+from domain.polices.nsd_policy import NsdPolicyPort
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_nsd_port import RepositoryNsdPort
+from domain.ports.repository_statements_fetched_port import (
+    RepositoryStatementFetchedPort,
+)
 from domain.ports.repository_statements_raw_port import RepositoryStatementsRawPort
-from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
 from domain.ports.scraper_nsd_port import ScraperNsdPort
 from domain.ports.scraper_statements_raw_port import ScraperStatementRawPort
-# from domain.ports.scraper_statements_fetched_port import ScraperStatementFetchedPort
-from infrastructure.utils.byte_formatter import ByteFormatter
-from domain.services.service_company_data import CompanyDataService
-from domain.services.service_nsd import NsdService
-from application.ports.worker_pool_port import WorkerPoolPort
-from application.ports.uow_port import UowFactoryPort
-from domain.polices.nsd_policy import NsdPolicyPort
 from domain.services.financial_normalizer import FinancialNormalizerPort
 from domain.services.ratios_calculator import RatiosCalculatorPort
+from domain.services.service_company_data import CompanyDataService
+from domain.services.service_nsd import NsdService
+
+# from domain.ports.scraper_statements_fetched_port import ScraperStatementFetchedPort
+from infrastructure.utils.byte_formatter import ByteFormatter
 
 
 class Cli:
@@ -37,18 +39,14 @@ class Cli:
         self,
         config: ConfigPort,
         logger: LoggerPort,
-
         company_repository: RepositoryCompanyDataPort,
         nsd_repository: RepositoryNsdPort,
         statements_raw_repository: RepositoryStatementsRawPort,
-        statements_fetched_repository: RepositoryStatementFetchedPort, 
-
+        statements_fetched_repository: RepositoryStatementFetchedPort,
         scraper_company_data: ScraperCompanyDataPort,
-        scraper_nsd: ScraperNsdPort,      
+        scraper_nsd: ScraperNsdPort,
         scraper_statements_raw: ScraperStatementRawPort,
-
         worker_pool: WorkerPoolPort,
-
         policy: NsdPolicyPort,
         uow_factory: UowFactoryPort,
         financial_normalizer: FinancialNormalizerPort,
@@ -80,7 +78,7 @@ class Cli:
     def __call__(self) -> None:
         try:
             return self.run()
-        except Exception as e:
+        except Exception:
             pass
 
     def run(self) -> None:
@@ -90,9 +88,11 @@ class Cli:
 
         # Kick off the company data pipeline
         company_results: SyncResultsDTO = self._company_service()
-        self.logger.log(f"Total Download: {self.byte_formatter.format_bytes(company_results.metrics)}")
+        self.logger.log(
+            f"Total Download: {self.byte_formatter.format_bytes(company_results.metrics)}"
+        )
 
-        statements_results: SyncResultsDTO = self._statements_service()
+        self._statements_service()
 
         return None
 
@@ -108,37 +108,33 @@ class Cli:
             logger=self.logger,
             repository=company_repository,
             scraper=scraper_company_data,
+            uow_factory=self.uow_factory,
         )
 
         # Run the synchronization step
         return company_service()
 
     def _statements_service(self) -> SyncResultsDTO:
-        """
-        """
+        """ """
 
         nsd_service = NsdService(
             config=self.config,
             logger=self.logger,
-
             company_repository=self.company_repository,
             nsd_repository=self.nsd_repository,
             statements_raw_repository=self.statements_raw_repository,
-            statements_fetched_repository=self.statements_fetched_repository,   
-
+            statements_fetched_repository=self.statements_fetched_repository,
             scraper_company_data=self.scraper_company_data,
             scraper_nsd=self.scraper_nsd,
             scraper_statements_raw=self.scraper_statements_raw,
-
             worker_pool=self.worker_pool,
-
-            policy=self.policy,                  # porta para política composta
-            financial_normalizer=self.financial_normalizer, # serviço de domínio puro
-            ratios_calculator=self.ratios_calculator,   # serviço de domínio puro
-            uow_factory=self.uow_factory,        # fábrica de UoW (SQLAlchemy + SQLite)
-            )
+            policy=self.policy,  # porta para política composta
+            financial_normalizer=self.financial_normalizer,  # serviço de domínio puro
+            ratios_calculator=self.ratios_calculator,  # serviço de domínio puro
+            uow_factory=self.uow_factory,  # fábrica de UoW (SQLAlchemy + SQLite)
+        )
 
         # Run the synchronization step
-        service = nsd_service()
-    
+        nsd_service()
+
         # return statements_service.sync_statements()


### PR DESCRIPTION
## Summary
- pass Unit of Work factory through CLI, service, and scraper so SaveStrategy can persist company data
- initialize UoW in CLI factory before constructing scrapers
- tidy CLI service calls and logging

## Testing
- `ruff check domain/services/service_company_data.py infrastructure/factories/cli_factory.py infrastructure/scrapers/scraper_company_data.py presentation/controllers/cli.py`
- `black domain/services/service_company_data.py infrastructure/factories/cli_factory.py infrastructure/scrapers/scraper_company_data.py presentation/controllers/cli.py`
- `isort domain/services/service_company_data.py infrastructure/factories/cli_factory.py infrastructure/scrapers/scraper_company_data.py presentation/controllers/cli.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'domain.dto.statement_fetched_dto')*


------
https://chatgpt.com/codex/tasks/task_e_68c04687f8f4832e9394218357ea7a97