### PR TITLE
Implement statement hash duplicate guard

### DIFF
--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -238,7 +238,7 @@ class NsdProcessor:
                 quarterized = self.financial_normalizer.quarterize(deduped)
                 standardized = self.financial_normalizer.standardize(quarterized)
                 ratios = self.ratios_calculator.calculate(cast(Sequence[StatementFetchedDTO], standardized))
-                fetched = list(standardized) + list(ratios)
+                fetched_rows = list(standardized) + list(ratios)
 
                 nsd_quarter = nsd.quarter.strftime("%Y-%m-%d") if isinstance(nsd.quarter, datetime) else (nsd.quarter or "")
                 extra_info = [ f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"]
@@ -250,7 +250,7 @@ class NsdProcessor:
                 )
 
                 agg.add_raw_many(raw_lines)
-                agg.add_fetched_many(list(fetched))
+                agg.add_fetched_many(self._filter_new_fetched(fetched_rows, uow=uow))
                 agg.set_nsd(nsd)
                 agg.flush(uow=uow)
                 uow.commit()
@@ -258,6 +258,44 @@ class NsdProcessor:
                 return nsd
             except Exception as e:
                 self.logger.log(f"{e}")
+
+    def _filter_new_fetched(
+        self,
+        rows: Sequence[StatementFetchedDTO],
+        *,
+        uow: Uow,
+    ) -> list[StatementFetchedDTO]:
+        """Remove fetched statements already persisted for the same company/hash."""
+
+        if not rows:
+            return []
+
+        deduped: list[StatementFetchedDTO] = []
+        seen_hashes: set[tuple[Optional[str], str]] = set()
+
+        for row in rows:
+            hash_ = getattr(row, "processing_hash", "") or ""
+
+            if not hash_:
+                deduped.append(row)
+                continue
+
+            key = (row.company_name, hash_)
+            if key in seen_hashes:
+                continue
+
+            seen_hashes.add(key)
+
+            if self.statements_fetched_repository.exists_with_hash(
+                company_name=row.company_name,
+                hash_=hash_,
+                uow=uow,
+            ):
+                continue
+
+            deduped.append(row)
+
+        return deduped
 
     def _ensure_company_exists(self, company_name: Optional[str], *, uow: Uow) -> Optional[str]:
         if not company_name:

--- a/domain/ports/repository_statements_fetched_port.py
+++ b/domain/ports/repository_statements_fetched_port.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import Optional, Protocol, runtime_checkable
 
+from application.ports.uow_port import Uow
 from domain.dtos.statement_fetched_dto import StatementFetchedDTO
 
 from .repository_base_port import RepositoryBasePort
@@ -15,18 +16,15 @@ class RepositoryStatementFetchedPort(RepositoryBasePort[StatementFetchedDTO, int
     financial statements associated with companies.
     """
 
-    # def exists_with_hash(self, company_name: str, hash_: str) -> bool:
-    #     """Check if a fetched statement already exists for a company and hash.
-
-    #     Args:
-    #         company_name (str): Name of the company to check.
-    #         hash_ (str): Unique hash identifying the fetched statement.
-
-    #     Returns:
-    #         bool: True if a fetched statement with the given hash already exists
-    #         for the company, False otherwise.
-    #     """
-    #     ...
+    def exists_with_hash(
+        self,
+        *,
+        company_name: Optional[str],
+        hash_: str,
+        uow: Uow,
+    ) -> bool:
+        """Return True when ``company_name`` has ``hash_`` persisted."""
+        ...
 
     # def replace_all_for_company(
     #     self,

--- a/infrastructure/repositories/repository_statements_fetched.py
+++ b/infrastructure/repositories/repository_statements_fetched.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from sqlalchemy.dialects.sqlite import insert
 
@@ -78,3 +78,26 @@ class StatementFetchedRepository(
                 .all()
             )
             return [r.to_dto() for r in results]
+
+    def exists_with_hash(
+        self,
+        *,
+        company_name: Optional[str],
+        hash_: str,
+        uow: Uow,
+    ) -> bool:
+        """Return True when ``company_name`` has ``hash_`` persisted."""
+
+        if not hash_:
+            return False
+
+        session = uow.session
+        model, _ = self.get_model_class()
+
+        query = session.query(model.id).filter(model.processing_hash == hash_)
+        if company_name is None:
+            query = query.filter(model.company_name.is_(None))
+        else:
+            query = query.filter(model.company_name == company_name)
+
+        return query.first() is not None


### PR DESCRIPTION
## Summary
- add a repository port hook to verify when a statement hash is already stored
- implement the duplicate lookup in the SQLAlchemy fetched statements repository
- filter fetched statements in the NSD processor so already-known hashes are skipped

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'domain.dto.statement_fetched_dto')*

------
https://chatgpt.com/codex/tasks/task_e_68ceef8b2cf0832eb69c1814e86d9514