### PR TITLE
Update BCB indicator scraper URL generation

### DIFF
--- a/application/usecases/sync_bcb_indicators.py
+++ b/application/usecases/sync_bcb_indicators.py
@@ -67,16 +67,15 @@ class SyncBCBIndicatorUseCase:
         """
         # Collect company identifiers already stored in the repository
         results: list[IndicatorRecordDTO] = []
-        existing_codes = []
+        existing_codes: list[tuple[str, str, datetime | None, datetime]] = []
         try:
             with self.uow_factory() as uow:
                 sources: List[Tuple[str, str]] = self.config.indicators.source["bcb"]
-                start_date = "01/01/1900"
-                end_date = datetime.today().strftime("%d/%m/%Y")
+                start_date = datetime(1900, 1, 1)
+                end_date = datetime.today()
 
                 for (source, code_series) in sources:
-                    url = self.config.indicators.endpoint["bcb"].format(codigo_serie=code_series, dataInicial=start_date, dataFinal=end_date,)
-                    existing_codes.append((source, code_series, url))
+                    existing_codes.append((source, code_series, start_date, end_date))
                 # Fetch from scraper and persist them in batch mode
                 results = self.scraper_indicators.fetch_all(existing_codes=existing_codes, save_callback=self._save_batch)
 

--- a/infrastructure/scrapers/scraper_indicators.py
+++ b/infrastructure/scrapers/scraper_indicators.py
@@ -23,7 +23,7 @@ from domain.ports.scraper_indicators_port import ScraperIndicatorsPort
 from infrastructure.utils.byte_formatter import ByteFormatter
 from infrastructure.utils.save_strategy import SaveStrategy
 
-IndicatorsExistingItem = Tuple[str, str, str]
+IndicatorsExistingItem = Tuple[str, str, datetime | None, datetime]
 
 
 class IndicatorsScraper(ScraperIndicatorsPort):
@@ -92,7 +92,16 @@ class IndicatorsScraper(ScraperIndicatorsPort):
             entry = cast(IndicatorsExistingItem, task.data)
             worker_id = task.worker_id
 
-            name, code_series, url = entry
+            name, code_series, start_date, end_date = entry
+
+            start = start_date or datetime(1900, 1, 1)
+            start_str = start.strftime("%d/%m/%Y")
+            end_str = end_date.strftime("%d/%m/%Y")
+            url = self.config.indicators.endpoint["bcb"].format(
+                codigo_serie=code_series,
+                dataInicial=start_str,
+                dataFinal=end_str,
+            )
 
             try:
                 with self.http_client.borrow_session() as session:


### PR DESCRIPTION
## Summary
- adjust the indicators scraper to unpack start/end dates and construct the BCB URL dynamically
- update the BCB sync use case to pass datetime ranges instead of preformatted URLs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e4aec448832ebd8718eba7d84f7a