### PR TITLE
chore: scaffold indicators service architecture

### DIFF
--- a/application/ports/indicator_processor_port.py
+++ b/application/ports/indicator_processor_port.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+
+from domain.dtos.indicator_dto import IndicatorRawDTO, IndicatorRecordDTO
+from domain.dtos.sync_results_dto import SyncResultsDTO
+
+
+class IndicatorProcessorPort(ABC):
+    """Processor contract that defines the load/transform/persist workflow."""
+
+    @abstractmethod
+    def run(self) -> SyncResultsDTO[IndicatorRecordDTO]:
+        """Execute the full processing pipeline for an indicator source."""
+
+    @abstractmethod
+    def load(self) -> Iterable[IndicatorRawDTO]:
+        """Load raw datapoints from the configured source."""
+
+    @abstractmethod
+    def transform(
+        self, raw_entries: Iterable[IndicatorRawDTO]
+    ) -> Iterable[IndicatorRecordDTO]:
+        """Normalize raw datapoints into standardized indicator records."""
+
+    @abstractmethod
+    def persist(self, records: Iterable[IndicatorRecordDTO]) -> SyncResultsDTO[IndicatorRecordDTO]:
+        """Persist the normalized records and return synchronization metadata."""

--- a/application/services/__init__.py
+++ b/application/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application services for coordinating indicator workflows."""

--- a/application/services/indicators_service.py
+++ b/application/services/indicators_service.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from application.ports.indicator_processor_port import IndicatorProcessorPort
+from domain.dtos.indicator_dto import IndicatorRecordDTO
+from domain.dtos.sync_results_dto import SyncResultsDTO
+
+
+class IndicatorsService:
+    """Coordinate synchronization of economic indicators across sources."""
+
+    def __init__(self, processors: Mapping[str, IndicatorProcessorPort]) -> None:
+        self._processors = dict(processors)
+
+    def available_sources(self) -> tuple[str, ...]:
+        """Expose the registered indicator sources."""
+
+        return tuple(self._processors)
+
+    def run(self, source: str) -> SyncResultsDTO[IndicatorRecordDTO]:
+        """Trigger synchronization for a single source."""
+
+        processor = self._processors[source]
+        return processor.run()

--- a/application/usecases/__init__.py
+++ b/application/usecases/__init__.py
@@ -1,4 +1,5 @@
 from application.usecases.statements_transformer import StatementTransformer
 from application.usecases.sync_company_data import SyncCompanyDataUseCase
+from application.usecases.sync_indicator_bcb import SyncIndicatorBcbUseCase
 
-__all__ = ["StatementTransformer", "SyncCompanyDataUseCase"]
+__all__ = ["StatementTransformer", "SyncCompanyDataUseCase", "SyncIndicatorBcbUseCase"]

--- a/application/usecases/sync_indicator_bcb.py
+++ b/application/usecases/sync_indicator_bcb.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+
+from application.ports.config_port import ConfigPort
+from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import UowFactoryPort
+from application.ports.indicator_processor_port import IndicatorProcessorPort
+from domain.dtos.indicator_dto import IndicatorRawDTO, IndicatorRecordDTO
+from domain.dtos.sync_results_dto import SyncResultsDTO
+from domain.ports.repository_indicator_port import RepositoryIndicatorPort
+from domain.ports.scraper_indicator_bcb_port import ScraperIndicatorBcbPort
+
+
+class SyncIndicatorBcbUseCase(IndicatorProcessorPort):
+    """Use case for synchronizing indicators from Banco Central do Brasil."""
+
+    def __init__(
+        self,
+        *,
+        config: ConfigPort,
+        logger: LoggerPort,
+        repository: RepositoryIndicatorPort,
+        scraper: ScraperIndicatorBcbPort,
+        uow_factory: UowFactoryPort,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> None:
+        self.config = config
+        self.logger = logger
+        self.repository = repository
+        self.scraper = scraper
+        self.uow_factory = uow_factory
+        self.start_date = start_date
+        self.end_date = end_date
+
+    def run(self) -> SyncResultsDTO[IndicatorRecordDTO]:
+        raise NotImplementedError
+
+    def load(self) -> Iterable[IndicatorRawDTO]:
+        raise NotImplementedError
+
+    def transform(self, raw_entries: Iterable[IndicatorRawDTO]) -> Iterable[IndicatorRecordDTO]:
+        raise NotImplementedError
+
+    def persist(self, records: Iterable[IndicatorRecordDTO]) -> SyncResultsDTO[IndicatorRecordDTO]:
+        raise NotImplementedError

--- a/domain/dtos/__init__.py
+++ b/domain/dtos/__init__.py
@@ -7,9 +7,20 @@ from .company_data_dto import (
     CompanyDataListingDTO,
 )
 from .nsd_dto import NsdDTO
+from .indicator_dto import IndicatorRawDTO, IndicatorRecordDTO
 from .statement_fetched_dto import StatementFetchedDTO
 from .statement_raw_dto import StatementRawDTO
 from .worker_task_dto import WorkerTaskDTO
 
-__all__ = ["CodeDTO", "CompanyDataDetailDTO", "CompanyDataDTO", "CompanyDataListingDTO",
-           "NsdDTO", "StatementRawDTO", "StatementFetchedDTO", "WorkerTaskDTO"]
+__all__ = [
+    "CodeDTO",
+    "CompanyDataDetailDTO",
+    "CompanyDataDTO",
+    "CompanyDataListingDTO",
+    "NsdDTO",
+    "StatementRawDTO",
+    "StatementFetchedDTO",
+    "WorkerTaskDTO",
+    "IndicatorRawDTO",
+    "IndicatorRecordDTO",
+]

--- a/domain/dtos/indicator_dto.py
+++ b/domain/dtos/indicator_dto.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping, MutableMapping
+
+
+@dataclass(frozen=True, slots=True)
+class IndicatorRecordDTO:
+    """Normalized representation of a single indicator datapoint."""
+
+    origin: str
+    name: str
+    code: str
+    date: datetime
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class IndicatorRawDTO:
+    """Raw datapoint as returned by a specific external provider."""
+
+    source: str
+    payload: Mapping[str, object] | MutableMapping[str, object]

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -17,10 +17,13 @@ from domain.ports.repository_statements_raw_port import RepositoryStatementsRawP
 from domain.ports.scraper_base_port import ScraperBasePort
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
 from domain.ports.scraper_statements_raw_port import ScraperStatementRawPort
+from domain.ports.repository_indicator_port import RepositoryIndicatorPort
+from domain.ports.scraper_indicator_bcb_port import ScraperIndicatorBcbPort
 
 __all__ = ["CliPort","RepositoryCompanyDataPort", "ConfigPort", "DataCleanerPort",
            "AffinityHttpClientPort", "LoggerPort",
            "RepositoryBasePort", "RepositoryNsdPort",
            "RepositoryStatementsRawPort", "RepositoryStatementFetchedPort",
            "ScraperBasePort", "ScraperCompanyDataPort",
-           "ScraperStatementRawPort", "MetricsCollectorPort", "WorkerPoolPort"]
+           "ScraperStatementRawPort", "MetricsCollectorPort", "WorkerPoolPort",
+           "RepositoryIndicatorPort", "ScraperIndicatorBcbPort"]

--- a/domain/ports/repository_indicator_port.py
+++ b/domain/ports/repository_indicator_port.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Protocol
+
+from domain.dtos.indicator_dto import IndicatorRecordDTO
+
+
+class RepositoryIndicatorPort(Protocol):
+    """Repository boundary for persisting normalized indicator datapoints."""
+
+    def list_existing_codes(self, origin: str) -> Sequence[str]:
+        """Return the set of indicator codes already stored for the origin."""
+
+    def upsert_many(self, records: Iterable[IndicatorRecordDTO]) -> None:
+        """Persist a batch of normalized indicator datapoints atomically."""

--- a/domain/ports/scraper_indicator_bcb_port.py
+++ b/domain/ports/scraper_indicator_bcb_port.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Protocol
+
+from domain.dtos.indicator_dto import IndicatorRawDTO
+
+
+class ScraperIndicatorBcbPort(Protocol):
+    """External data source contract for Banco Central do Brasil indicators."""
+
+    @abstractmethod
+    def fetch(
+        self,
+        *,
+        existing_codes: Iterable[str],
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> Iterable[IndicatorRawDTO]:
+        """Fetch raw datapoints from BCB for the given codes and interval."""

--- a/infrastructure/repositories/__init__.py
+++ b/infrastructure/repositories/__init__.py
@@ -1,4 +1,5 @@
 from infrastructure.repositories.repository_base import RepositoryBase
 from infrastructure.repositories.repository_company_data import RepositoryCompanyData
+from infrastructure.repositories.indicator_repository import IndicatorRepository
 
-__all__ = ["RepositoryBase", "RepositoryCompanyData"]
+__all__ = ["RepositoryBase", "RepositoryCompanyData", "IndicatorRepository"]

--- a/infrastructure/repositories/indicator_repository.py
+++ b/infrastructure/repositories/indicator_repository.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from domain.dtos.indicator_dto import IndicatorRecordDTO
+from domain.ports.repository_indicator_port import RepositoryIndicatorPort
+
+
+class IndicatorRepository(RepositoryIndicatorPort):
+    """Persistence adapter for indicator datapoints."""
+
+    def list_existing_codes(self, origin: str) -> Sequence[str]:
+        raise NotImplementedError
+
+    def upsert_many(self, records: Iterable[IndicatorRecordDTO]) -> None:
+        raise NotImplementedError

--- a/infrastructure/scrapers/__init__.py
+++ b/infrastructure/scrapers/__init__.py
@@ -1,3 +1,4 @@
 from .scraper_company_data import CompanyDataScraper
+from .indicator_bcb_scraper import IndicatorBcbScraper
 
-__all__ = ["CompanyDataScraper"]
+__all__ = ["CompanyDataScraper", "IndicatorBcbScraper"]

--- a/infrastructure/scrapers/indicator_bcb_scraper.py
+++ b/infrastructure/scrapers/indicator_bcb_scraper.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+
+from domain.dtos.indicator_dto import IndicatorRawDTO
+from domain.ports.scraper_indicator_bcb_port import ScraperIndicatorBcbPort
+
+
+class IndicatorBcbScraper(ScraperIndicatorBcbPort):
+    """Concrete scraper for Banco Central do Brasil indicator data."""
+
+    def fetch(
+        self,
+        *,
+        existing_codes: Iterable[str],
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> Iterable[IndicatorRawDTO]:
+        raise NotImplementedError

--- a/presentation/controllers/__init__.py
+++ b/presentation/controllers/__init__.py
@@ -1,3 +1,4 @@
 from .cli import Cli
+from .indicators_controller import IndicatorsController
 
-__all__ = ["Cli"]
+__all__ = ["Cli", "IndicatorsController"]

--- a/presentation/controllers/indicators_controller.py
+++ b/presentation/controllers/indicators_controller.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from application.services.indicators_service import IndicatorsService
+from application.ports.logger_port import LoggerPort
+from domain.dtos.indicator_dto import IndicatorRecordDTO
+from domain.dtos.sync_results_dto import SyncResultsDTO
+
+
+class IndicatorsController:
+    """Presentation layer coordinator for indicator synchronization."""
+
+    def __init__(self, *, logger: LoggerPort, service: IndicatorsService) -> None:
+        self._logger = logger
+        self._service = service
+
+    def sync(self, source: str) -> SyncResultsDTO[IndicatorRecordDTO]:
+        """Trigger synchronization for the requested source."""
+
+        self._logger.log(f"Syncing indicators for source={source}", level="info")
+        return self._service.run(source)


### PR DESCRIPTION
## Summary
- add frozen indicator DTOs and dedicated repository/scraper ports to model the new data source boundaries
- scaffold the indicators service and Banco Central do Brasil use case contracts, exposing them through the presentation controller
- register placeholder infrastructure adapters for future indicator persistence and scraping implementations

## Testing
- pytest -q *(fails: existing test `test_run_logs_missing_nsd_with_collector_metrics` expects different log payload)*

------
https://chatgpt.com/codex/tasks/task_e_68da5e536f48832e9d4bfe9088bc8bff