### PR TITLE
Use scraper metrics collector for NSD logging

### DIFF
--- a/application/processors/nsd_processor.py
+++ b/application/processors/nsd_processor.py
@@ -25,7 +25,6 @@ from domain.ports.scraper_nsd_port import ScraperNsdPort
 from domain.ports.scraper_statements_raw_port import ScraperStatementRawPort
 from domain.services.financial_normalizer import FinancialNormalizerPort
 from domain.services.ratios_calculator import RatiosCalculatorPort
-from infrastructure.utils.byte_formatter import ByteFormatter
 from infrastructure.utils.id_generator import IdGenerator
 from infrastructure.utils.list_flatenner import ListFlattener
 
@@ -175,7 +174,6 @@ class NsdProcessor:
         self.ratios_calculator = ratios_calculator
 
         self.id_generator = IdGenerator(config=config)
-        self.byte_formatter = ByteFormatter()
 
         # Progress tracking helpers -------------------------------------------------
         self._progress_lock = threading.Lock()
@@ -193,7 +191,6 @@ class NsdProcessor:
         )
         timeline = _StageTimeline(started_at=start_time)
         nsd = self.scraper_nsd.fetch_one(int(nsd_id))
-        download_extra = self._build_download_extra(scraper=self.scraper_nsd)
         progress = self._build_progress_payload(task=task, start_time=progress_start)
 
         if nsd is None:
@@ -206,7 +203,7 @@ class NsdProcessor:
                 progress=missing_progress,
                 worker_id=task.worker_id,
                 extra_info=[summary] if summary else None,
-                extra=download_extra,
+                scraper=self.scraper_nsd,
             )
             return task.data
 
@@ -228,7 +225,7 @@ class NsdProcessor:
                     progress=progress,
                     worker_id=task.worker_id,
                     timeline=timeline,
-                    extra=download_extra,
+                    scraper=self.scraper_nsd,
                 )
 
                 return nsd
@@ -240,7 +237,6 @@ class NsdProcessor:
             aggregator=aggregator,
             uow=uow,
             timeline=timeline,
-            download_extra=download_extra,
         )
 
     def _process_statement_nsd(
@@ -252,7 +248,6 @@ class NsdProcessor:
         aggregator: _NsdTxnAggregator,
         uow: Uow,
         timeline: _StageTimeline,
-        download_extra: Mapping[str, str] | None,
     ) -> Any:
         quarter_police = self.policy.normalize_quarter(nsd)
         sent_date = getattr(nsd, "sent_date")
@@ -269,9 +264,6 @@ class NsdProcessor:
         )
 
         raw_lines = self._fetch_raw_lines(nsd=nsd, task=task)
-        raw_download_extra = self._build_download_extra(
-            scraper=self.scraper_statements_raw
-        )
         if action.is_raw():
             aggregator.add_raw_many(raw_lines)
             self._finalize_nsd(
@@ -287,7 +279,7 @@ class NsdProcessor:
                 progress=progress,
                 worker_id=task.worker_id,
                 timeline=timeline,
-                extra=raw_download_extra,
+                scraper=self.scraper_statements_raw,
             )
 
             return nsd
@@ -332,7 +324,7 @@ class NsdProcessor:
                 progress=progress,
                 worker_id=task.worker_id,
                 timeline=timeline,
-                extra=raw_download_extra,
+                scraper=self.scraper_statements_raw,
             )
 
             return nsd
@@ -432,6 +424,7 @@ class NsdProcessor:
         worker_id: str,
         timeline: _StageTimeline | None = None,
         extra: Mapping[str, Any] | None = None,
+        scraper: Any | None = None,
     ) -> None:
         extra_tokens = [self._format_extra_info_line(nsd)]
         if timeline is not None:
@@ -447,6 +440,7 @@ class NsdProcessor:
             worker_id=worker_id,
             extra_info=extra_tokens,
             extra=extra,
+            scraper=scraper,
         )
 
     def _log_message(
@@ -457,16 +451,18 @@ class NsdProcessor:
         worker_id: str,
         extra_info: Sequence[str] | None = None,
         extra: Mapping[str, Any] | None = None,
+        scraper: Any | None = None,
     ) -> None:
         payload = dict(progress)
         if extra_info is not None:
             payload["extra_info"] = list(extra_info)
+        combined_extra = self._combine_extras(extra, scraper)
         self.logger.log(
             message,
             level="info",
             progress=payload,
             worker_id=worker_id,
-            extra=extra,
+            extra=combined_extra,
         )
 
     def _format_extra_info_line(self, nsd: NsdDTO) -> str:
@@ -533,27 +529,43 @@ class NsdProcessor:
         self.company_repository.save_all([dto], uow=uow)
         return dto.cvm_code
 
-    def _build_download_extra(
+    def _combine_extras(
         self,
-        *,
-        scraper: Any | None = None,
-    ) -> Mapping[str, str] | None:
-        subject = scraper if scraper is not None else self.scraper_nsd
-        collector = getattr(subject, "metrics_collector", None)
+        extra: Mapping[str, Any] | None,
+        scraper: Any | None,
+    ) -> Mapping[str, Any] | None:
+        combined: dict[str, Any] = {}
+
+        if extra is not None:
+            combined.update(dict(extra))
+
+        metrics = self._collect_metrics(scraper)
+        if metrics is not None:
+            combined.update(metrics)
+
+        return combined or None
+
+    def _collect_metrics(self, scraper: Any | None) -> Mapping[str, int] | None:
+        if scraper is None:
+            return None
+
+        collector = getattr(scraper, "_metrics_collector", None)
+        if collector is None:
+            collector = getattr(scraper, "metrics_collector", None)
 
         if collector is None:
             return None
 
         download_bytes = getattr(collector, "download_bytes", None)
-        total_bytes = getattr(collector, "network_bytes", None)
+        network_bytes = getattr(collector, "network_bytes", None)
 
-        extra: dict[str, str] = {}
-        if isinstance(download_bytes, int) and download_bytes > 0:
-            extra["Download"] = self.byte_formatter.format_bytes(download_bytes)
-        if isinstance(total_bytes, int) and total_bytes > 0:
-            extra["Total download"] = self.byte_formatter.format_bytes(total_bytes)
+        metrics: dict[str, int] = {}
+        if isinstance(download_bytes, int) and download_bytes >= 0:
+            metrics["download_bytes"] = download_bytes
+        if isinstance(network_bytes, int) and network_bytes >= 0:
+            metrics["network_bytes"] = network_bytes
 
-        return extra or None
+        return metrics or None
 
     def _save_batch(
         self,

--- a/tests/application/processors/test_nsd_processor.py
+++ b/tests/application/processors/test_nsd_processor.py
@@ -176,7 +176,9 @@ def test_run_logs_missing_nsd_with_collector_metrics() -> None:
 
     nsd_collector = SimpleNamespace(download_bytes=0, network_bytes=0)
     processor.scraper_nsd.metrics_collector = nsd_collector
+    processor.scraper_nsd._metrics_collector = nsd_collector  # type: ignore[attr-defined]
     processor.scraper_statements_raw.metrics_collector = nsd_collector
+    processor.scraper_statements_raw._metrics_collector = nsd_collector  # type: ignore[attr-defined]
 
     def _fetch_one(_: int) -> None:
         nsd_collector.download_bytes = 512
@@ -192,8 +194,8 @@ def test_run_logs_missing_nsd_with_collector_metrics() -> None:
     logger.log.assert_called_once()
     _, kwargs = logger.log.call_args
     assert kwargs["extra"] == {
-        "Download": "512.00B",
-        "Total download": "512.00B",
+        "download_bytes": 512,
+        "network_bytes": 512,
     }
 
 
@@ -342,35 +344,6 @@ def test_finalize_nsd_persists_processed_level_when_requested() -> None:
     uow.commit.assert_called_once()
 
 
-def test_build_download_extra_formats_metrics() -> None:
-    processor, _ = _build_processor()
-    processor.scraper_nsd.metrics_collector = SimpleNamespace(
-        download_bytes=1024,
-        network_bytes=10_485_760,
-    )
-
-    extra = processor._build_download_extra()
-
-    assert extra == {
-        "Download": "1.00KB",
-        "Total download": "10.00MB",
-    }
-
-
-def test_build_download_extra_accepts_custom_scraper() -> None:
-    processor, _ = _build_processor()
-    scraper = SimpleNamespace(
-        metrics_collector=SimpleNamespace(download_bytes=512, network_bytes=2048)
-    )
-
-    extra = processor._build_download_extra(scraper=scraper)
-
-    assert extra == {
-        "Download": "512.00B",
-        "Total download": "2.00KB",
-    }
-
-
 class _DummyAction:
     def __init__(self, raw: bool) -> None:
         self._raw = raw
@@ -379,7 +352,7 @@ class _DummyAction:
         return self._raw
 
 
-def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
+def test_process_statement_nsd_logs_raw_stage_with_metrics() -> None:
     processor, logger = _build_processor()
     logger.reset_mock()
 
@@ -392,7 +365,9 @@ def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
     nsd_collector.add_network_bytes = add_bytes  # type: ignore[attr-defined]
 
     processor.scraper_nsd.metrics_collector = nsd_collector
+    processor.scraper_nsd._metrics_collector = nsd_collector  # type: ignore[attr-defined]
     processor.scraper_statements_raw.metrics_collector = nsd_collector
+    processor.scraper_statements_raw._metrics_collector = nsd_collector  # type: ignore[attr-defined]
 
     def _fetch_raw(task: WorkerTaskDTO) -> Mapping[str, Sequence[StatementRawDTO]]:
         add_bytes(2048)
@@ -400,9 +375,6 @@ def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
 
     processor.scraper_statements_raw.fetch.side_effect = _fetch_raw
     add_bytes(1024)
-    download_extra = processor._build_download_extra(
-        scraper=processor.scraper_nsd,
-    )
     processor.policy.normalize_quarter.return_value = SimpleNamespace(
         year=2020, month=3, is_december=False
     )
@@ -423,7 +395,6 @@ def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
         aggregator=aggregator,
         uow=MagicMock(),
         timeline=None,
-        download_extra=download_extra,
     )
 
     raw_call = next(
@@ -433,12 +404,12 @@ def test_process_statement_nsd_logs_raw_stage_with_download_extra() -> None:
     )
 
     assert raw_call["extra"] == {
-        "Download": "2.00KB",
-        "Total download": "3.00KB",
+        "download_bytes": 2048,
+        "network_bytes": 3072,
     }
 
 
-def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
+def test_process_statement_nsd_logs_ftd_stage_with_raw_metrics() -> None:
     processor, logger = _build_processor()
     logger.reset_mock()
 
@@ -451,7 +422,9 @@ def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
     nsd_collector.add_network_bytes = add_bytes  # type: ignore[attr-defined]
 
     processor.scraper_nsd.metrics_collector = nsd_collector
+    processor.scraper_nsd._metrics_collector = nsd_collector  # type: ignore[attr-defined]
     processor.scraper_statements_raw.metrics_collector = nsd_collector
+    processor.scraper_statements_raw._metrics_collector = nsd_collector  # type: ignore[attr-defined]
 
     def _fetch_raw(task: WorkerTaskDTO) -> Mapping[str, Sequence[StatementRawDTO]]:
         add_bytes(3072)
@@ -459,9 +432,6 @@ def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
 
     processor.scraper_statements_raw.fetch.side_effect = _fetch_raw
     add_bytes(2048)
-    download_extra = processor._build_download_extra(
-        scraper=processor.scraper_nsd,
-    )
     processor.policy.normalize_quarter.return_value = SimpleNamespace(
         year=2020, month=3, is_december=False
     )
@@ -487,7 +457,6 @@ def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
         aggregator=aggregator,
         uow=MagicMock(),
         timeline=None,
-        download_extra=download_extra,
     )
 
     ftd_call = next(
@@ -497,6 +466,6 @@ def test_process_statement_nsd_logs_ftd_stage_with_raw_download_extra() -> None:
     )
 
     assert ftd_call["extra"] == {
-        "Download": "3.00KB",
-        "Total download": "5.00KB",
+        "download_bytes": 3072,
+        "network_bytes": 5120,
     }


### PR DESCRIPTION
## Summary
- log NSD and statement stages using the scrapers' metrics collectors instead of ad-hoc download extras
- merge metrics data into logger payloads and update unit tests to assert the new structure

## Testing
- pytest tests/application/processors/test_nsd_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68d0204d658c832ea844ccdd3c2d8ba3