### PR TITLE
Add NSD download metrics to logging

### DIFF
--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -25,6 +25,7 @@ from domain.ports.scraper_nsd_port import ScraperNsdPort
 from domain.ports.scraper_statements_raw_port import ScraperStatementRawPort
 from domain.services.financial_normalizer import FinancialNormalizerPort
 from domain.services.ratios_calculator import RatiosCalculatorPort
+from infrastructure.utils.byte_formatter import ByteFormatter
 from infrastructure.utils.id_generator import IdGenerator
 from infrastructure.utils.list_flatenner import ListFlattener
 
@@ -174,6 +175,7 @@ class NsdProcessor:
         self.ratios_calculator = ratios_calculator
 
         self.id_generator = IdGenerator(config=config)
+        self.byte_formatter = ByteFormatter()
 
         # Progress tracking helpers -------------------------------------------------
         self._progress_lock = threading.Lock()
@@ -191,6 +193,7 @@ class NsdProcessor:
         )
         timeline = _StageTimeline(started_at=start_time)
         nsd = self.scraper_nsd.fetch_one(int(nsd_id))
+        download_extra = self._build_download_extra()
         progress = self._build_progress_payload(task=task, start_time=progress_start)
 
         if nsd is None:
@@ -202,6 +205,7 @@ class NsdProcessor:
                 progress=missing_progress,
                 worker_id=task.worker_id,
                 extra_info=[summary] if summary else None,
+                extra=download_extra,
             )
             return task.data
 
@@ -223,18 +227,20 @@ class NsdProcessor:
                     progress=progress,
                     worker_id=task.worker_id,
                     timeline=timeline,
+                    extra=download_extra,
                 )
 
                 return nsd
 
-            return self._process_statement_nsd(
+        return self._process_statement_nsd(
                 nsd=nsd,
                 task=task,
-                progress=progress,
-                aggregator=aggregator,
-                uow=uow,
-                timeline=timeline,
-            )
+            progress=progress,
+            aggregator=aggregator,
+            uow=uow,
+            timeline=timeline,
+            download_extra=download_extra,
+        )
 
     def _process_statement_nsd(
         self,
@@ -245,7 +251,16 @@ class NsdProcessor:
         aggregator: _NsdTxnAggregator,
         uow: Uow,
         timeline: _StageTimeline,
+        download_extra: Mapping[str, str] | None,
     ) -> Any:
+        self._log_stage(
+            "NSD",
+            nsd,
+            progress=progress,
+            worker_id=task.worker_id,
+            timeline=timeline,
+            extra=download_extra,
+        )
         quarter_police = self.policy.normalize_quarter(nsd)
         sent_date = getattr(nsd, "sent_date")
         if hasattr(sent_date, "date"):
@@ -418,6 +433,7 @@ class NsdProcessor:
         progress: dict[str, Any],
         worker_id: str,
         timeline: _StageTimeline | None = None,
+        extra: Mapping[str, Any] | None = None,
     ) -> None:
         extra_tokens = [self._format_extra_info_line(nsd)]
         if timeline is not None:
@@ -432,6 +448,7 @@ class NsdProcessor:
             progress=stage_progress,
             worker_id=worker_id,
             extra_info=extra_tokens,
+            extra=extra,
         )
 
     def _log_message(
@@ -441,11 +458,18 @@ class NsdProcessor:
         progress: dict[str, Any],
         worker_id: str,
         extra_info: Sequence[str] | None = None,
+        extra: Mapping[str, Any] | None = None,
     ) -> None:
         payload = dict(progress)
         if extra_info is not None:
             payload["extra_info"] = list(extra_info)
-        self.logger.log(message, level="info", progress=payload, worker_id=worker_id)
+        self.logger.log(
+            message,
+            level="info",
+            progress=payload,
+            worker_id=worker_id,
+            extra=extra,
+        )
 
     def _format_extra_info_line(self, nsd: NsdDTO) -> str:
         quarter = (
@@ -510,6 +534,22 @@ class NsdProcessor:
         )
         self.company_repository.save_all([dto], uow=uow)
         return dto.cvm_code
+
+    def _build_download_extra(self) -> Mapping[str, str] | None:
+        collector = getattr(self.scraper_nsd, "metrics_collector", None)
+        if collector is None:
+            return None
+
+        download_bytes = getattr(collector, "download_bytes", None)
+        total_bytes = getattr(collector, "network_bytes", None)
+
+        extra: dict[str, str] = {}
+        if isinstance(download_bytes, int):
+            extra["Download"] = self.byte_formatter.format_bytes(download_bytes)
+        if isinstance(total_bytes, int):
+            extra["Total download"] = self.byte_formatter.format_bytes(total_bytes)
+
+        return extra or None
 
     def _save_batch(
         self,

--- a/infrastructure/scrapers/scraper_nsd.py
+++ b/infrastructure/scrapers/scraper_nsd.py
@@ -83,6 +83,7 @@ class NsdScraper(ScraperNsdPort):
             url = self.nsd_endpoint.format(nsd=nsd)
             with self.http_client.borrow_session() as session:
                 body = self.http_client.fetch_with(session, url, headers=session.headers)
+                self._metrics_collector.add_network_bytes(len(body))
             parsed = self._parse_html(nsd, body.decode("utf-8"))
             return (
                 NsdDTO.from_dict(parsed, cleandate=self._cleandate_required)
@@ -121,6 +122,7 @@ class NsdScraper(ScraperNsdPort):
             try:
                 with self.http_client.borrow_session() as session:
                     body = self.http_client.fetch_with(session, url, headers=session.headers)
+                    self._metrics_collector.add_network_bytes(len(body))
                 parsed = self._parse_html(code, body.decode("utf-8"))
                 if not parsed:
                     self.logger.log(f"Processed NSD: {code} Empty", level="info")

--- a/tests/application/processors/test_nsd_processor.py
+++ b/tests/application/processors/test_nsd_processor.py
@@ -200,6 +200,28 @@ def test_log_stage_uses_existing_progress_formatter_payload() -> None:
     assert kwargs["progress"]["extra_info"] == [
         "2010-12-31 v1 | 2010-04-20 09:35:15 | FORM Example SA"
     ]
+    assert kwargs["extra"] is None
+
+
+def test_log_stage_forwards_extra_payload() -> None:
+    processor, logger = _build_processor()
+    logger.reset_mock()
+
+    nsd = _make_nsd()
+    progress = {"index": 0, "size": 1, "start_time": 42.0}
+    extra_payload = {"Download": "1.00KB", "Total download": "2.00KB"}
+
+    processor._log_stage(
+        "NSD",
+        nsd,
+        progress=progress,
+        worker_id="worker",
+        extra=extra_payload,
+    )
+
+    logger.log.assert_called_once()
+    _, kwargs = logger.log.call_args
+    assert kwargs["extra"] == extra_payload
 # =======
 # def test_stage_timeline_summary_tracks_elapsed(monkeypatch) -> None:
 #     timeline = _StageTimeline(started_at=0.0)
@@ -291,3 +313,18 @@ def test_finalize_nsd_persists_processed_level_when_requested() -> None:
     processor.statements_raw_repository.save_all.assert_called_once()
     processor.statements_fetched_repository.save_all.assert_called_once()
     uow.commit.assert_called_once()
+
+
+def test_build_download_extra_formats_metrics() -> None:
+    processor, _ = _build_processor()
+    processor.scraper_nsd.metrics_collector = SimpleNamespace(
+        download_bytes=1024,
+        network_bytes=10_485_760,
+    )
+
+    extra = processor._build_download_extra()
+
+    assert extra == {
+        "Download": "1.00KB",
+        "Total download": "10.00MB",
+    }


### PR DESCRIPTION
## Summary
- record NSD download byte counts in the scraper so metrics stay up to date
- include formatted download and total download figures in NSD processor logs
- extend processor tests to cover the new extra payload and metric formatting logic

## Testing
- pytest tests/application/processors/test_nsd_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68cffcaea018832ebadab979ce395ebd