### PR TITLE
Ensure company data scraper propagates unit of work

### DIFF
--- a/application/usecases/sync_company_data.py
+++ b/application/usecases/sync_company_data.py
@@ -44,10 +44,7 @@ class SyncCompanyDataUseCase:
         self.max_workers = max_workers or (self.config.worker_pool.max_workers or 1)
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
-        try:
-            return self.run()
-        except Exception as e:
-            pass
+        return self.run()
 
     def run(self) -> SyncResultsDTO:
         """Run the full company synchronization pipeline.

--- a/infrastructure/scrapers/scraper_company_data.py
+++ b/infrastructure/scrapers/scraper_company_data.py
@@ -139,7 +139,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
             List[CompanyDataDTO]: Fully fetched company detail DTOs.
         """
         # Normalize list of codes to a set for O(1) membership checks
-        self.existing_codes = existing_codes or set()
+        self.existing_codes = set(existing_codes or [])
 
         # Determine persistence threshold (explicit > config > default)
         self.threshold = threshold or self.config.repository.persistence_threshold or 50
@@ -185,7 +185,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         # adapta callback do porto (items) para a estratégia (items, *, uow)
         def _adapter(items: List[Dict], *, uow=None) -> None:
             if save_callback is not None:
-                save_callback(items)
+                save_callback(items, uow=uow)
 
 
         # Build a save strategy to flush items while iterating pages
@@ -319,7 +319,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         # adapter para a estratégia
         def _adapter(items: List[CompanyDataDTO], *, uow=None) -> None:
             if save_callback is not None:
-                save_callback(items)
+                save_callback(items, uow=uow)
 
         # Build a save strategy that buffers detail DTOs and flushes on threshold
         strategy: SaveStrategy[CompanyDataDTO] = SaveStrategy.from_config(


### PR DESCRIPTION
## Summary
- convert existing code list to a set before filtering fetched companies
- forward the active unit of work to save callbacks when flushing company batches
- simplify the sync use case call method so exceptions surface to callers

## Testing
- pytest *(fails: legacy test suite depends on missing legacy domain modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cf097cd8c4832e993511f096590c20