### PR TITLE
Ensure company data scraper propagates unit of work

### DIFF
--- a/application/usecases/sync_company_data.py
+++ b/application/usecases/sync_company_data.py
@@ -44,10 +44,7 @@ class SyncCompanyDataUseCase:
         self.max_workers = max_workers or (self.config.worker_pool.max_workers or 1)
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
-        try:
-            return self.run()
-        except Exception as e:
-            pass
+        return self.run()
 
     def run(self) -> SyncResultsDTO:
         """Run the full company synchronization pipeline.

--- a/infrastructure/scrapers/scraper_company_data.py
+++ b/infrastructure/scrapers/scraper_company_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import json
 import time
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Dict, List, Optional, TypeVar
 
 from application.mappers.company_data_mapper import CompanyDataMapper
 from application.mappers.company_data_merger import CompanyDataMerger
@@ -11,7 +11,7 @@ from application.ports.config_port import ConfigPort
 from application.ports.http_client_port import AffinityHttpClientPort
 from application.ports.logger_port import LoggerPort
 from application.ports.metrics_collector_port import MetricsCollectorPort
-from application.ports.uow_port import UowFactoryPort
+from application.ports.uow_port import Uow, UowFactoryPort
 from application.ports.worker_pool_port import WorkerPoolPort
 from application.processors.company_detail_processor import CompanyDataDetailProcessor
 from application.processors.entry_cleaner import EntryCleaner
@@ -22,7 +22,7 @@ from domain.ports.datacleaner_port import DataCleanerPort
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
 from infrastructure.scrapers.scraper_company_detail import DetailFetcher
 # from domain.ports.scraper_base_port import SaveCallback
-from infrastructure.utils.save_strategy import SaveStrategy
+from infrastructure.utils.save_strategy import SaveCallback, SaveStrategy
 from infrastructure.utils.byte_formatter import ByteFormatter
 
 # from infrastructure.scrapers.company_data_processors import (
@@ -118,7 +118,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         self,
         threshold: Optional[int] = None,
         existing_codes: Optional[List[str]] = None,
-        save_callback: Optional[Callable[[List[CompanyDataDTO]], None]] = None,
+        save_callback: SaveCallback[CompanyDataDTO] | None = None,
         **kwargs,
     ) -> List[CompanyDataDTO]:
         """Fetch the full set of companies and their details, optionally saving in batches.
@@ -131,7 +131,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
             threshold (Optional[int]): Number of companies to buffer before flushing.
                 Falls back to repository configuration or 50 if not provided.
             existing_codes (Optional[List[str]]): Collection of company identifiers to skip.
-            save_callback (Optional[Callable[[List[CompanyDataDTO]], None]]):
+            save_callback (Optional[SaveCallback[CompanyDataDTO]]):
                 Callback to persist buffered DTOs when the threshold is reached.
             **kwargs: Reserved for future extensions.
 
@@ -139,13 +139,13 @@ class CompanyDataScraper(ScraperCompanyDataPort):
             List[CompanyDataDTO]: Fully fetched company detail DTOs.
         """
         # Normalize list of codes to a set for O(1) membership checks
-        self.existing_codes = existing_codes or set()
+        self.existing_codes = set(existing_codes or [])
 
         # Determine persistence threshold (explicit > config > default)
         self.threshold = threshold or self.config.repository.persistence_threshold or 50
 
         # No-op callback used when only building the initial list
-        def _adapter(_items: List[Dict], *, uow=None) -> None:
+        def _adapter(_items: List[Dict[str, Any]], *, uow: Uow) -> None:
             return None
 
         # 1) Fetch the initial list of companies (optionally flushing to storage)
@@ -164,7 +164,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
 
     def _fetch_companies_list(
         self,
-        save_callback: Optional[Callable[[List[Dict]], None]] = None,
+        save_callback: SaveCallback[Dict[str, Any]] | None = None,
     ) -> List[Dict[str, Any]]:
         """Fetch the initial set of companies available on the exchange.
 
@@ -172,7 +172,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         metrics reporting, and optional parallel page fetching.
 
         Args:
-            save_callback (Optional[Callable[[List[Dict]], None]]): Optional sink to
+            save_callback (Optional[SaveCallback[Dict[str, Any]]]): Optional sink to
                 persist items while streaming through pages.
 
         Returns:
@@ -183,9 +183,9 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         start_time = time.perf_counter()
 
         # adapta callback do porto (items) para a estratégia (items, *, uow)
-        def _adapter(items: List[Dict], *, uow=None) -> None:
+        def _adapter(items: List[Dict[str, Any]], *, uow: Uow) -> None:
             if save_callback is not None:
-                save_callback(items)
+                save_callback(items, uow=uow)
 
 
         # Build a save strategy to flush items while iterating pages
@@ -291,7 +291,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
     def _fetch_companies_details(
         self,
         companies_list: List[Dict],
-        save_callback: Optional[Callable[[List[CompanyDataDTO]], None]] = None,
+        save_callback: SaveCallback[CompanyDataDTO] | None = None,
     ) -> List[CompanyDataDTO]:
         """Fetch and parse detailed info for a list of companies.
 
@@ -301,7 +301,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
 
         Args:
             companies_list (List[Dict]): Raw company entries with at least ``codeCVM``.
-            save_callback (Optional[Callable[[List[CompanyDataDTO]], None]]):
+            save_callback (Optional[SaveCallback[CompanyDataDTO]]):
                 Sink to persist buffered detail DTOs.
 
         Returns:
@@ -317,9 +317,9 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         """
 
         # adapter para a estratégia
-        def _adapter(items: List[CompanyDataDTO], *, uow=None) -> None:
+        def _adapter(items: List[CompanyDataDTO], *, uow: Uow) -> None:
             if save_callback is not None:
-                save_callback(items)
+                save_callback(items, uow=uow)
 
         # Build a save strategy that buffers detail DTOs and flushes on threshold
         strategy: SaveStrategy[CompanyDataDTO] = SaveStrategy.from_config(

--- a/infrastructure/utils/save_strategy.py
+++ b/infrastructure/utils/save_strategy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Generic, Iterable, List, Optional, TypeVar, Protocol
+from typing import Generic, Iterable, List, Optional, TypeVar, Protocol
 
 from application.ports.config_port import ConfigPort
 from application.ports.uow_port import Uow, UowFactoryPort
@@ -9,7 +9,7 @@ from application.ports.uow_port import Uow, UowFactoryPort
 T = TypeVar("T")
 
 class SaveCallback(Protocol, Generic[T]):
-    def __call__(self, items: List[T], *, uow: Optional[Uow] = None) -> None: ...
+    def __call__(self, items: List[T], *, uow: Uow) -> None: ...
 
 
 @dataclass
@@ -24,7 +24,7 @@ class SaveStrategy(Generic[T]):
         T: The item type to be buffered and persisted.
 
     Attributes:
-        save_callback (Callable[[List[T]], None]): Function invoked when the
+        save_callback (SaveCallback[T]): Function invoked when the
             buffer is flushed; receives the current buffered items.
         threshold (int): Maximum number of items to buffer before triggering
             a flush.
@@ -71,7 +71,7 @@ class SaveStrategy(Generic[T]):
             SaveStrategy[T]: A strategy instance ready to buffer and flush items.
         """
         # Choose a callback or fall back to a no-op implementation
-        cb: SaveCallback[T] = save_callback or (lambda items, *, uow=None: None)
+        cb: SaveCallback[T] = save_callback or (lambda items, *, uow: None)
 
         # Choose a threshold from explicit arg, config, or a conservative default
         th = threshold or (config.repository.persistence_threshold if config else 50)


### PR DESCRIPTION
## Summary
- convert existing code list to a set before filtering fetched companies
- ensure SaveStrategy and company data scraper adapters forward the active unit of work to save callbacks when flushing company batches
- simplify the sync use case call method so exceptions surface to callers

## Testing
- pytest *(fails: legacy test suite depends on missing legacy domain modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cf097cd8c4832e993511f096590c20