### PR TITLE
Add indicators configuration for BCB API

### DIFF
--- a/infrastructure/config/__init__.py
+++ b/infrastructure/config/__init__.py
@@ -9,5 +9,17 @@ from infrastructure.config.paths import Path
 from infrastructure.config.repository import RepositoryConfig
 from infrastructure.config.scraping import ScrapingConfig
 from infrastructure.config.worker_pool import WorkerPoolConfig
+from infrastructure.config.indicators import IndicatorsConfig
 
-__all__ = ["DatabaseConfig", "DomainConfig", "ExchangeApiConfig", "FlyConfig", "LoggerConfig", "Path", "RepositoryConfig", "ScrapingConfig", "WorkerPoolConfig"]
+__all__ = [
+    "DatabaseConfig",
+    "DomainConfig",
+    "ExchangeApiConfig",
+    "FlyConfig",
+    "LoggerConfig",
+    "Path",
+    "RepositoryConfig",
+    "ScrapingConfig",
+    "WorkerPoolConfig",
+    "IndicatorsConfig",
+]

--- a/infrastructure/config/config_adapter.py
+++ b/infrastructure/config/config_adapter.py
@@ -15,6 +15,7 @@ from infrastructure.config.repository import RepositoryConfig, load_repository_c
 from infrastructure.config.scraping import ScrapingConfig, load_scraping_config
 from infrastructure.config.statements import StatementsConfig, load_statements_config
 from infrastructure.config.worker_pool import WorkerPoolConfig, load_worker_pool_config
+from infrastructure.config.indicators import IndicatorsConfig, load_indicators_config
 
 
 @dataclass(frozen=True)
@@ -55,4 +56,7 @@ class ConfigAdapter:
 
     # Statements to Scrape
     statements: StatementsConfig = field(default_factory=load_statements_config)
+
+    # Financial indicators integrations (e.g., BCB time series)
+    indicators: IndicatorsConfig = field(default_factory=load_indicators_config)
 

--- a/infrastructure/config/indicators.py
+++ b/infrastructure/config/indicators.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Template URL for fetching time series data from the Brazilian Central Bank (BCB)
+DEFAULT_BCB_URL_TEMPLATE = (
+    "http://api.bcb.gov.br/dados/serie/bcdata.sgs.{codigo_serie}/dados"
+    "?formato=json&dataInicial={data_inicial}&dataFinal={data_final}"
+)
+
+
+@dataclass(frozen=True)
+class IndicatorsConfig:
+    """Immutable configuration for financial indicators integrations.
+
+    Attributes:
+        bcb_url_template (str): URL template for querying the BCB time-series
+            endpoint. The template expects ``codigo_serie`` (series identifier),
+            ``data_inicial`` (start date in YYYY-MM-DD), and ``data_final``
+            (end date in YYYY-MM-DD) placeholders that will be formatted by
+            callers when building requests.
+    """
+
+    # URL template to request data from the BCB API
+    bcb_url_template: str = field(default=DEFAULT_BCB_URL_TEMPLATE)
+
+    def build_bcb_url(self, codigo_serie: str, data_inicial: str, data_final: str) -> str:
+        """Compose the BCB endpoint using the configured template."""
+
+        return self.bcb_url_template.format(
+            codigo_serie=codigo_serie,
+            data_inicial=data_inicial,
+            data_final=data_final,
+        )
+
+
+def load_indicators_config() -> IndicatorsConfig:
+    """Factory method returning the indicators configuration."""
+
+    return IndicatorsConfig(bcb_url_template=DEFAULT_BCB_URL_TEMPLATE)


### PR DESCRIPTION
## Summary
- add a dedicated indicators configuration with the default BCB URL template
- expose the new indicators configuration through the config adapter and package exports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd41300bbc832e99e8cd8fdb3c02c9