### PR TITLE
Reuse progress formatter for NSD pipeline timing

### DIFF
--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import time
 from datetime import date, datetime
 from typing import Any, Iterable, Mapping, Optional, Sequence, cast
@@ -102,6 +103,10 @@ class NsdProcessor:
 
         self.id_generator = IdGenerator(config=config)
 
+        # Progress tracking helpers -------------------------------------------------
+        self._progress_lock = threading.Lock()
+        self._progress_started_at: float | None = None
+
     # compat com pools que chamam .run(task) ou chamam o objeto
     def __call__(self, task: WorkerTaskDTO) -> Any:
         return self.run(task)
@@ -109,15 +114,19 @@ class NsdProcessor:
     def run(self, task: WorkerTaskDTO) -> Any:
         nsd_id = task.data
         start_time = time.perf_counter()
+        progress_start = self._resolve_progress_start_time(
+            start_time, reset=task.index == 0
+        )
         nsd = self.scraper_nsd.fetch_one(int(nsd_id))
-        progress = self._build_progress_payload(task=task, start_time=start_time)
+        progress = self._build_progress_payload(task=task, start_time=progress_start)
 
         if nsd is None:
+            missing_progress = dict(progress)
+            missing_progress["stage"] = "NSD"
             self._log_message(
                 f"NSD {nsd_id}",
-                progress=progress,
+                progress=missing_progress,
                 worker_id=task.worker_id,
-                extra_info=[""],
             )
             return task.data
 
@@ -231,10 +240,38 @@ class NsdProcessor:
             statements_fetched_repository=self.statements_fetched_repository,
         )
 
+    def _resolve_progress_start_time(
+        self, candidate: float, *, reset: bool = False
+    ) -> float:
+        """Return a shared start time for progress calculations.
+
+        The first task processed defines the baseline `start_time`. Subsequent
+        tasks reuse this timestamp so that elapsed time reflects the entire
+        batch execution instead of the duration of a single NSD pipeline.
+
+        Args:
+            candidate: Monotonic timestamp captured for the current task.
+            reset: When True, force the shared start time to this candidate.
+        """
+
+        with self._progress_lock:
+            if reset or self._progress_started_at is None:
+                self._progress_started_at = candidate
+            return self._progress_started_at
+
     def _build_progress_payload(self, *, task: WorkerTaskDTO, start_time: float) -> dict[str, Any]:
+        raw_total = task.total_size or (task.index + 1)
+        try:
+            total_size = int(raw_total)
+        except (TypeError, ValueError):  # pragma: no cover - defensive fallback
+            total_size = task.index + 1
+
+        if total_size <= 0:
+            total_size = 1
+
         return {
             "index": task.index,
-            "size": task.total_size,
+            "size": total_size,
             "start_time": start_time,
         }
 
@@ -246,11 +283,15 @@ class NsdProcessor:
         progress: dict[str, Any],
         worker_id: str,
     ) -> None:
+        extra_tokens = [self._format_extra_info_line(nsd)]
+        stage_progress = dict(progress)
+        stage_progress["stage"] = stage
+
         self._log_message(
             f"{stage} {nsd.nsd}",
-            progress=progress,
+            progress=stage_progress,
             worker_id=worker_id,
-            extra_info=[self._format_extra_info_line(nsd)],
+            extra_info=extra_tokens,
         )
 
     def _log_message(

--- a/tests/application/processors/test_nsd_processor.py
+++ b/tests/application/processors/test_nsd_processor.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from application.processors.nsd_processor import NsdProcessor
+from domain.dtos.worker_task_dto import WorkerTaskDTO
+
+
+def _build_processor() -> NsdProcessor:
+    config = SimpleNamespace(fly_settings=SimpleNamespace(app_name="TestApp"))
+
+    return NsdProcessor(
+        config=config,
+        logger=MagicMock(),
+        nsd_repository=MagicMock(),
+        company_repository=MagicMock(),
+        statements_raw_repository=MagicMock(),
+        statements_fetched_repository=MagicMock(),
+        scraper_nsd=MagicMock(),
+        scraper_statements_raw=MagicMock(),
+        policy=MagicMock(),
+        financial_normalizer=MagicMock(),
+        ratios_calculator=MagicMock(),
+        uow_factory=MagicMock(),
+    )
+
+
+def test_resolve_progress_start_time_reuses_first_value() -> None:
+    processor = _build_processor()
+
+    first = processor._resolve_progress_start_time(100.0)
+    second = processor._resolve_progress_start_time(150.0)
+
+    assert first == second == 100.0
+
+
+def test_resolve_progress_start_time_resets_when_requested() -> None:
+    processor = _build_processor()
+
+    processor._resolve_progress_start_time(50.0)
+    updated = processor._resolve_progress_start_time(200.0, reset=True)
+
+    assert updated == 200.0
+
+
+def test_build_progress_payload_defaults_total_size_when_missing() -> None:
+    processor = _build_processor()
+    task = WorkerTaskDTO(index=4, data="payload", worker_id="worker", total_size=None)
+
+    payload = processor._build_progress_payload(task=task, start_time=123.456)
+
+    assert payload["size"] == 5
+    assert payload["index"] == 4
+    assert payload["start_time"] == 123.456
+
+
+def test_log_stage_uses_existing_progress_formatter_payload() -> None:
+    processor = _build_processor()
+    processor.logger.reset_mock()
+
+    nsd = SimpleNamespace(
+        nsd="123",
+        quarter="2010-12-31",
+        sent_date="2010-04-20 09:35:15",
+        version=1,
+        nsd_type="FORM",
+        company_name="Example SA",
+    )
+
+    progress = {"index": 0, "size": 10, "start_time": 42.0}
+
+    processor._log_stage("NSD", nsd, progress=progress, worker_id="worker")
+
+    processor.logger.log.assert_called_once()
+    _, kwargs = processor.logger.log.call_args
+
+    assert kwargs["progress"]["stage"] == "NSD"
+    assert kwargs["progress"]["extra_info"] == [
+        "123 2010-12-31 | 2010-04-20 09:35:15 v1 | FORM Example SA"
+    ]


### PR DESCRIPTION
## Summary
- share a batch-wide start time so NSD progress logs reflect real elapsed time with the existing formatter
- include the active stage in the progress payload while reusing the existing progress logger instead of introducing a new timeline helper
- cover the start-time reuse, payload defaults, and stage logging behavior with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf17906dd4832e86970b84ab932906