### PR TITLE
Refactor NSD processor for readability

### DIFF
--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import time
 from datetime import date, datetime
-from typing import List, Optional, Sequence, cast
+from typing import Any, Iterable, Mapping, Optional, Sequence, cast
 
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import Uow, UowFactoryPort
 from domain.dtos.company_data_dto import CompanyDataDTO
-from domain.dtos.statement_raw_dto import StatementRawDTO
-from domain.dtos.statement_fetched_dto import StatementFetchedDTO
 from domain.dtos.nsd_dto import NsdDTO
+from domain.dtos.statement_fetched_dto import StatementFetchedDTO
+from domain.dtos.statement_raw_dto import StatementRawDTO
 from domain.dtos.worker_task_dto import WorkerTaskDTO
 from domain.polices.nsd_policy import NsdPolicyPort
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
@@ -28,21 +28,28 @@ from infrastructure.utils.id_generator import IdGenerator
 
 class _NsdTxnAggregator:
     """Mantém NSD, RAW e FETCHED juntos para flush atômico."""
-    def __init__(self, *, nsd_repository, statements_raw_repository, statements_fetched_repository):
+
+    def __init__(
+        self,
+        *,
+        nsd_repository: RepositoryNsdPort,
+        statements_raw_repository: RepositoryStatementsRawPort,
+        statements_fetched_repository: RepositoryStatementFetchedPort,
+    ) -> None:
         self.nsd_repository = nsd_repository
         self.statements_raw_repository = statements_raw_repository
         self.statements_fetched_repository = statements_fetched_repository
-        self._nsd_data: Optional[NsdDTO] = None
-        self._raw_data = []
-        self._fetched_data = []
+        self._nsd_data: NsdDTO | None = None
+        self._raw_data: list[StatementRawDTO] = []
+        self._fetched_data: list[StatementFetchedDTO] = []
 
     def set_nsd(self, nsd: NsdDTO) -> None:
         self._nsd_data = nsd
 
-    def add_raw_many(self, items) -> None:
+    def add_raw_many(self, items: Iterable[StatementRawDTO]) -> None:
         self._raw_data.extend(items)
 
-    def add_fetched_many(self, items) -> None:
+    def add_fetched_many(self, items: Iterable[StatementFetchedDTO]) -> None:
         self._fetched_data.extend(items)
 
     def flush(self, *, uow: Uow) -> None:
@@ -66,15 +73,12 @@ class NsdProcessor:
         *,
         config: ConfigPort,
         logger: LoggerPort,
-
         nsd_repository: RepositoryNsdPort,
         company_repository: RepositoryCompanyDataPort,
         statements_raw_repository: RepositoryStatementsRawPort,
         statements_fetched_repository: RepositoryStatementFetchedPort,
-
         scraper_nsd: ScraperNsdPort,
         scraper_statements_raw: ScraperStatementRawPort,
-
         policy: NsdPolicyPort,
         financial_normalizer: FinancialNormalizerPort,
         ratios_calculator: RatiosCalculatorPort,
@@ -99,29 +103,21 @@ class NsdProcessor:
         self.id_generator = IdGenerator(config=config)
 
     # compat com pools que chamam .run(task) ou chamam o objeto
-    def __call__(self, task: WorkerTaskDTO) -> NsdDTO:
+    def __call__(self, task: WorkerTaskDTO) -> Any:
         return self.run(task)
 
-    def run(self, task: WorkerTaskDTO) -> NsdDTO:
-        data = task.data
-        # data = 82408  
-        # nsd = NsdDTO(id=None, nsd=10012, company_name='IND MAQS AGRICOLAS FUCHS SA', quarter=datetime.datetime(2011, 3, 31, 0, 0), version=2, nsd_type='INFORMACOES TRIMESTRAIS', dri='JALMAR JOSE MARTEL', auditor='MULTICON AUDITORIA E ASSESSORIA CONTABIL SS', responsible_auditor='MARCO ANTONIO PALERMO', protocol='007064ITR310320110200010012-79', sent_date=datetime.datetime(2011, 7, 7, 11, 7, 36), reason='AS INFORMACOES NO RELATORIO DA REVISAO ESPECIAL NAO SE REFEREM AO TRIMESTRE EM QUESTAO E SIM SOBRE O MESMO PERIODO POREM DO EXERCICIO ANTERIOR E QUE AGORA ESTAMOS TRANSCREVENDO O CONTEUDO CORRETO')
-
+    def run(self, task: WorkerTaskDTO) -> Any:
+        nsd_id = task.data
         start_time = time.perf_counter()
-        nsd = self.scraper_nsd.fetch_one(int(data))
-        progress = {
-            "index": task.index,
-            "size": task.total_size,
-            "start_time": start_time,
-        }
+        nsd = self.scraper_nsd.fetch_one(int(nsd_id))
+        progress = self._build_progress_payload(task=task, start_time=start_time)
 
         if nsd is None:
-            extra_info = [ f""]
-            self.logger.log(
-                f"NSD {data}",
-                level="info",
-                progress={**progress, "extra_info": extra_info},
+            self._log_message(
+                f"NSD {nsd_id}",
+                progress=progress,
                 worker_id=task.worker_id,
+                extra_info=[""],
             )
             return task.data
 
@@ -129,135 +125,158 @@ class NsdProcessor:
             self._ensure_company_exists(nsd.company_name, uow=uow)
             nsd_type = self.policy.identify_type(nsd)
 
-            agg = _NsdTxnAggregator(
-                nsd_repository=self.nsd_repository,
-                statements_raw_repository=self.statements_raw_repository,
-                statements_fetched_repository=self.statements_fetched_repository,
-            )
-
-            nsd_quarter = nsd.quarter.strftime("%Y-%m-%d") if isinstance(nsd.quarter, datetime) else (nsd.quarter or "")
-            extra_info = [ f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"]
-            self.logger.log(
-                f"NSD {nsd.nsd}",
-                level="info",
-                progress={**progress, "extra_info": extra_info},
-                worker_id=task.worker_id,
-            )
+            aggregator = self._create_aggregator()
+            self._log_stage("NSD", nsd, progress=progress, worker_id=task.worker_id)
 
             if not nsd_type.is_statement:
-                agg.set_nsd(nsd)
-                agg.flush(uow=uow)
-                uow.commit()
-
+                self._finalize_nsd(nsd=nsd, aggregator=aggregator, uow=uow)
                 return nsd
 
-            quarter_police = self.policy.normalize_quarter(nsd)
-            sd = getattr(nsd, "sent_date")
-            if hasattr(sd, "date"):
-                sd = sd.date()
-            when = sd or date(quarter_police.year, quarter_police.month, 1)
-            recency = self.policy.compute_recency_window(when)
-            action = self.policy.decide_action(
-                year=quarter_police.year, quarter=quarter_police.month, version=nsd.version,
-                is_december=quarter_police.is_december, is_recent=recency.is_recent,
+            return self._process_statement_nsd(
+                nsd=nsd,
+                task=task,
+                progress=progress,
+                aggregator=aggregator,
+                uow=uow,
             )
 
-            # raw_lines = list(self.scraper_statements_raw.fetch(nsd))
-            raw_result  = self.scraper_statements_raw.fetch(
-                WorkerTaskDTO(
-                    index=task.index,
-                    data=nsd,
-                    worker_id=task.worker_id,
-                    total_size=task.total_size,
+    def _process_statement_nsd(
+        self,
+        *,
+        nsd: NsdDTO,
+        task: WorkerTaskDTO,
+        progress: dict[str, Any],
+        aggregator: _NsdTxnAggregator,
+        uow: Uow,
+    ) -> Any:
+        quarter_police = self.policy.normalize_quarter(nsd)
+        sent_date = getattr(nsd, "sent_date")
+        if hasattr(sent_date, "date"):
+            sent_date = sent_date.date()
+        when = sent_date or date(quarter_police.year, quarter_police.month, 1)
+        recency = self.policy.compute_recency_window(when)
+        action = self.policy.decide_action(
+            year=quarter_police.year,
+            quarter=quarter_police.month,
+            version=nsd.version,
+            is_december=quarter_police.is_december,
+            is_recent=recency.is_recent,
+        )
+
+        raw_lines = self._fetch_raw_lines(nsd=nsd, task=task)
+        self._log_stage("RAW", nsd, progress=progress, worker_id=task.worker_id)
+
+        if action.is_raw():
+            aggregator.add_raw_many(raw_lines)
+            self._finalize_nsd(nsd=nsd, aggregator=aggregator, uow=uow)
+            return nsd
+
+        try:
+            year_view = list(
+                self.statements_raw_repository.get_company_year_view(
+                    company_name=nsd.company_name,
+                    year=quarter_police.year,
+                    uow=uow,
                 )
             )
-            raw_lines = list(raw_result["items"])
-
-            nsd_quarter = nsd.quarter.strftime("%Y-%m-%d") if isinstance(nsd.quarter, datetime) else (nsd.quarter or "")
-            extra_info = [ f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"]
-            self.logger.log(
-                f"RAW {nsd.nsd}",
-                level="info",
-                progress={**progress, "extra_info": extra_info},
-                worker_id=task.worker_id,
+            combined: list[StatementRawDTO] = [*year_view, *raw_lines]
+            deduped = self.policy.version_deduplicate(combined)
+            quarterized = self.financial_normalizer.quarterize(deduped)
+            standardized_rows = list(self.financial_normalizer.standardize(quarterized))
+            ratios = list(
+                self.ratios_calculator.calculate(
+                    cast(Sequence[StatementFetchedDTO], standardized_rows)
+                )
             )
+            fetched_rows: list[StatementFetchedDTO] = [*standardized_rows, *ratios]
 
-            # from dataclasses import asdict
-            # import pandas as pd
-            # from pathlib import Path
+            self._log_stage("FTD", nsd, progress=progress, worker_id=task.worker_id)
 
-            # # salvar
-            # path = Path("raw_lines.csv")
-            # pd.DataFrame([asdict(x) for x in raw_lines]).to_csv(path, index=False, encoding="utf-8")
+            aggregator.add_raw_many(raw_lines)
+            aggregator.add_fetched_many(self._filter_new_fetched(fetched_rows, uow=uow))
+            self._finalize_nsd(nsd=nsd, aggregator=aggregator, uow=uow)
 
-            # # ler
-            # from pathlib import Path
-            # import pandas as pd
-            # path = Path("raw_lines.csv")
-            # df = pd.read_csv(path, encoding="utf-8")
-            # from dataclasses import fields
-            # from domain.dtos.statement_raw_dto import StatementRawDTO  # ajuste o import
+            return nsd
+        except Exception as exc:
+            self.logger.log(str(exc))
+            return None
 
-            # cols = [f.name for f in fields(StatementRawDTO)]
-            # raw_lines = []
-            # for _, row in df[cols].iterrows():
-            #     raw_lines.append(
-            #         StatementRawDTO(
-            #             nsd=str(row["nsd"]),
-            #             company_name=str(row["company_name"]),
-            #             quarter=row["quarter"],
-            #             version=row["version"],
-            #             grupo=str(row["grupo"]),
-            #             quadro=str(row["quadro"]),
-            #             account=str(row["account"]),
-            #             description=str(row["description"]),
-            #             value=float(row["value"]),
-            #         )
-            #     )
-            
+    def _fetch_raw_lines(self, *, nsd: NsdDTO, task: WorkerTaskDTO) -> list[StatementRawDTO]:
+        raw_task = WorkerTaskDTO(
+            index=task.index,
+            data=nsd,
+            worker_id=task.worker_id,
+            total_size=task.total_size,
+        )
+        raw_result: Mapping[str, Sequence[StatementRawDTO]] = self.scraper_statements_raw.fetch(
+            raw_task
+        )
+        return list(raw_result["items"])
 
-            if action.is_raw():
-                agg.add_raw_many(raw_lines)
-                agg.set_nsd(nsd)
-                agg.flush(uow=uow)
-                uow.commit()
-                return nsd
-            try:
-                # PROCESS
-                # company_id = self.company_repository.get_cvm_by_name(nsd.company_name, uow=uow)
-                year_view = list(
-                    self.statements_raw_repository.get_company_year_view(
-                        company_name=nsd.company_name,
-                        year=quarter_police.year,
-                        uow=uow,
-                    )
-                )
+    def _finalize_nsd(
+        self,
+        *,
+        nsd: NsdDTO,
+        aggregator: _NsdTxnAggregator,
+        uow: Uow,
+    ) -> None:
+        aggregator.set_nsd(nsd)
+        aggregator.flush(uow=uow)
+        uow.commit()
 
-                combined: List[StatementRawDTO] = list(year_view) + list(raw_lines)
-                deduped = self.policy.version_deduplicate(combined)
-                quarterized = self.financial_normalizer.quarterize(deduped)
-                standardized = self.financial_normalizer.standardize(quarterized)
-                ratios = self.ratios_calculator.calculate(cast(Sequence[StatementFetchedDTO], standardized))
-                fetched_rows = list(standardized) + list(ratios)
+    def _create_aggregator(self) -> _NsdTxnAggregator:
+        return _NsdTxnAggregator(
+            nsd_repository=self.nsd_repository,
+            statements_raw_repository=self.statements_raw_repository,
+            statements_fetched_repository=self.statements_fetched_repository,
+        )
 
-                nsd_quarter = nsd.quarter.strftime("%Y-%m-%d") if isinstance(nsd.quarter, datetime) else (nsd.quarter or "")
-                extra_info = [ f"{nsd.nsd} {nsd_quarter} | {nsd.sent_date} v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"]
-                self.logger.log(
-                    f"FTD {nsd.nsd}",
-                    level="info",
-                    progress={**progress, "extra_info": extra_info},
-                    worker_id=task.worker_id,
-                )
+    def _build_progress_payload(self, *, task: WorkerTaskDTO, start_time: float) -> dict[str, Any]:
+        return {
+            "index": task.index,
+            "size": task.total_size,
+            "start_time": start_time,
+        }
 
-                agg.add_raw_many(raw_lines)
-                agg.add_fetched_many(self._filter_new_fetched(fetched_rows, uow=uow))
-                agg.set_nsd(nsd)
-                agg.flush(uow=uow)
-                uow.commit()
+    def _log_stage(
+        self,
+        stage: str,
+        nsd: NsdDTO,
+        *,
+        progress: dict[str, Any],
+        worker_id: str,
+    ) -> None:
+        self._log_message(
+            f"{stage} {nsd.nsd}",
+            progress=progress,
+            worker_id=worker_id,
+            extra_info=[self._format_extra_info_line(nsd)],
+        )
 
-                return nsd
-            except Exception as e:
-                self.logger.log(f"{e}")
+    def _log_message(
+        self,
+        message: str,
+        *,
+        progress: dict[str, Any],
+        worker_id: str,
+        extra_info: Sequence[str] | None = None,
+    ) -> None:
+        payload = dict(progress)
+        if extra_info is not None:
+            payload["extra_info"] = list(extra_info)
+        self.logger.log(message, level="info", progress=payload, worker_id=worker_id)
+
+    def _format_extra_info_line(self, nsd: NsdDTO) -> str:
+        quarter = (
+            nsd.quarter.strftime("%Y-%m-%d")
+            if isinstance(nsd.quarter, datetime)
+            else nsd.quarter
+        )
+        quarter_display = quarter or ""
+        return (
+            f"{nsd.nsd} {quarter_display} | {nsd.sent_date} "
+            f"v{nsd.version} | {nsd.nsd_type} {nsd.company_name}"
+        )
 
     def _filter_new_fetched(
         self,
@@ -273,7 +292,7 @@ class NsdProcessor:
             return []
 
         unique_rows: list[StatementFetchedDTO] = []
-        seen_keys: set[tuple] = set()
+        seen_keys: set[tuple[Any, ...]] = set()
 
         for row in rows:
             key = (
@@ -292,16 +311,19 @@ class NsdProcessor:
 
         return unique_rows
 
-    def _ensure_company_exists(self, company_name: Optional[str], *, uow: Uow) -> Optional[str]:
+    def _ensure_company_exists(
+        self, company_name: Optional[str], *, uow: Uow
+    ) -> Optional[str]:
         if not company_name:
             return None
+
         cvm = self.company_repository.get_cvm_by_name(company_name, uow=uow)
         if cvm:
             return cvm
+
         dto = CompanyDataDTO(
             cvm_code=self.id_generator.create_id(size=6),
             company_name=company_name,
         )
         self.company_repository.save_all([dto], uow=uow)
         return dto.cvm_code
-


### PR DESCRIPTION
## Summary
- restructure the NSD processor to break down the run flow into smaller helpers and improve logging helpers
- add type hints and aggregator helpers to clarify responsibilities while preserving behavior

## Testing
- python -m compileall FLY/application/processors/nsd_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68cef504a718832e8b7f3c1c78010157