### PR TITLE
Simplify NSD download metrics logging

### DIFF
--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -29,85 +29,6 @@ from infrastructure.utils.byte_formatter import ByteFormatter
 from infrastructure.utils.id_generator import IdGenerator
 from infrastructure.utils.list_flatenner import ListFlattener
 
-
-class _DownloadCycle:
-    """Track download deltas for all scrapers participating in a pipeline run."""
-
-    def __init__(self, *, byte_formatter: ByteFormatter) -> None:
-        self._byte_formatter = byte_formatter
-        self._collectors: dict[int, Any] = {}
-        self._baselines: dict[int, int] = {}
-
-    def register(self, subject: Any) -> None:
-        """Register a scraper-like object so its metrics can be tracked."""
-
-        collector = getattr(subject, "metrics_collector", None)
-        if collector is None:
-            return
-
-        try:
-            baseline = int(getattr(collector, "network_bytes", 0))
-        except (TypeError, ValueError):  # pragma: no cover - defensive fallback
-            baseline = 0
-
-        key = id(collector)
-        self._collectors[key] = collector
-        self._baselines[key] = baseline
-
-    def total_bytes(self, *, fallback: int | None = None) -> int:
-        """Return the accumulated download delta for the registered collectors."""
-
-        total = 0
-        has_any = False
-        for key, collector in self._collectors.items():
-            current = getattr(collector, "network_bytes", None)
-            if not isinstance(current, int):
-                continue
-            has_any = True
-            baseline = self._baselines.get(key, 0)
-            delta = current - baseline
-            if delta > 0:
-                total += delta
-
-        if total <= 0:
-            fallback_value = fallback or 0
-            if not has_any:
-                return fallback_value
-            return max(total, fallback_value)
-
-        if fallback and fallback > total:
-            return fallback
-
-        return total
-
-    def build_extra(self, *, collector: Any | None) -> Mapping[str, str] | None:
-        """Create the log payload for the given collector using the tracked totals."""
-
-        if collector is None:
-            total = self.total_bytes()
-            if total <= 0:
-                return None
-            return {"Total download": self._byte_formatter.format_bytes(total)}
-
-        download_bytes = getattr(collector, "download_bytes", None)
-        stage_download = (
-            int(download_bytes)
-            if isinstance(download_bytes, int)
-            else None
-        )
-
-        extra: dict[str, str] = {}
-        if stage_download and stage_download > 0:
-            extra["Download"] = self._byte_formatter.format_bytes(stage_download)
-
-        total_bytes = self.total_bytes(fallback=stage_download)
-        if total_bytes > 0:
-            extra["Total download"] = self._byte_formatter.format_bytes(total_bytes)
-        elif stage_download is not None and stage_download >= 0:
-            extra["Total download"] = self._byte_formatter.format_bytes(stage_download)
-
-        return extra or None
-
 # <<<<<<< codex/add-save_batch-method-to-nsd_processor-nbtb3g
 
 _T = TypeVar("_T")
@@ -271,11 +192,8 @@ class NsdProcessor:
             start_time, reset=task.index == 0
         )
         timeline = _StageTimeline(started_at=start_time)
-        download_cycle = self._start_download_cycle()
         nsd = self.scraper_nsd.fetch_one(int(nsd_id))
-        download_extra = self._build_download_extra(
-            scraper=self.scraper_nsd, cycle=download_cycle
-        )
+        download_extra = self._build_download_extra(scraper=self.scraper_nsd)
         progress = self._build_progress_payload(task=task, start_time=progress_start)
 
         if nsd is None:
@@ -322,7 +240,6 @@ class NsdProcessor:
             aggregator=aggregator,
             uow=uow,
             timeline=timeline,
-            download_cycle=download_cycle,
             download_extra=download_extra,
         )
 
@@ -335,7 +252,6 @@ class NsdProcessor:
         aggregator: _NsdTxnAggregator,
         uow: Uow,
         timeline: _StageTimeline,
-        download_cycle: _DownloadCycle,
         download_extra: Mapping[str, str] | None,
     ) -> Any:
         quarter_police = self.policy.normalize_quarter(nsd)
@@ -354,7 +270,7 @@ class NsdProcessor:
 
         raw_lines = self._fetch_raw_lines(nsd=nsd, task=task)
         raw_download_extra = self._build_download_extra(
-            scraper=self.scraper_statements_raw, cycle=download_cycle
+            scraper=self.scraper_statements_raw
         )
         if action.is_raw():
             aggregator.add_raw_many(raw_lines)
@@ -491,12 +407,6 @@ class NsdProcessor:
                 self._progress_started_at = candidate
             return self._progress_started_at
 
-    def _start_download_cycle(self) -> _DownloadCycle:
-        cycle = _DownloadCycle(byte_formatter=self.byte_formatter)
-        cycle.register(self.scraper_nsd)
-        cycle.register(self.scraper_statements_raw)
-        return cycle
-
     def _build_progress_payload(self, *, task: WorkerTaskDTO, start_time: float) -> dict[str, Any]:
         raw_total = task.total_size or (task.index + 1)
         try:
@@ -627,13 +537,9 @@ class NsdProcessor:
         self,
         *,
         scraper: Any | None = None,
-        cycle: _DownloadCycle | None = None,
     ) -> Mapping[str, str] | None:
         subject = scraper if scraper is not None else self.scraper_nsd
         collector = getattr(subject, "metrics_collector", None)
-
-        if cycle is not None:
-            return cycle.build_extra(collector=collector)
 
         if collector is None:
             return None
@@ -642,9 +548,9 @@ class NsdProcessor:
         total_bytes = getattr(collector, "network_bytes", None)
 
         extra: dict[str, str] = {}
-        if isinstance(download_bytes, int):
+        if isinstance(download_bytes, int) and download_bytes > 0:
             extra["Download"] = self.byte_formatter.format_bytes(download_bytes)
-        if isinstance(total_bytes, int):
+        if isinstance(total_bytes, int) and total_bytes > 0:
             extra["Total download"] = self.byte_formatter.format_bytes(total_bytes)
 
         return extra or None

--- a/infrastructure/factories/cli_factory.py
+++ b/infrastructure/factories/cli_factory.py
@@ -91,6 +91,7 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
     scraper_statements_raw = ScraperStatementRaw(
         config=config,
         logger=logger,
+        metrics_collector=metrics_collector,
         # statements_raw_repository=raw_statements_repository,
         # datacleaner=datacleaner,
         # metrics_collector=metrics_collector,

--- a/infrastructure/scrapers/scraper_statements_raw.py
+++ b/infrastructure/scrapers/scraper_statements_raw.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup, Tag
 from application.ports.config_port import ConfigPort
 from application.ports.http_client_port import AffinityHttpClientPort
 from application.ports.logger_port import LoggerPort
+from application.ports.metrics_collector_port import MetricsCollectorPort
 from domain.dtos.nsd_dto import NsdDTO
 from domain.dtos.statement_raw_dto import StatementRawDTO
 from domain.dtos.worker_task_dto import WorkerTaskDTO
@@ -26,11 +27,13 @@ class ScraperStatementRaw(ScraperStatementRawPort):
         *,
         config: ConfigPort,
         logger: LoggerPort,
+        metrics_collector: MetricsCollectorPort,
         http_client: AffinityHttpClientPort,
     ) -> None:
         self.config = config
         self.logger = logger
         self.http = http_client
+        self._metrics_collector = metrics_collector
 
     # API pública: cumpre o porto
     def fetch(self, task: WorkerTaskDTO) -> Mapping[str, Any]:
@@ -75,10 +78,16 @@ class ScraperStatementRaw(ScraperStatementRawPort):
             with self.http.borrow_session() as s:
                 hdrs = {str(k): str(v) for k, v in s.headers.items()}
                 body = self.http.fetch_with(s, url, headers=hdrs)
+                self._metrics_collector.add_network_bytes(len(body))
                 return body.decode("utf-8")
         hdrs = {str(k): str(v) for k, v in session.headers.items()}
         body = self.http.fetch_with(session, url, headers=hdrs)
+        self._metrics_collector.add_network_bytes(len(body))
         return body.decode("utf-8")
+
+    @property
+    def metrics_collector(self) -> MetricsCollectorPort:
+        return self._metrics_collector
 
     def _extract_hash(self, html: str) -> str:
         soup = BeautifulSoup(html, "html.parser")

--- a/tests/application/processors/test_nsd_processor.py
+++ b/tests/application/processors/test_nsd_processor.py
@@ -170,16 +170,13 @@ def test_build_progress_payload_defaults_total_size_when_missing() -> None:
     assert payload["start_time"] == 123.456
 
 
-def test_run_logs_missing_nsd_with_cycle_totals() -> None:
+def test_run_logs_missing_nsd_with_collector_metrics() -> None:
     processor, logger = _build_processor()
     logger.reset_mock()
 
     nsd_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
     processor.scraper_nsd.metrics_collector = nsd_collector
-    processor.scraper_statements_raw.metrics_collector = SimpleNamespace(
-        download_bytes=0,
-        network_bytes=0,
-    )
+    processor.scraper_statements_raw.metrics_collector = nsd_collector
 
     def _fetch_one(_: int) -> None:
         nsd_collector.download_bytes = 512
@@ -374,37 +371,6 @@ def test_build_download_extra_accepts_custom_scraper() -> None:
     }
 
 
-# <<<<<<< codex/ensure-download_extra-is-always-applied-2vo1h9
-def test_build_download_extra_uses_cycle_totals() -> None:
-    processor, _ = _build_processor()
-    processor.scraper_nsd.metrics_collector = SimpleNamespace(
-        download_bytes=0,
-        network_bytes=0,
-    )
-    processor.scraper_statements_raw.metrics_collector = SimpleNamespace(
-        download_bytes=0,
-        network_bytes=0,
-    )
-
-    cycle = processor._start_download_cycle()
-
-    processor.scraper_nsd.metrics_collector.download_bytes = 1024
-    processor.scraper_nsd.metrics_collector.network_bytes = 1024
-    processor.scraper_statements_raw.metrics_collector.download_bytes = 2048
-    processor.scraper_statements_raw.metrics_collector.network_bytes = 2048
-
-    extra = processor._build_download_extra(
-        scraper=processor.scraper_statements_raw, cycle=cycle
-    )
-
-    assert extra == {
-        "Download": "2.00KB",
-        "Total download": "3.00KB",
-    }
-
-
-# =======
-# >>>>>>> 2025-09-20-Stock-Value
 class _DummyAction:
     def __init__(self, raw: bool) -> None:
         self._raw = raw
@@ -417,29 +383,25 @@ def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
     processor, logger = _build_processor()
     logger.reset_mock()
 
-# <<<<<<< codex/ensure-download_extra-is-always-applied-2vo1h9
     nsd_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
-    raw_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
+
+    def add_bytes(amount: int) -> None:
+        nsd_collector.download_bytes = amount
+        nsd_collector.network_bytes += amount
+
+    nsd_collector.add_network_bytes = add_bytes  # type: ignore[attr-defined]
+
     processor.scraper_nsd.metrics_collector = nsd_collector
-    processor.scraper_statements_raw.metrics_collector = raw_collector
-    cycle = processor._start_download_cycle()
+    processor.scraper_statements_raw.metrics_collector = nsd_collector
 
     def _fetch_raw(task: WorkerTaskDTO) -> Mapping[str, Sequence[StatementRawDTO]]:
-        raw_collector.download_bytes = 2048
-        raw_collector.network_bytes = 2048
+        add_bytes(2048)
         return {"items": [_make_raw()]}
 
     processor.scraper_statements_raw.fetch.side_effect = _fetch_raw
-    nsd_collector.download_bytes = 1024
-    nsd_collector.network_bytes = 1024
+    add_bytes(1024)
     download_extra = processor._build_download_extra(
-        scraper=processor.scraper_nsd, cycle=cycle
-# =======
-#     processor.scraper_statements_raw.fetch.return_value = {"items": [_make_raw()]}
-#     processor.scraper_statements_raw.metrics_collector = SimpleNamespace(
-#         download_bytes=2048,
-#         network_bytes=4096,
-# >>>>>>> 2025-09-20-Stock-Value
+        scraper=processor.scraper_nsd,
     )
     processor.policy.normalize_quarter.return_value = SimpleNamespace(
         year=2020, month=3, is_december=False
@@ -461,12 +423,7 @@ def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
         aggregator=aggregator,
         uow=MagicMock(),
         timeline=None,
-# <<<<<<< codex/ensure-download_extra-is-always-applied-2vo1h9
-        download_cycle=cycle,
         download_extra=download_extra,
-# =======
-#         download_extra=None,
-# >>>>>>> 2025-09-20-Stock-Value
     )
 
     raw_call = next(
@@ -477,11 +434,7 @@ def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
 
     assert raw_call["extra"] == {
         "Download": "2.00KB",
-# <<<<<<< codex/ensure-download_extra-is-always-applied-2vo1h9
         "Total download": "3.00KB",
-# =======
-#         "Total download": "4.00KB",
-# >>>>>>> 2025-09-20-Stock-Value
     }
 
 
@@ -489,29 +442,25 @@ def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
     processor, logger = _build_processor()
     logger.reset_mock()
 
-# <<<<<<< codex/ensure-download_extra-is-always-applied-2vo1h9
     nsd_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
-    raw_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
+
+    def add_bytes(amount: int) -> None:
+        nsd_collector.download_bytes = amount
+        nsd_collector.network_bytes += amount
+
+    nsd_collector.add_network_bytes = add_bytes  # type: ignore[attr-defined]
+
     processor.scraper_nsd.metrics_collector = nsd_collector
-    processor.scraper_statements_raw.metrics_collector = raw_collector
-    cycle = processor._start_download_cycle()
+    processor.scraper_statements_raw.metrics_collector = nsd_collector
 
     def _fetch_raw(task: WorkerTaskDTO) -> Mapping[str, Sequence[StatementRawDTO]]:
-        raw_collector.download_bytes = 3072
-        raw_collector.network_bytes = 3072
+        add_bytes(3072)
         return {"items": [_make_raw()]}
 
     processor.scraper_statements_raw.fetch.side_effect = _fetch_raw
-    nsd_collector.download_bytes = 2048
-    nsd_collector.network_bytes = 2048
+    add_bytes(2048)
     download_extra = processor._build_download_extra(
-        scraper=processor.scraper_nsd, cycle=cycle
-# =======
-#     processor.scraper_statements_raw.fetch.return_value = {"items": [_make_raw()]}
-#     processor.scraper_statements_raw.metrics_collector = SimpleNamespace(
-#         download_bytes=3072,
-#         network_bytes=6144,
-# >>>>>>> 2025-09-20-Stock-Value
+        scraper=processor.scraper_nsd,
     )
     processor.policy.normalize_quarter.return_value = SimpleNamespace(
         year=2020, month=3, is_december=False
@@ -538,12 +487,7 @@ def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
         aggregator=aggregator,
         uow=MagicMock(),
         timeline=None,
-# <<<<<<< codex/ensure-download_extra-is-always-applied-2vo1h9
-        download_cycle=cycle,
         download_extra=download_extra,
-# =======
-#         download_extra=None,
-# >>>>>>> 2025-09-20-Stock-Value
     )
 
     ftd_call = next(
@@ -554,9 +498,5 @@ def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
 
     assert ftd_call["extra"] == {
         "Download": "3.00KB",
-# <<<<<<< codex/ensure-download_extra-is-always-applied-2vo1h9
         "Total download": "5.00KB",
-# =======
-#         "Total download": "6.00KB",
-# >>>>>>> 2025-09-20-Stock-Value
     }


### PR DESCRIPTION
## Summary
- simplify NSD processor download logging to use scraper metrics collectors directly
- track raw statement fetch sizes through the shared metrics collector and wire it in the CLI factory
- update processor tests to reflect the simplified metrics flow

## Testing
- pytest tests/application/processors/test_nsd_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68d009abdfe4832eb79cca36a0dfe0b7