### PR TITLE
Sanitize progress formatter extra info pipes

### DIFF
--- a/infrastructure/logging/progress_formatter.py
+++ b/infrastructure/logging/progress_formatter.py
@@ -77,7 +77,12 @@ class ProgressFormatter:
             if isinstance(extra_info, list):
                 # Join non-empty tokens with spaces
                 extra_str = " ".join(str(e) for e in extra_info if e)
-                return f"{base} | {extra_str}" if extra_str else base
+                if extra_str:
+                    # Sanitize pipes to avoid introducing extra " | " delimiters
+                    sanitized = extra_str.replace("|", "/").strip()
+                    if sanitized:
+                        return f"{base} ({sanitized})"
+                return base
 
             # Return base string when extra_info is not a list
             return base

--- a/tests/infrastructure/logging/test_progress_formatter.py
+++ b/tests/infrastructure/logging/test_progress_formatter.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from infrastructure.logging.progress_formatter import ProgressFormatter
+
+
+def test_format_does_not_create_extra_pipe_tokens() -> None:
+    formatter = ProgressFormatter()
+    nsd_extra_info = "2020-03-31 v1 | 2020-04-20 10:30:00 | FORM Example SA"
+
+    progress = {
+        "index": 0,
+        "size": 10,
+        "start_time": time.perf_counter() - 1,
+        "extra_info": [nsd_extra_info],
+    }
+
+    line = formatter.format(progress)
+    parts = line.split(" | ")
+
+    assert len(parts) == 3
+    assert "|" not in parts[2]
+    assert "2020-03-31 v1 / 2020-04-20 10:30:00 / FORM Example SA" in parts[2]
+    assert parts[2].endswith(")")


### PR DESCRIPTION
## Summary
- sanitize progress formatter extra info by replacing pipe characters and wrapping it in parentheses so log lines keep their three-pipe structure
- add a regression test using the NSD processor extra info output to ensure the formatter preserves the expected token count

## Testing
- pytest tests/infrastructure/logging/test_progress_formatter.py

------
https://chatgpt.com/codex/tasks/task_e_68cf4b33326c832eb80a464e23157466