### PR TITLE
Track cumulative download totals in NSD logs

### DIFF
--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -29,6 +29,85 @@ from infrastructure.utils.byte_formatter import ByteFormatter
 from infrastructure.utils.id_generator import IdGenerator
 from infrastructure.utils.list_flatenner import ListFlattener
 
+
+class _DownloadCycle:
+    """Track download deltas for all scrapers participating in a pipeline run."""
+
+    def __init__(self, *, byte_formatter: ByteFormatter) -> None:
+        self._byte_formatter = byte_formatter
+        self._collectors: dict[int, Any] = {}
+        self._baselines: dict[int, int] = {}
+
+    def register(self, subject: Any) -> None:
+        """Register a scraper-like object so its metrics can be tracked."""
+
+        collector = getattr(subject, "metrics_collector", None)
+        if collector is None:
+            return
+
+        try:
+            baseline = int(getattr(collector, "network_bytes", 0))
+        except (TypeError, ValueError):  # pragma: no cover - defensive fallback
+            baseline = 0
+
+        key = id(collector)
+        self._collectors[key] = collector
+        self._baselines[key] = baseline
+
+    def total_bytes(self, *, fallback: int | None = None) -> int:
+        """Return the accumulated download delta for the registered collectors."""
+
+        total = 0
+        has_any = False
+        for key, collector in self._collectors.items():
+            current = getattr(collector, "network_bytes", None)
+            if not isinstance(current, int):
+                continue
+            has_any = True
+            baseline = self._baselines.get(key, 0)
+            delta = current - baseline
+            if delta > 0:
+                total += delta
+
+        if total <= 0:
+            fallback_value = fallback or 0
+            if not has_any:
+                return fallback_value
+            return max(total, fallback_value)
+
+        if fallback and fallback > total:
+            return fallback
+
+        return total
+
+    def build_extra(self, *, collector: Any | None) -> Mapping[str, str] | None:
+        """Create the log payload for the given collector using the tracked totals."""
+
+        if collector is None:
+            total = self.total_bytes()
+            if total <= 0:
+                return None
+            return {"Total download": self._byte_formatter.format_bytes(total)}
+
+        download_bytes = getattr(collector, "download_bytes", None)
+        stage_download = (
+            int(download_bytes)
+            if isinstance(download_bytes, int)
+            else None
+        )
+
+        extra: dict[str, str] = {}
+        if stage_download and stage_download > 0:
+            extra["Download"] = self._byte_formatter.format_bytes(stage_download)
+
+        total_bytes = self.total_bytes(fallback=stage_download)
+        if total_bytes > 0:
+            extra["Total download"] = self._byte_formatter.format_bytes(total_bytes)
+        elif stage_download is not None and stage_download >= 0:
+            extra["Total download"] = self._byte_formatter.format_bytes(stage_download)
+
+        return extra or None
+
 # <<<<<<< codex/add-save_batch-method-to-nsd_processor-nbtb3g
 
 _T = TypeVar("_T")
@@ -192,8 +271,11 @@ class NsdProcessor:
             start_time, reset=task.index == 0
         )
         timeline = _StageTimeline(started_at=start_time)
+        download_cycle = self._start_download_cycle()
         nsd = self.scraper_nsd.fetch_one(int(nsd_id))
-        download_extra = self._build_download_extra()
+        download_extra = self._build_download_extra(
+            scraper=self.scraper_nsd, cycle=download_cycle
+        )
         progress = self._build_progress_payload(task=task, start_time=progress_start)
 
         if nsd is None:
@@ -233,12 +315,13 @@ class NsdProcessor:
                 return nsd
 
         return self._process_statement_nsd(
-                nsd=nsd,
-                task=task,
+            nsd=nsd,
+            task=task,
             progress=progress,
             aggregator=aggregator,
             uow=uow,
             timeline=timeline,
+            download_cycle=download_cycle,
             download_extra=download_extra,
         )
 
@@ -251,6 +334,7 @@ class NsdProcessor:
         aggregator: _NsdTxnAggregator,
         uow: Uow,
         timeline: _StageTimeline,
+        download_cycle: _DownloadCycle,
         download_extra: Mapping[str, str] | None,
     ) -> Any:
         self._log_stage(
@@ -276,6 +360,9 @@ class NsdProcessor:
         )
 
         raw_lines = self._fetch_raw_lines(nsd=nsd, task=task)
+        raw_download_extra = self._build_download_extra(
+            scraper=self.scraper_statements_raw, cycle=download_cycle
+        )
         if action.is_raw():
             aggregator.add_raw_many(raw_lines)
             self._finalize_nsd(
@@ -291,6 +378,7 @@ class NsdProcessor:
                 progress=progress,
                 worker_id=task.worker_id,
                 timeline=timeline,
+                extra=raw_download_extra,
             )
 
             return nsd
@@ -335,6 +423,7 @@ class NsdProcessor:
                 progress=progress,
                 worker_id=task.worker_id,
                 timeline=timeline,
+                extra=raw_download_extra,
             )
 
             return nsd
@@ -408,6 +497,12 @@ class NsdProcessor:
             if reset or self._progress_started_at is None:
                 self._progress_started_at = candidate
             return self._progress_started_at
+
+    def _start_download_cycle(self) -> _DownloadCycle:
+        cycle = _DownloadCycle(byte_formatter=self.byte_formatter)
+        cycle.register(self.scraper_nsd)
+        cycle.register(self.scraper_statements_raw)
+        return cycle
 
     def _build_progress_payload(self, *, task: WorkerTaskDTO, start_time: float) -> dict[str, Any]:
         raw_total = task.total_size or (task.index + 1)
@@ -535,8 +630,18 @@ class NsdProcessor:
         self.company_repository.save_all([dto], uow=uow)
         return dto.cvm_code
 
-    def _build_download_extra(self) -> Mapping[str, str] | None:
-        collector = getattr(self.scraper_nsd, "metrics_collector", None)
+    def _build_download_extra(
+        self,
+        *,
+        scraper: Any | None = None,
+        cycle: _DownloadCycle | None = None,
+    ) -> Mapping[str, str] | None:
+        subject = scraper if scraper is not None else self.scraper_nsd
+        collector = getattr(subject, "metrics_collector", None)
+
+        if cycle is not None:
+            return cycle.build_extra(collector=collector)
+
         if collector is None:
             return None
 

--- a/tests/application/processors/test_nsd_processor.py
+++ b/tests/application/processors/test_nsd_processor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Mapping, Sequence, cast
 from unittest.mock import MagicMock
 
 import sys
@@ -170,6 +170,36 @@ def test_build_progress_payload_defaults_total_size_when_missing() -> None:
     assert payload["start_time"] == 123.456
 
 
+def test_run_logs_missing_nsd_with_cycle_totals() -> None:
+    processor, logger = _build_processor()
+    logger.reset_mock()
+
+    nsd_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
+    processor.scraper_nsd.metrics_collector = nsd_collector
+    processor.scraper_statements_raw.metrics_collector = SimpleNamespace(
+        download_bytes=0,
+        network_bytes=0,
+    )
+
+    def _fetch_one(_: int) -> None:
+        nsd_collector.download_bytes = 512
+        nsd_collector.network_bytes = 512
+        return None
+
+    processor.scraper_nsd.fetch_one.side_effect = _fetch_one
+
+    task = WorkerTaskDTO(index=0, data="123", worker_id="worker", total_size=1)
+
+    processor.run(task)
+
+    logger.log.assert_called_once()
+    _, kwargs = logger.log.call_args
+    assert kwargs["extra"] == {
+        "Download": "512.00B",
+        "Total download": "512.00B",
+    }
+
+
 # <<<<<<< codex/fix-unrealistic-time-progression-logs-0j1j18
 def test_log_stage_uses_existing_progress_formatter_payload() -> None:
     processor, logger = _build_processor()
@@ -327,4 +357,173 @@ def test_build_download_extra_formats_metrics() -> None:
     assert extra == {
         "Download": "1.00KB",
         "Total download": "10.00MB",
+    }
+
+
+def test_build_download_extra_accepts_custom_scraper() -> None:
+    processor, _ = _build_processor()
+    scraper = SimpleNamespace(
+        metrics_collector=SimpleNamespace(download_bytes=512, network_bytes=2048)
+    )
+
+    extra = processor._build_download_extra(scraper=scraper)
+
+    assert extra == {
+        "Download": "512.00B",
+        "Total download": "2.00KB",
+    }
+
+
+def test_build_download_extra_uses_cycle_totals() -> None:
+    processor, _ = _build_processor()
+    processor.scraper_nsd.metrics_collector = SimpleNamespace(
+        download_bytes=0,
+        network_bytes=0,
+    )
+    processor.scraper_statements_raw.metrics_collector = SimpleNamespace(
+        download_bytes=0,
+        network_bytes=0,
+    )
+
+    cycle = processor._start_download_cycle()
+
+    processor.scraper_nsd.metrics_collector.download_bytes = 1024
+    processor.scraper_nsd.metrics_collector.network_bytes = 1024
+    processor.scraper_statements_raw.metrics_collector.download_bytes = 2048
+    processor.scraper_statements_raw.metrics_collector.network_bytes = 2048
+
+    extra = processor._build_download_extra(
+        scraper=processor.scraper_statements_raw, cycle=cycle
+    )
+
+    assert extra == {
+        "Download": "2.00KB",
+        "Total download": "3.00KB",
+    }
+
+
+class _DummyAction:
+    def __init__(self, raw: bool) -> None:
+        self._raw = raw
+
+    def is_raw(self) -> bool:
+        return self._raw
+
+
+def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
+    processor, logger = _build_processor()
+    logger.reset_mock()
+
+    nsd_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
+    raw_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
+    processor.scraper_nsd.metrics_collector = nsd_collector
+    processor.scraper_statements_raw.metrics_collector = raw_collector
+    cycle = processor._start_download_cycle()
+
+    def _fetch_raw(task: WorkerTaskDTO) -> Mapping[str, Sequence[StatementRawDTO]]:
+        raw_collector.download_bytes = 2048
+        raw_collector.network_bytes = 2048
+        return {"items": [_make_raw()]}
+
+    processor.scraper_statements_raw.fetch.side_effect = _fetch_raw
+    nsd_collector.download_bytes = 1024
+    nsd_collector.network_bytes = 1024
+    download_extra = processor._build_download_extra(
+        scraper=processor.scraper_nsd, cycle=cycle
+    )
+    processor.policy.normalize_quarter.return_value = SimpleNamespace(
+        year=2020, month=3, is_december=False
+    )
+    processor.policy.compute_recency_window.return_value = SimpleNamespace(
+        is_recent=False
+    )
+    processor.policy.decide_action.return_value = _DummyAction(raw=True)
+
+    processor._finalize_nsd = MagicMock()
+    aggregator = MagicMock()
+    task = WorkerTaskDTO(index=0, data="payload", worker_id="worker", total_size=1)
+    progress = {"index": 0, "size": 1, "start_time": 0.0}
+
+    processor._process_statement_nsd(
+        nsd=_make_nsd(),
+        task=task,
+        progress=progress,
+        aggregator=aggregator,
+        uow=MagicMock(),
+        timeline=None,
+        download_cycle=cycle,
+        download_extra=download_extra,
+    )
+
+    raw_call = next(
+        kwargs
+        for args, kwargs in logger.log.call_args_list
+        if args and args[0] == "RAW 123"
+    )
+
+    assert raw_call["extra"] == {
+        "Download": "2.00KB",
+        "Total download": "3.00KB",
+    }
+
+
+def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
+    processor, logger = _build_processor()
+    logger.reset_mock()
+
+    nsd_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
+    raw_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
+    processor.scraper_nsd.metrics_collector = nsd_collector
+    processor.scraper_statements_raw.metrics_collector = raw_collector
+    cycle = processor._start_download_cycle()
+
+    def _fetch_raw(task: WorkerTaskDTO) -> Mapping[str, Sequence[StatementRawDTO]]:
+        raw_collector.download_bytes = 3072
+        raw_collector.network_bytes = 3072
+        return {"items": [_make_raw()]}
+
+    processor.scraper_statements_raw.fetch.side_effect = _fetch_raw
+    nsd_collector.download_bytes = 2048
+    nsd_collector.network_bytes = 2048
+    download_extra = processor._build_download_extra(
+        scraper=processor.scraper_nsd, cycle=cycle
+    )
+    processor.policy.normalize_quarter.return_value = SimpleNamespace(
+        year=2020, month=3, is_december=False
+    )
+    processor.policy.compute_recency_window.return_value = SimpleNamespace(
+        is_recent=True
+    )
+    processor.policy.decide_action.return_value = _DummyAction(raw=False)
+    processor.statements_raw_repository.get_company_year_view.return_value = []
+    processor.policy.version_deduplicate.return_value = []
+    processor.financial_normalizer.quarterize.return_value = []
+    processor.financial_normalizer.standardize.return_value = []
+    processor._filter_new_fetched = MagicMock(return_value=[])
+
+    processor._finalize_nsd = MagicMock()
+    aggregator = MagicMock()
+    task = WorkerTaskDTO(index=0, data="payload", worker_id="worker", total_size=1)
+    progress = {"index": 0, "size": 1, "start_time": 0.0}
+
+    processor._process_statement_nsd(
+        nsd=_make_nsd(),
+        task=task,
+        progress=progress,
+        aggregator=aggregator,
+        uow=MagicMock(),
+        timeline=None,
+        download_cycle=cycle,
+        download_extra=download_extra,
+    )
+
+    ftd_call = next(
+        kwargs
+        for args, kwargs in logger.log.call_args_list
+        if args and args[0] == "FTD 123"
+    )
+
+    assert ftd_call["extra"] == {
+        "Download": "3.00KB",
+        "Total download": "5.00KB",
     }


### PR DESCRIPTION
## Summary
- add a download cycle tracker so the NSD processor can accumulate per-run network deltas across its scrapers
- ensure every NSD stage log includes the combined total download size for the cycle, including raw and processed phases
- extend the processor unit tests to cover the new cumulative download reporting scenarios

## Testing
- pytest tests/application/processors/test_nsd_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68d000709654832ebb142ba4a4fce3ac