### PR TITLE
Remove statement hash usage across domain and infrastructure

### DIFF
--- a/application/processors/financial_report_processor.py
+++ b/application/processors/financial_report_processor.py
@@ -17,8 +17,7 @@ class FinancialReportProcessor:
       2) Busca e persiste sempre os RAW (trilha de auditoria).
       3) Avalia política de parsing.
       4) Transforma RAW -> FETCHED.
-      5) Garante idempotência por hash de conteúdo.
-      6) Upsert dos FETCHED e atualização de estado do NSD.
+      5) Upsert dos FETCHED e atualização de estado do NSD.
 
     A implementação concreta depende das portas injetadas.
     """
@@ -60,7 +59,7 @@ class FinancialReportProcessor:
         #
         # fetched = self.transformer.transform(raw_dto)
         #
-        # if self.fetched_repo.is_duplicate(fetched.processing_hash):
+        # if self.fetched_repo.is_duplicate(fetched):
         #     self.logger.log("Duplicate fetched content. Skipping persist.", level="info")
         #     return
         #

--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -265,37 +265,32 @@ class NsdProcessor:
         *,
         uow: Uow,
     ) -> list[StatementFetchedDTO]:
-        """Remove fetched statements already persisted for the same company/hash."""
+        """Remove duplicates within the current batch using natural keys."""
+
+        _ = uow  # retained for signature compatibility
 
         if not rows:
             return []
 
-        deduped: list[StatementFetchedDTO] = []
-        seen_hashes: set[tuple[Optional[str], str]] = set()
+        unique_rows: list[StatementFetchedDTO] = []
+        seen_keys: set[tuple] = set()
 
         for row in rows:
-            hash_ = getattr(row, "processing_hash", "") or ""
-
-            if not hash_:
-                deduped.append(row)
+            key = (
+                row.nsd,
+                row.company_name,
+                row.quarter,
+                row.version,
+                row.grupo,
+                row.quadro,
+                row.account,
+            )
+            if key in seen_keys:
                 continue
+            seen_keys.add(key)
+            unique_rows.append(row)
 
-            key = (row.company_name, hash_)
-            if key in seen_hashes:
-                continue
-
-            seen_hashes.add(key)
-
-            if self.statements_fetched_repository.exists_with_hash(
-                company_name=row.company_name,
-                hash_=hash_,
-                uow=uow,
-            ):
-                continue
-
-            deduped.append(row)
-
-        return deduped
+        return unique_rows
 
     def _ensure_company_exists(self, company_name: Optional[str], *, uow: Uow) -> Optional[str]:
         if not company_name:
@@ -310,16 +305,3 @@ class NsdProcessor:
         self.company_repository.save_all([dto], uow=uow)
         return dto.cvm_code
 
-    def _hash_run(self, *parts) -> str:
-        import hashlib
-        import json
-
-        def to_prim(obj):
-            if isinstance(obj, (list, tuple)):
-                return [to_prim(x) for x in obj]
-            if hasattr(obj, "__dict__"):
-                return {k: to_prim(v) for k, v in obj.__dict__.items()}
-            return obj
-
-        blob = json.dumps([to_prim(p) for p in parts], sort_keys=True, default=str)
-        return hashlib.sha256(blob.encode("utf-8")).hexdigest()

--- a/application/usecases/statements_transformer.py
+++ b/application/usecases/statements_transformer.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-
 from domain.dtos.statement_fetched_dto import StatementFetchedDTO
 from domain.dtos.statement_raw_dto import StatementRawDTO
 from domain.ports.datacleaner_port import DataCleanerPort
@@ -11,8 +9,7 @@ class StatementTransformer:
     """Transforms raw financial statements into fetched statements.
 
     This class uses a data cleaner to sanitize raw statements
-    and generates a fetched DTO that includes a content hash
-    for uniqueness and traceability.
+    and generates a fetched DTO ready for persistence.
 
     Attributes:
         cleaner (DataCleanerPort): Component responsible for cleaning
@@ -26,15 +23,11 @@ class StatementTransformer:
     def transform(self, raw: StatementRawDTO) -> StatementFetchedDTO:
         """Convert a raw statement into a fetched statement.
 
-        Applies data cleaning and computes a unique hash based on
-        the normalized content.
-
         Args:
             raw (StatementRawDTO): Raw financial statement input.
 
         Returns:
-            StatementFetchedDTO: Structured and cleaned statement
-            enriched with a deterministic hash.
+            StatementFetchedDTO: Structured and cleaned statement.
         """
         # normaliza textos
         company = self.cleaner.clean_text(raw.company_name or "") if hasattr(self.cleaner, "clean_text") else (raw.company_name or "")
@@ -58,24 +51,6 @@ class StatementTransformer:
             account=account or "",
             description=description or "",
             value=float(raw.value),
-            processing_hash="",  # preenche após calcular
         )
 
-        # hash determinístico com campos canônicos
-        payload = "|".join([
-            fetched.nsd,
-            fetched.company_name or "",
-            fetched.quarter.strftime("%Y-%m-%d") if fetched.quarter else "",
-            fetched.version or "",
-            fetched.grupo,
-            fetched.quadro,
-            fetched.account,
-            fetched.description,
-            f"{fetched.value:.6f}",
-        ]).encode("utf-8")
-        digest = hashlib.sha256(payload).hexdigest()
-
-        # reconstroi DTO imutável com o hash
-        return StatementFetchedDTO(
-            **{**fetched.__dict__, "processing_hash": digest}
-        )
+        return fetched

--- a/domain/dtos/statement_fetched_dto.py
+++ b/domain/dtos/statement_fetched_dto.py
@@ -20,7 +20,6 @@ class StatementFetchedDTO:
         account (str): Account identifier.
         description (str): Human-readable description of the account.
         value (float): Numeric value of the account entry.
-        processing_hash (str): Optional hash used for deduplication and integrity checks.
     """
 
     id: Optional[int] = None
@@ -33,7 +32,6 @@ class StatementFetchedDTO:
     account: str
     description: str
     value: float
-    processing_hash: str = ""
 
     @staticmethod
     def from_dict(raw: dict[str, Any], *, cleandate: Callable[[object], datetime]) -> "StatementFetchedDTO":
@@ -72,5 +70,4 @@ class StatementFetchedDTO:
             account=str(raw.get("account", "")),
             description=str(raw.get("description", "")),
             value=float(raw.get("value", 0.0)),
-            processing_hash=str(raw.get("processing_hash", "")),
         )

--- a/domain/dtos/statement_raw_dto.py
+++ b/domain/dtos/statement_raw_dto.py
@@ -100,5 +100,4 @@ class StatementRawDTO:
             account=account,
             description=description,
             value=self.value,
-            processing_hash="",
         )

--- a/domain/ports/repository_statements_fetched_port.py
+++ b/domain/ports/repository_statements_fetched_port.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Protocol, runtime_checkable
-
-from application.ports.uow_port import Uow
+from typing import Protocol, runtime_checkable
 from domain.dtos.statement_fetched_dto import StatementFetchedDTO
 
 from .repository_base_port import RepositoryBasePort
@@ -16,31 +14,3 @@ class RepositoryStatementFetchedPort(RepositoryBasePort[StatementFetchedDTO, int
     financial statements associated with companies.
     """
 
-    def exists_with_hash(
-        self,
-        *,
-        company_name: Optional[str],
-        hash_: str,
-        uow: Uow,
-    ) -> bool:
-        """Return True when ``company_name`` has ``hash_`` persisted."""
-        ...
-
-    # def replace_all_for_company(
-    #     self,
-    #     company_name: str,
-    #     fetched_dtos: List[StatementFetchedDTO],
-    #     new_hash: str,
-    # ) -> None:
-    #     """Replace all fetched statements for a company with a new set.
-
-    #     Args:
-    #         company_name (str): Name of the company whose statements are updated.
-    #         fetched_dtos (List[StatementFetchedDTO]): New list of fetched statements
-    #             to persist in place of the old ones.
-    #         new_hash (str): Hash associated with the new fetched statements.
-
-    #     Returns:
-    #         None
-    #     """
-    #     ...

--- a/domain/services/financial_normalizer.py
+++ b/domain/services/financial_normalizer.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from dataclasses import is_dataclass, replace
 from datetime import datetime
-import hashlib
-import json
 # from decimal import Decimal
 from typing import Any, Callable, Dict, Iterable, List, Tuple, Optional, Sequence
 
@@ -107,18 +105,6 @@ class FinancialNormalizer(FinancialNormalizerPort):
         # quarter como texto YYYY-MM (mês do quarter)
         account, sep, description = (column or "").partition(" - ")
 
-        payload = {
-            "nsd": raw.nsd,
-            "company": raw.company_name,
-            "quarter": raw.quarter.date().isoformat() if isinstance(raw.quarter, datetime) else str(raw.quarter).split(" ")[0],
-            "version": raw.version,
-            "quadro": raw.quadro,
-            "grupo": raw.grupo,
-            "valor": raw.value,
-        }
-
-        processing_hash = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
-
         return StatementFetchedDTO(
             id=None,
             nsd=raw.nsd,
@@ -132,7 +118,6 @@ class FinancialNormalizer(FinancialNormalizerPort):
             account=account,
             description=description,
             value=raw.value,
-            processing_hash=processing_hash,
         )
 
     # def _diff_quarters(self, qmap: Dict[int, StatementRawDTO]) -> Iterable[StatementRawDTO]:
@@ -428,5 +413,4 @@ class FinancialNormalizer(FinancialNormalizerPort):
     #         account=str(getattr(raw, "account", getattr(raw, "account_code", ""))),
     #         description=str(getattr(raw, "description", "")),
     #         value=float(value),
-    #         processing_hash="",
     #     )

--- a/domain/services/ratios_calculator.py
+++ b/domain/services/ratios_calculator.py
@@ -162,7 +162,6 @@ class RatiosCalculator(RatiosCalculatorPort):
                             account=account,
                             description=description,
                             value=v,
-                            processing_hash="",
                         )
                     )
 

--- a/infrastructure/models/statements_fetched_model.py
+++ b/infrastructure/models/statements_fetched_model.py
@@ -39,9 +39,7 @@ class StatementFetchedModel(BaseStatementModel):
         Index("ix_statements_fetched_company_name_quarter", "company_name", "quarter"),
     )
 
-    processing_hash: Mapped[str | None] = mapped_column(String, index=True)
-
-    _FIELDS = BaseStatementModel._FIELDS + ("processing_hash",)
+    _FIELDS = BaseStatementModel._FIELDS
 
     @staticmethod
     def from_dto(dto: StatementFetchedDTO) -> "StatementFetchedModel":

--- a/infrastructure/repositories/repository_statements_fetched.py
+++ b/infrastructure/repositories/repository_statements_fetched.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from sqlalchemy.dialects.sqlite import insert
 
@@ -43,7 +43,7 @@ class StatementFetchedRepository(
     def save_all(self, items: List[StatementFetchedDTO], *, uow: Uow) -> None:
         """Persist fetched statements using SQLite upserts."""
         session = uow.session
-        model, pk_columns = self.get_model_class()
+        model, _ = self.get_model_class()
         flat_items = ListFlattener.flatten(items)
         valid_items = [i for i in flat_items if i is not None]
         for dto in valid_items:
@@ -79,25 +79,3 @@ class StatementFetchedRepository(
             )
             return [r.to_dto() for r in results]
 
-    def exists_with_hash(
-        self,
-        *,
-        company_name: Optional[str],
-        hash_: str,
-        uow: Uow,
-    ) -> bool:
-        """Return True when ``company_name`` has ``hash_`` persisted."""
-
-        if not hash_:
-            return False
-
-        session = uow.session
-        model, _ = self.get_model_class()
-
-        query = session.query(model.id).filter(model.processing_hash == hash_)
-        if company_name is None:
-            query = query.filter(model.company_name.is_(None))
-        else:
-            query = query.filter(model.company_name == company_name)
-
-        return query.first() is not None


### PR DESCRIPTION
## Summary
- remove statement hash handling from DTOs, transformers, and normalizer logic
- drop hash-based deduplication in the NSD processor in favor of natural keys
- simplify the fetched statements repository and model now that processing hashes are unused

## Testing
- pytest *(fails: ModuleNotFoundError importing legacy domain dto package)*

------
https://chatgpt.com/codex/tasks/task_e_68cef33089c4832ea468773a1b01fa42