### PR TITLE
Add cotahist market adapter and richer symbol resolution

### DIFF
--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -14,6 +14,7 @@ from domain.dtos.statement_raw_dto import StatementRawDTO
 from domain.dtos.statement_fetched_dto import StatementFetchedDTO
 from domain.dtos.nsd_dto import NsdDTO
 from domain.dtos.worker_task_dto import WorkerTaskDTO
+from domain.dtos.market_symbol_dto import MarketSymbolsDTO
 from domain.polices.nsd_policy import NsdPolicyPort
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_nsd_port import RepositoryNsdPort
@@ -32,7 +33,14 @@ from infrastructure.utils.id_generator import IdGenerator
 
 class _NsdTxnAggregator:
     """Mantém NSD, RAW e FETCHED juntos para flush atômico."""
-    def __init__(self, *, nsd_repository, statements_raw_repository, statements_fetched_repository):
+
+    def __init__(
+        self,
+        *,
+        nsd_repository,
+        statements_raw_repository,
+        statements_fetched_repository,
+    ):
         self.nsd_repository = nsd_repository
         self.statements_raw_repository = statements_raw_repository
         self.statements_fetched_repository = statements_fetched_repository
@@ -70,15 +78,12 @@ class NsdProcessor:
         *,
         config: ConfigPort,
         logger: LoggerPort,
-
         nsd_repository: RepositoryNsdPort,
         company_repository: RepositoryCompanyDataPort,
         statements_raw_repository: RepositoryStatementsRawPort,
         statements_fetched_repository: RepositoryStatementFetchedPort,
-
         scraper_nsd: ScraperNsdPort,
         scraper_statements_raw: ScraperStatementRawPort,
-
         policy: NsdPolicyPort,
         market_data_port: MarketDataPort,
         financial_normalizer: FinancialNormalizerPort,
@@ -110,7 +115,7 @@ class NsdProcessor:
 
     def run(self, task: WorkerTaskDTO) -> NsdDTO:
         data = task.data
-        # data = 82408  
+        # data = 82408
         # nsd = NsdDTO(id=None, nsd=10012, company_name='IND MAQS AGRICOLAS FUCHS SA', quarter=datetime.datetime(2011, 3, 31, 0, 0), version=2, nsd_type='INFORMACOES TRIMESTRAIS', dri='JALMAR JOSE MARTEL', auditor='MULTICON AUDITORIA E ASSESSORIA CONTABIL SS', responsible_auditor='MARCO ANTONIO PALERMO', protocol='007064ITR310320110200010012-79', sent_date=datetime.datetime(2011, 7, 7, 11, 7, 36), reason='AS INFORMACOES NO RELATORIO DA REVISAO ESPECIAL NAO SE REFEREM AO TRIMESTRE EM QUESTAO E SIM SOBRE O MESMO PERIODO POREM DO EXERCICIO ANTERIOR E QUE AGORA ESTAMOS TRANSCREVENDO O CONTEUDO CORRETO')
 
         start_time = time.perf_counter()
@@ -122,7 +127,7 @@ class NsdProcessor:
         }
 
         if nsd is None:
-            extra_info = [ f""]
+            extra_info = [f""]
             self.logger.log(
                 f"NSD {data}",
                 level="info",
@@ -141,8 +146,14 @@ class NsdProcessor:
                 statements_fetched_repository=self.statements_fetched_repository,
             )
 
-            nsd_quarter = nsd.quarter.strftime("%Y-%m-%d") if isinstance(nsd.quarter, datetime) else (nsd.quarter or "")
-            extra_info = [ f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"]
+            nsd_quarter = (
+                nsd.quarter.strftime("%Y-%m-%d")
+                if isinstance(nsd.quarter, datetime)
+                else (nsd.quarter or "")
+            )
+            extra_info = [
+                f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"
+            ]
             self.logger.log(
                 f"NSD {nsd.nsd}",
                 level="info",
@@ -164,12 +175,15 @@ class NsdProcessor:
             when = sd or date(quarter_police.year, quarter_police.month, 1)
             recency = self.policy.compute_recency_window(when)
             action = self.policy.decide_action(
-                year=quarter_police.year, quarter=quarter_police.month, version=nsd.version,
-                is_december=quarter_police.is_december, is_recent=recency.is_recent,
+                year=quarter_police.year,
+                quarter=quarter_police.month,
+                version=nsd.version,
+                is_december=quarter_police.is_december,
+                is_recent=recency.is_recent,
             )
 
             # raw_lines = list(self.scraper_statements_raw.fetch(nsd))
-            raw_result  = self.scraper_statements_raw.fetch(
+            raw_result = self.scraper_statements_raw.fetch(
                 WorkerTaskDTO(
                     index=task.index,
                     data=nsd,
@@ -179,8 +193,14 @@ class NsdProcessor:
             )
             raw_lines = list(raw_result["items"])
 
-            nsd_quarter = nsd.quarter.strftime("%Y-%m-%d") if isinstance(nsd.quarter, datetime) else (nsd.quarter or "")
-            extra_info = [ f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"]
+            nsd_quarter = (
+                nsd.quarter.strftime("%Y-%m-%d")
+                if isinstance(nsd.quarter, datetime)
+                else (nsd.quarter or "")
+            )
+            extra_info = [
+                f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"
+            ]
             self.logger.log(
                 f"RAW {nsd.nsd}",
                 level="info",
@@ -220,7 +240,6 @@ class NsdProcessor:
             #             value=float(row["value"]),
             #         )
             #     )
-            
 
             if action.is_raw():
                 agg.add_raw_many(raw_lines)
@@ -268,9 +287,11 @@ class NsdProcessor:
                             continue
                     by_company[(s.nsd, company)].add(q_end)
 
-                symbol_cache: Dict[tuple[str, str], Optional[str]] = {}
+                symbol_cache: Dict[tuple[str, str], Optional[MarketSymbolsDTO]] = {}
 
-                def resolve_symbol(nsd_code: str, company: str) -> Optional[str]:
+                def resolve_symbol(
+                    nsd_code: str, company: str
+                ) -> Optional[MarketSymbolsDTO]:
                     key = (nsd_code, company)
                     if key not in symbol_cache:
                         symbol_cache[key] = self.company_repository.get_market_symbol(
@@ -281,14 +302,16 @@ class NsdProcessor:
                     return symbol_cache[key]
 
                 for (nsd_code, company), quarter_ends in by_company.items():
-                    symbol = resolve_symbol(nsd_code, company)
-                    if not symbol:
+                    symbols = resolve_symbol(nsd_code, company)
+                    if not symbols or not symbols.primary:
                         continue
-                    market_service.ensure_series_for_quarters(symbol, quarter_ends)
+                    market_service.ensure_series_for_quarters(
+                        symbols.primary, quarter_ends
+                    )
 
                 def price_lookup(nsd_code: str, company: str, quarter_end: date):
-                    symbol = resolve_symbol(nsd_code, company)
-                    if not symbol:
+                    symbols = resolve_symbol(nsd_code, company)
+                    if not symbols or not symbols.primary:
                         return None
                     when = quarter_end
                     if isinstance(when, datetime):
@@ -298,19 +321,26 @@ class NsdProcessor:
                             when = date.fromisoformat(str(when).split(" ")[0])
                         except Exception:
                             return None
-                    return market_service.price_at_quarter_end(symbol, when)
+                    return market_service.price_at_quarter_end(symbols.primary, when)
 
                 ratios = self.ratios_calculator.calculate(
                     cast(Sequence[StatementFetchedDTO], standardized),
                     price_lookup=price_lookup,
                 )
 
-
-                ratios = self.ratios_calculator.calculate(cast(Sequence[StatementFetchedDTO], standardized))
+                ratios = self.ratios_calculator.calculate(
+                    cast(Sequence[StatementFetchedDTO], standardized)
+                )
                 fetched = list(standardized) + list(ratios)
 
-                nsd_quarter = nsd.quarter.strftime("%Y-%m-%d") if isinstance(nsd.quarter, datetime) else (nsd.quarter or "")
-                extra_info = [ f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"]
+                nsd_quarter = (
+                    nsd.quarter.strftime("%Y-%m-%d")
+                    if isinstance(nsd.quarter, datetime)
+                    else (nsd.quarter or "")
+                )
+                extra_info = [
+                    f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"
+                ]
                 self.logger.log(
                     f"FTD {nsd.nsd}",
                     level="info",
@@ -328,7 +358,9 @@ class NsdProcessor:
             except Exception as e:
                 self.logger.log(f"{e}")
 
-    def _ensure_company_exists(self, company_name: Optional[str], *, uow: Uow) -> Optional[str]:
+    def _ensure_company_exists(
+        self, company_name: Optional[str], *, uow: Uow
+    ) -> Optional[str]:
         if not company_name:
             return None
         cvm = self.company_repository.get_cvm_by_name(company_name, uow=uow)

--- a/domain/dtos/__init__.py
+++ b/domain/dtos/__init__.py
@@ -11,6 +11,17 @@ from .statement_fetched_dto import StatementFetchedDTO
 from .statement_raw_dto import StatementRawDTO
 from .worker_task_dto import WorkerTaskDTO
 from .market_quote_dto import MarketQuoteDTO
+from .market_symbol_dto import MarketSymbolsDTO
 
-__all__ = ["CodeDTO", "CompanyDataDetailDTO", "CompanyDataDTO", "CompanyDataListingDTO",
-           "NsdDTO", "StatementRawDTO", "StatementFetchedDTO", "WorkerTaskDTO", "MarketQuoteDTO"]
+__all__ = [
+    "CodeDTO",
+    "CompanyDataDetailDTO",
+    "CompanyDataDTO",
+    "CompanyDataListingDTO",
+    "NsdDTO",
+    "StatementRawDTO",
+    "StatementFetchedDTO",
+    "WorkerTaskDTO",
+    "MarketQuoteDTO",
+    "MarketSymbolsDTO",
+]

--- a/domain/dtos/market_symbol_dto.py
+++ b/domain/dtos/market_symbol_dto.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class MarketSymbolsDTO:
+    """Represents the resolved trading symbols for a company.
+
+    Attributes:
+        primary: Preferred ticker code to be used when a single symbol is
+            required (e.g., for price lookups). The string is returned in the
+            canonical B3 format without exchange suffixes.
+        tickers: Ordered tuple with all recognized ticker codes for the
+            company, already normalized to uppercase without separators.
+        b3_root: Issuer root code used by B3 endpoints such as COTAHIST. This
+            value usually matches the CVM "issuing_company" field and is the
+            symbol required to request monthly quotation tables.
+    """
+
+    primary: str | None
+    tickers: Tuple[str, ...]
+    b3_root: str | None
+
+    def has_symbol(self) -> bool:
+        """Return ``True`` when a primary trading symbol is available."""
+
+        return bool(self.primary)

--- a/domain/ports/repository_company_data_port.py
+++ b/domain/ports/repository_company_data_port.py
@@ -4,6 +4,7 @@ from typing import Optional, Protocol, runtime_checkable
 
 from application.ports.uow_port import Uow
 from domain.dtos.company_data_dto import CompanyDataDTO
+from domain.dtos.market_symbol_dto import MarketSymbolsDTO
 from domain.ports.repository_base_port import RepositoryBasePort
 
 
@@ -21,7 +22,7 @@ class RepositoryCompanyDataPort(RepositoryBasePort[CompanyDataDTO, int], Protoco
     """
 
     def get_cvm_by_name(self, company_name: str, *, uow: Uow) -> str | None:
-            """Retrieve the CVM code for a company by its name.
+        """Retrieve the CVM code for a company by its name.
 
         Args:
             company_name (str): The official company name.
@@ -32,11 +33,10 @@ class RepositoryCompanyDataPort(RepositoryBasePort[CompanyDataDTO, int], Protoco
 
     def get_market_symbol(
         self, nsd: str | int, company_name: str, *, uow: Uow
-    ) -> Optional[str]:
-        """Resolve the canonical trading symbol for the given company."""
+    ) -> Optional[MarketSymbolsDTO]:
+        """Resolve the canonical trading symbol(s) for the given company."""
 
     # # utilitário para “garantir companhia” em lote
     # def iter_existing_by_names(self, names: set[str], *, uow: Uow) -> Iterator[str]: ...
 
     # # já herdado de RepositoryBasePort: save_all(..., uow)
-

--- a/infrastructure/adapters/b3_cotahist_adapter.py
+++ b/infrastructure/adapters/b3_cotahist_adapter.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Dict, Iterable, List, Sequence
+
+import requests
+from bs4 import BeautifulSoup
+
+from application.ports.market_data_port import MarketDataPort
+from domain.dtos.market_quote_dto import MarketQuoteDTO
+
+
+class B3CotahistAdapter(MarketDataPort):
+    """Adapter that fetches historical quotes from the B3 COTAHIST website."""
+
+    def __init__(
+        self,
+        *,
+        provider: str = "b3-cotahist",
+        currency: str = "BRL",
+        timeout: int = 15,
+        session: requests.Session | None = None,
+    ) -> None:
+        self.provider = provider
+        self.currency = currency
+        self.timeout = timeout
+        self.session = session or requests.Session()
+
+    def fetch_window(
+        self, symbol: str, start: date, end: date
+    ) -> Sequence[MarketQuoteDTO]:
+        canonical = (symbol or "").strip().upper()
+        if not canonical or start > end:
+            return []
+
+        issuer_root = self._issuer_root(canonical)
+        months = list(self._iter_months(start, end))
+        quotes_by_day: Dict[date, MarketQuoteDTO] = {}
+
+        for year, month in months:
+            month_quotes = self._fetch_month(issuer_root, year, month)
+            if not month_quotes:
+                continue
+
+            daily_quotes = month_quotes.get(canonical)
+            if daily_quotes is None and canonical.endswith("F"):
+                daily_quotes = month_quotes.get(canonical[:-1])
+            if daily_quotes is None and canonical not in month_quotes:
+                alt = canonical.rstrip("F")
+                daily_quotes = month_quotes.get(alt)
+            if not daily_quotes:
+                continue
+
+            for quote in daily_quotes:
+                if start <= quote.day <= end:
+                    quotes_by_day[quote.day] = quote
+
+        return [quotes_by_day[d] for d in sorted(quotes_by_day)]
+
+    @staticmethod
+    def _issuer_root(symbol: str) -> str:
+        for idx, char in enumerate(symbol):
+            if char.isdigit():
+                return symbol[:idx] or symbol
+        return symbol
+
+    @staticmethod
+    def _iter_months(start: date, end: date) -> Iterable[tuple[int, int]]:
+        current = date(start.year, start.month, 1)
+        limit = date(end.year, end.month, 1)
+        while current <= limit:
+            yield current.year, current.month
+            if current.month == 12:
+                current = date(current.year + 1, 1, 1)
+            else:
+                current = date(current.year, current.month + 1, 1)
+
+    def _fetch_month(
+        self, root: str, year: int, month: int
+    ) -> Dict[str, List[MarketQuoteDTO]]:
+        if not root:
+            return {}
+        url = (
+            "https://bvmf.bmfbovespa.com.br/sig/FormConsultaMercVista.asp?"
+            f"strTipoResumo=RES_MERC_VISTA&strSocEmissora={root}&strDtReferencia={month:02d}-{year}"
+            "&strIdioma=P&intCodNivel=2&intCodCtrl=160"
+        )
+        try:
+            response = self.session.get(
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                },
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException:
+            return {}
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        container = soup.find("table", id="tblResDiario")
+        if not container:
+            return {}
+
+        quotes: Dict[str, List[MarketQuoteDTO]] = {}
+        for table in container.find_all("table"):
+            if "Nome da Ação" not in table.get_text():
+                continue
+            ticker = self._extract_symbol(table)
+            if not ticker:
+                continue
+            rows = self._parse_rows(table, ticker, year, month)
+            if rows:
+                quotes[ticker] = rows
+        return quotes
+
+    @staticmethod
+    def _extract_symbol(table) -> str | None:
+        header = table.find("tr")
+        if not header:
+            return None
+        text = header.get_text(" ", strip=True)
+        match = re.search(r"\(([^)]+)\)", text)
+        return match.group(1).upper() if match else None
+
+    def _parse_rows(
+        self, table, ticker: str, year: int, month: int
+    ) -> List[MarketQuoteDTO]:
+        rows: List[MarketQuoteDTO] = []
+        for row in table.find_all("tr"):
+            cells = [col.get_text(strip=True) for col in row.find_all("td")]
+            if len(cells) < 12:
+                continue
+            day_digits = "".join(ch for ch in cells[0] if ch.isdigit())
+            if not day_digits:
+                continue
+            try:
+                day = int(day_digits)
+                when = date(year, month, day)
+            except ValueError:
+                continue
+
+            close = self._parse_decimal(cells[-1])
+            if close is None:
+                continue
+            rows.append(
+                MarketQuoteDTO(
+                    provider=self.provider,
+                    symbol=ticker,
+                    day=when,
+                    close=close,
+                    adjusted_close=close,
+                    currency=self.currency,
+                )
+            )
+        rows.sort(key=lambda q: q.day)
+        return rows
+
+    @staticmethod
+    def _parse_decimal(raw: str) -> float | None:
+        if not raw:
+            return None
+        cleaned = re.sub(r"[^0-9,.-]", "", raw)
+        cleaned = cleaned.replace(".", "").replace(",", ".").strip()
+        if cleaned in {"", "-", "--"}:
+            return None
+        try:
+            return float(cleaned)
+        except ValueError:
+            return None

--- a/infrastructure/adapters/composite_market_data_adapter.py
+++ b/infrastructure/adapters/composite_market_data_adapter.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import List, Sequence, Tuple
+
+from application.ports.market_data_port import MarketDataPort
+from domain.dtos.market_quote_dto import MarketQuoteDTO
+
+
+class CompositeMarketDataAdapter(MarketDataPort):
+    """Combine multiple market data providers, preferring earlier ones."""
+
+    def __init__(self, providers: Sequence[MarketDataPort]) -> None:
+        self.providers = tuple(providers)
+
+    def fetch_window(
+        self, symbol: str, start: date, end: date
+    ) -> Sequence[MarketQuoteDTO]:
+        seen: set[Tuple[date, str]] = set()
+        collected: List[MarketQuoteDTO] = []
+        for provider in self.providers:
+            for quote in provider.fetch_window(symbol, start, end):
+                if quote.day < start or quote.day > end:
+                    continue
+                key = (quote.day, quote.symbol)
+                if key in seen:
+                    continue
+                seen.add(key)
+                collected.append(quote)
+        collected.sort(key=lambda q: q.day)
+        return collected

--- a/infrastructure/factories/cli_factory.py
+++ b/infrastructure/factories/cli_factory.py
@@ -14,6 +14,10 @@ from infrastructure.adapters.symbol_mapping import b3_to_yahoo
 from infrastructure.adapters.yahoo_market_data_adapter import (
     YahooMarketDataAdapter,
 )
+from infrastructure.adapters.b3_cotahist_adapter import B3CotahistAdapter
+from infrastructure.adapters.composite_market_data_adapter import (
+    CompositeMarketDataAdapter,
+)
 
 # from infrastructure.http.affinity_http_client import RequestsAffinityHttpClient
 from infrastructure.http.builders import build_http_client
@@ -116,7 +120,12 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
         intel_module_path=(getattr(config.domain, "intel_module_path", None))
     )
 
-    market_data_adapter = YahooMarketDataAdapter(symbol_mapper=b3_to_yahoo)
+    market_data_adapter = CompositeMarketDataAdapter(
+        [
+            B3CotahistAdapter(),
+            YahooMarketDataAdapter(symbol_mapper=b3_to_yahoo),
+        ]
+    )
 
     # Return the CLI controller with its dependencies injected
     cli = Cli(

--- a/infrastructure/repositories/repository_company_data.py
+++ b/infrastructure/repositories/repository_company_data.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+import json
+import re
+from typing import List, Optional, Sequence, Tuple
 
 from sqlalchemy.dialects.sqlite import insert
 
@@ -8,6 +10,7 @@ from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import Uow
 from domain.dtos.company_data_dto import CompanyDataDTO
+from domain.dtos.market_symbol_dto import MarketSymbolsDTO
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from infrastructure.models.company_data_model import CompanyDataModel
 from infrastructure.repositories.repository_base import RepositoryBase
@@ -16,8 +19,8 @@ from infrastructure.repositories.repository_base import RepositoryBase
 
 
 class RepositoryCompanyData(
-    RepositoryBase[CompanyDataDTO, int],
-    RepositoryCompanyDataPort):
+    RepositoryBase[CompanyDataDTO, int], RepositoryCompanyDataPort
+):
     """SQLite/SQLAlchemy repository for company data.
 
     Implements the `RepositoryCompanyDataPort` using a local SQLite database
@@ -35,9 +38,7 @@ class RepositoryCompanyData(
 
     """
 
-    def __init__(
-        self, config: ConfigPort, logger: LoggerPort
-    ) -> None:
+    def __init__(self, config: ConfigPort, logger: LoggerPort) -> None:
         """Initialize the repository with configuration and logger.
 
         Args:
@@ -86,7 +87,7 @@ class RepositoryCompanyData(
         model, pk_columns = self.get_model_class()
 
         # Normalize potentially nested inputs into a flat list
-        flat_items = items # ListFlattener.flatten(items)
+        flat_items = items  # ListFlattener.flatten(items)
 
         # Filter out `None` values to avoid mapping errors
         valid_items = [i for i in flat_items if i is not None]
@@ -147,9 +148,92 @@ class RepositoryCompanyData(
 
         return row[0] if row else None
 
+    @staticmethod
+    def _normalize_symbol(value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        cleaned = str(value).upper().strip()
+        if not cleaned:
+            return None
+        cleaned = re.sub(r"[^A-Z0-9]", "", cleaned)
+        if cleaned.endswith("F") and any(ch.isdigit() for ch in cleaned[:-1]):
+            cleaned = cleaned[:-1]
+        return cleaned or None
+
+    @classmethod
+    def _split_codes(cls, raw: Optional[str]) -> List[str]:
+        if raw is None:
+            return []
+        raw = str(raw).strip()
+        if raw == "":
+            return []
+
+        items: List[str] = []
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            tokens = re.split(r"[,;/\s]+", raw)
+            items.extend(token for token in tokens if token)
+        else:
+            if isinstance(parsed, list):
+                items.extend(str(item) for item in parsed if item)
+            elif isinstance(parsed, str):
+                items.append(parsed)
+            elif parsed is not None:
+                items.append(str(parsed))
+
+        normalized: List[str] = []
+        seen = set()
+        for item in items:
+            symbol = cls._normalize_symbol(item)
+            if not symbol or symbol in seen:
+                continue
+            seen.add(symbol)
+            normalized.append(symbol)
+        return normalized
+
+    @staticmethod
+    def _score_symbol(symbol: str, index: int) -> tuple[int, int, int, str]:
+        digits = "".join(ch for ch in symbol if ch.isdigit())
+        suffix_two = digits[-2:] if len(digits) >= 2 else ""
+        suffix_one = digits[-1] if digits else ""
+
+        rank = 5
+        if suffix_one == "3":
+            rank = 0
+        elif suffix_one == "4":
+            rank = 1
+        elif suffix_two == "11":
+            rank = 2
+        elif suffix_one == "5":
+            rank = 3
+        elif suffix_one == "6":
+            rank = 4
+
+        penalty = 1 if suffix_one and symbol.endswith("F") else 0
+        return rank, penalty, index, symbol
+
+    @classmethod
+    def _ordered_candidates(cls, candidates: Sequence[str]) -> List[str]:
+        scored = [
+            cls._score_symbol(symbol, idx) for idx, symbol in enumerate(candidates)
+        ]
+        scored.sort()
+        return [item[-1] for item in scored]
+
+    @classmethod
+    def _extract_root(cls, value: Optional[str]) -> Optional[str]:
+        normalized = cls._normalize_symbol(value)
+        if not normalized:
+            return None
+        for idx, char in enumerate(normalized):
+            if char.isdigit():
+                return normalized[:idx] or None
+        return normalized
+
     def get_market_symbol(
         self, nsd: str | int, company_name: str, *, uow: Uow
-    ) -> Optional[str]:
+    ) -> Optional[MarketSymbolsDTO]:
         session = uow.session
         _ = nsd  # mantido para compatibilidade futura com códigos distintos
         row = (
@@ -166,22 +250,27 @@ class RepositoryCompanyData(
 
         code, tickers, issuing = row
 
-        def first_symbol(raw: Optional[str]) -> Optional[str]:
-            if not raw:
-                return None
-            for part in str(raw).split(","):
-                candidate = part.strip()
-                if candidate:
-                    return candidate.upper()
-            return None
+        primary_candidates = self._split_codes(tickers)
 
-        ticker_candidate = first_symbol(tickers)
-        if ticker_candidate:
-            return ticker_candidate
+        fallback_codes: List[str] = []
+        fallback_codes.extend(self._split_codes(code))
+        fallback_codes.extend(self._split_codes(issuing))
+        for candidate in fallback_codes:
+            if candidate not in primary_candidates:
+                primary_candidates.append(candidate)
 
-        for candidate in (code, issuing):
-            symbol = first_symbol(candidate)
-            if symbol:
-                return symbol
+        ordered = (
+            self._ordered_candidates(primary_candidates) if primary_candidates else []
+        )
+        primary = ordered[0] if ordered else None
 
-        return None
+        root_candidates = list(self._split_codes(issuing)) + list(
+            self._split_codes(code)
+        )
+        root = None
+        for candidate in ordered + root_candidates:
+            root = self._extract_root(candidate)
+            if root:
+                break
+
+        return MarketSymbolsDTO(primary=primary, tickers=tuple(ordered), b3_root=root)


### PR DESCRIPTION
## Summary
- add a `MarketSymbolsDTO` and enhance the company data repository to prioritize ticker variants and expose the B3 issuer root
- update the NSD processor to cache resolved symbols per company and request quarter windows through the market data service
- introduce a B3 COTAHIST adapter plus a composite market data adapter and wire them into the CLI factory for statement processing

## Testing
- pytest *(fails: legacy tests expect `domain.dtos` package available for legacy modules)*
- ruff check . *(fails: repository already has unsorted imports and other lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc7637014832eb95ec17796099e64