### PR TITLE
Align scraper typing with worker pool outputs

### DIFF
--- a/application/usecases/sync_stock_quote.py
+++ b/application/usecases/sync_stock_quote.py
@@ -68,6 +68,7 @@ class SyncStockQuoteUseCase:
         """
         # Collect company identifiers already stored in the repository
         with self.uow_factory() as uow:
+            results: list[StockQuoteDTO] = []
             try:
                 # existing_codes = [code for (code,) in self.repository_company.iter_existing_by_columns("company_name", uow=uow)]
 

--- a/domain/ports/scraper_base_port.py
+++ b/domain/ports/scraper_base_port.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Union, Tuple, Iterable, Generic, List, Optional, Protocol, TypeVar, runtime_checkable
 
 from application.ports.uow_port import Uow
 
 # Type variable representing the entity type being scraped
 T = TypeVar("T")
-ExistingItem = Union[str, Tuple[str, str]]
+ExistingItem = Union[
+    str,
+    int,
+    Tuple[str, str],
+    Tuple[str, str, datetime | None, datetime],
+]
 
 
 class SaveCallback(Protocol, Generic[T]):
@@ -34,8 +40,8 @@ class ScraperBasePort(Protocol, Generic[T]):
         Args:
             threshold (Optional[int]): Maximum number of items to fetch.
                 If None, no limit is applied.
-            existing_codes (Optional[List[str]]): Identifiers to exclude
-                from the scraping process.
+            existing_codes (Optional[Iterable[ExistingItem]]): Identifiers to
+                exclude from the scraping process.
             save_callback (Optional[SaveCallback[T]]): Optional callback
                 function executed after fetching, typically for persisting
                 results. The callback receives the buffered items and the

--- a/domain/services/financial_normalizer.py
+++ b/domain/services/financial_normalizer.py
@@ -337,6 +337,7 @@ class FinancialNormalizer(FinancialNormalizerPort):
                     return fetched
                 except Exception as e:
                     print(f"Erro no walk do nó {node}: {e}")
+                    return []
             # 3) Executa a árvore inteira sobre as linhas do trimestre
             out: list[StatementFetchedDTO] = []
             for node in roots:

--- a/infrastructure/scrapers/scraper_company_data.py
+++ b/infrastructure/scrapers/scraper_company_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import json
 import time
-from typing import Any, Dict, List, Optional, TypeVar
+from typing import Any, Dict, Iterable, List, Optional, TypeVar
 
 from application.mappers.company_data_mapper import CompanyDataMapper
 from application.mappers.company_data_merger import CompanyDataMerger
@@ -19,7 +19,7 @@ from domain.dtos.company_data_dto import CompanyDataDTO
 from domain.dtos.fetch_results_dto import FetchResultDTO
 from domain.dtos.worker_task_dto import WorkerTaskDTO
 from domain.ports.datacleaner_port import DataCleanerPort
-from domain.ports.scraper_base_port import SaveCallback
+from domain.ports.scraper_base_port import ExistingItem, SaveCallback
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
 from infrastructure.scrapers.scraper_company_detail import DetailFetcher
 
@@ -124,7 +124,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
     def fetch_all(
         self,
         threshold: Optional[int] = None,
-        existing_codes: Optional[List[str]] = None,
+        existing_codes: Optional[Iterable[ExistingItem]] = None,
         save_callback: SaveCallback[CompanyDataDTO] | None = None,
         **kwargs,
     ) -> List[CompanyDataDTO]:
@@ -137,7 +137,7 @@ class CompanyDataScraper(ScraperCompanyDataPort):
         Args:
             threshold (Optional[int]): Number of companies to buffer before flushing.
                 Falls back to repository configuration or 50 if not provided.
-            existing_codes (Optional[List[str]]): Collection of company identifiers to skip.
+            existing_codes (Optional[Iterable[ExistingItem]]): Collection of company identifiers to skip.
             save_callback (Optional[SaveCallback[CompanyDataDTO]]):
                 Callback to persist buffered DTOs when the threshold is reached.
             **kwargs: Reserved for future extensions.
@@ -146,7 +146,9 @@ class CompanyDataScraper(ScraperCompanyDataPort):
             List[CompanyDataDTO]: Fully fetched company detail DTOs.
         """
         # Normalize list of codes to a set for O(1) membership checks
-        self.existing_codes = set(existing_codes or [])
+        self.existing_codes = {
+            code for code in (existing_codes or []) if isinstance(code, str)
+        }
 
         # Determine persistence threshold (explicit > config > default)
         self.threshold = threshold or self.config.repository.persistence_threshold or 50

--- a/infrastructure/scrapers/scraper_nsd.py
+++ b/infrastructure/scrapers/scraper_nsd.py
@@ -16,7 +16,7 @@ from application.ports.uow_port import Uow
 from application.ports.worker_pool_port import WorkerPoolPort
 from domain.dtos.nsd_dto import NsdDTO
 from domain.ports.repository_nsd_port import RepositoryNsdPort
-from domain.ports.scraper_base_port import SaveCallback
+from domain.ports.scraper_base_port import ExistingItem, SaveCallback
 from domain.ports.scraper_nsd_port import ScraperNsdPort
 from infrastructure.adapters.datacleaner_adapter import DataCleaner
 
@@ -63,13 +63,14 @@ class NsdScraper(ScraperNsdPort):
     def fetch_all(
         self,
         threshold: Optional[int] = None,
-        existing_codes: Optional[List[str]] = None,
+        existing_codes: Optional[Iterable[ExistingItem]] = None,
         save_callback: Optional[SaveCallback[NsdDTO]] = None,
         **kwargs,
     ) -> List[NsdDTO]:
         start = int(kwargs.get("start", 1))
         max_nsd = int(kwargs.get("max_nsd", 1))
-        int_codes: Optional[List[int]] = [int(c) for c in existing_codes] if existing_codes else None
+        int_codes_list = [int(c) for c in (existing_codes or [])]
+        int_codes: Optional[List[int]] = int_codes_list or None
         items = list(self.iter_nsd(start=start, threshold=threshold, existing_codes=int_codes, max_nsd=max_nsd))
         if save_callback:
             uow: Uow | None = kwargs.get("uow")

--- a/infrastructure/scrapers/scraper_stock_quote.py
+++ b/infrastructure/scrapers/scraper_stock_quote.py
@@ -4,7 +4,7 @@ import calendar
 from datetime import datetime, date
 import time
 import pandas as pd
-from typing import Iterable, Iterator, Optional, Sequence, Any, List
+from typing import Iterable, Optional, List, Tuple, cast
 
 import requests
 import yfinance as yf  # dependência de infraestrutura
@@ -15,15 +15,17 @@ from application.ports.metrics_collector_port import MetricsCollectorPort
 from application.ports.uow_port import Uow, UowFactoryPort
 from application.ports.worker_pool_port import WorkerPoolPort
 from application.ports.http_client_port import AffinityHttpClientPort
-from application.ports.uow_port import Uow
 from domain.dtos.stock_quote_dto import StockQuoteDTO
 from domain.dtos.worker_task_dto import WorkerTaskDTO
 from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
-from domain.ports.scraper_base_port import SaveCallback
+from domain.ports.scraper_base_port import ExistingItem, SaveCallback
 from domain.ports.scraper_stock_quote_port import ScraperStockQuotePort
 
 from infrastructure.utils.byte_formatter import ByteFormatter
 from infrastructure.utils.save_strategy import SaveStrategy
+
+StockQuoteExistingItem = Tuple[str, str, datetime | None, datetime]
+
 
 class StockQuoteScraper(ScraperStockQuotePort):
     """Scraper de cotações com delta por ticker e saída em DTO."""
@@ -53,14 +55,27 @@ class StockQuoteScraper(ScraperStockQuotePort):
     def fetch_all(
         self,
         threshold: Optional[int] = None,
-        existing_codes: Optional[List[str]] = None,
+        existing_codes: Optional[Iterable[ExistingItem]] = None,
         save_callback: Optional[SaveCallback[StockQuoteDTO]] = None,
         **kwargs,
     ) -> List[StockQuoteDTO]:
         """Stream de DTOs de `start..end` e persistência opcional em lotes."""
 
-        # Normalize list of codes to a set for O(1) membership checks
-        self.existing_codes = existing_codes or []
+        raw_existing = list(existing_codes or [])
+        normalized_existing: list[StockQuoteExistingItem] = []
+        for entry in raw_existing:
+            if isinstance(entry, tuple) and len(entry) == 4:
+                ticker, company_name, start_date, end_date = entry
+                if not isinstance(ticker, str) or not isinstance(company_name, str):
+                    continue
+                if start_date is not None and not isinstance(start_date, datetime):
+                    continue
+                if not isinstance(end_date, datetime):
+                    continue
+                normalized_existing.append((ticker, company_name, start_date, end_date))
+
+        # Normalize list of codes to a deterministic sequence for processing
+        self.existing_codes = normalized_existing
 
         # Determine persistence threshold (explicit > config > default)
         self.threshold = threshold or self.config.repository.persistence_threshold or 50
@@ -86,11 +101,11 @@ class StockQuoteScraper(ScraperStockQuotePort):
 
 
         # Worker that processes a single company entry through the detail pipeline
-        def processor(task: WorkerTaskDTO) -> List[StockQuoteDTO]:  # noqa: F821
+        def processor(task: WorkerTaskDTO) -> List[StockQuoteDTO]:
             index = task.index
-            entry = task.data
+            entry = cast(StockQuoteExistingItem, task.data)
             worker_id = task.worker_id
-            
+
             ticker, company_name, start_date, end_date = entry
 
             symbol = ticker.upper() if "." in ticker else f"{ticker.upper()}.SA"
@@ -134,10 +149,14 @@ class StockQuoteScraper(ScraperStockQuotePort):
 
             # garante ordenação por data
             df = df.sort_index()
-            self._metrics_collector.add_network_bytes(int(df.memory_usage(deep=True).sum()))   
+            memory_usage = df.memory_usage(deep=True)
+            bytes_used = int(memory_usage.sum() if isinstance(memory_usage, pd.Series) else memory_usage)
+            self._metrics_collector.add_network_bytes(bytes_used)
 
-            d_min = df.index[0].date()
-            d_max = df.index[-1].date()
+            first_index = pd.Timestamp(df.index[0])
+            last_index = pd.Timestamp(df.index[-1])
+            d_min = first_index.date()
+            d_max = last_index.date()
 
             close_min = float(df.iloc[0]["Close"])
             close_max = float(df.iloc[-1]["Close"])
@@ -187,9 +206,8 @@ class StockQuoteScraper(ScraperStockQuotePort):
 
 
         # Handler that buffers items and triggers flushes via the strategy
-        def handle_batch(item: Optional[StockQuoteDTO]) -> None:  # noqa: F821
-            # Only buffer non-empty results
-            if item is not None:
+        def handle_batch(batch: List[StockQuoteDTO]) -> None:
+            for item in batch:
                 strategy.handle(item)
 
         # Execute detail processing concurrently
@@ -205,43 +223,49 @@ class StockQuoteScraper(ScraperStockQuotePort):
         # Ensure any residual buffered items are flushed
         strategy.finalize()
 
-        # Filter out None results from the execution
-        results = [r for r in pool_results if r is not None]
+        # Flatten nested worker results, skipping empty batches
+        results: List[StockQuoteDTO] = [
+            dto
+            for batch in pool_results
+            if batch
+            for dto in batch
+        ]
 
         # Return aggregated results and preserve execution metrics
         return results
 
     def has_yahoo_ticker(self, symbol: str, start_date: datetime, end_date: datetime) -> bool:
-            # probe simples para evitar consent/blocked
-            url = (
+        """Valida se um ticker possui dados disponíveis no intervalo informado."""
+        url = (
             f"https://query2.finance.yahoo.com/v8/finance/chart/{symbol}"
             f"?period1={calendar.timegm(start_date.utctimetuple())}"
             f"&period2={calendar.timegm(end_date.utctimetuple())}"
             f"&interval=1d"
         )
 
-            headers = {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                            "AppleWebKit/537.36 (KHTML, like Gecko) "
-                            "Chrome/115.0.0.0 Safari/537.36",
-                "Referer": "https://finance.yahoo.com/",
-            }
-            try:
-                r = requests.get(url, headers=headers)
-                j = r.json()
-                if r.status_code != 200:
-                    # symbol does not exist
-                    return False
-                else:
-                    q = j['chart']['result'][0]['indicators']['quote'][0]
-                    if not q:
-                        # symbol returns no data
-                        return False
-            except Exception as e:
-                # any other error
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/115.0.0.0 Safari/537.36"
+            ),
+            "Referer": "https://finance.yahoo.com/",
+        }
+
+        try:
+            response = requests.get(url, headers=headers, timeout=15)
+            payload = response.json()
+            if response.status_code != 200:
                 return False
-            # data exists for symbol and date range
-            return True
+
+            indicators = payload.get("chart", {}).get("result", [{}])[0].get("indicators", {})
+            quote = indicators.get("quote", [{}])[0]
+            if not quote:
+                return False
+        except Exception:
+            return False
+
+        return True
 
     def get_metrics(self) -> int:
         return self._metrics_collector.network_bytes

--- a/infrastructure/utils/worker_pool.py
+++ b/infrastructure/utils/worker_pool.py
@@ -5,7 +5,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
-from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Iterable, List, Optional, Tuple, TypeVar, cast
 
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
@@ -115,7 +115,7 @@ class WorkerPool(WorkerPoolPort):
         results: List[R] = []
 
         # Bounded queue to apply backpressure to producers
-        queue: Queue = Queue(self.config.worker_pool.queue_size)
+        queue: Queue[Any] = Queue(self.config.worker_pool.queue_size)
 
         # Lock to protect shared writes to the results list and callbacks
         lock = threading.Lock()
@@ -133,16 +133,23 @@ class WorkerPool(WorkerPoolPort):
                     break
 
                 # Unpack the work item and build a task DTO
-                index, entry = item
+                index, entry = cast(Tuple[int, Any], item)
                 task = WorkerTaskDTO(index=index, data=entry, worker_id=worker_id, total_size=total_size)
 
                 # Execute the task-specific processor
-                result:List[R] = processor(task)
+                result = processor(task)
 
                 # Append result and emit optional per-result callback
                 try:
                     with lock:
-                        if result is not None and len(result) > 0:
+                        if result is None:
+                            continue
+
+                        store_result = True
+                        if isinstance(result, list) and len(result) == 0:
+                            store_result = False
+
+                        if store_result:
                             results.append(result)
                             if callable(on_result):
                                 on_result(result)


### PR DESCRIPTION
## Summary
- broaden `ScraperBasePort` item typing so concrete scrapers can accept rich identifiers
- normalize inputs in the stock quote, company data, and NSD scrapers and adjust worker batching/metrics handling
- harden the worker pool callback flow and financial normalizer error handling to satisfy the stricter types

## Testing
- pytest -q *(fails: tests/application/processors/test_nsd_processor.py::test_run_logs_missing_nsd_with_collector_metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68d91d73d1d4832eaa4a00f52424aeaf