### PR TITLE
Refine BCB indicator sync flow

### DIFF
--- a/application/usecases/sync_bcb_indicators.py
+++ b/application/usecases/sync_bcb_indicators.py
@@ -1,7 +1,6 @@
 from typing import Any, List
 
-from datetime import datetime, timedelta
-from dateutil.relativedelta import relativedelta
+from datetime import date, datetime, timedelta
 from typing import Tuple
 
 from application.ports.config_port import ConfigPort
@@ -67,16 +66,34 @@ class SyncBCBIndicatorUseCase:
         """
         # Collect company identifiers already stored in the repository
         results: list[IndicatorRecordDTO] = []
-        existing_codes = []
+        existing_codes: List[Tuple[str, str, datetime | None, datetime]] = []
+        today = datetime.today()
+        default_start_date = datetime.strptime("01/01/1900", "%d/%m/%Y")
         try:
             with self.uow_factory() as uow:
                 sources: List[Tuple[str, str]] = self.config.indicators.source["bcb"]
-                start_date = "01/01/1900"
-                end_date = datetime.today().strftime("%d/%m/%Y")
+                for (name, code_series) in sources:
+                    last_date = self.repository_indicators.get_last_date(
+                        source="BCB", code=code_series, uow=uow
+                    )
 
-                for (source, code_series) in sources:
-                    url = self.config.indicators.endpoint["bcb"].format(codigo_serie=code_series, dataInicial=start_date, dataFinal=end_date,)
-                    existing_codes.append((source, code_series, url))
+                    last_datetime: datetime | None = None
+                    if isinstance(last_date, datetime):
+                        last_datetime = last_date
+                    elif isinstance(last_date, date):
+                        last_datetime = datetime.combine(
+                            last_date, datetime.min.time()
+                        )
+
+                    if last_datetime is not None:
+                        start_date = last_datetime + timedelta(days=1)
+                    else:
+                        start_date = default_start_date
+
+                    if start_date > today:
+                        continue
+
+                    existing_codes.append((name, code_series, start_date, today))
                 # Fetch from scraper and persist them in batch mode
                 results = self.scraper_indicators.fetch_all(existing_codes=existing_codes, save_callback=self._save_batch)
 

--- a/domain/ports/repository_indicators_port.py
+++ b/domain/ports/repository_indicators_port.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 
 from application.ports.uow_port import Uow
+from datetime import datetime
+
 from domain.dtos.indicators_dto import IndicatorRecordDTO
 from domain.ports.repository_base_port import RepositoryBasePort
 
@@ -20,12 +22,5 @@ class RepositoryIndicatorsPort(RepositoryBasePort[IndicatorRecordDTO, int], Prot
         for CRUD operations on CompanyData entities.
     """
 
-    def get_indicator_by_code(self, code: str, *, uow: Uow) -> str | None:
-            """Retrieve the indicator for a record by its code.
-
-        Args:
-            code (str): The indicator code.
-
-        Returns:
-            str: The code associated with the given indicator.
-        """
+    def get_last_date(self, *, source: str, code: str, uow: Uow) -> datetime | None:
+        """Retrieve the most recent persisted date for a given indicator."""

--- a/infrastructure/repositories/repository_indicators.py
+++ b/infrastructure/repositories/repository_indicators.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Set, Tuple, TypeVar
+from datetime import datetime
+from typing import List, Tuple, TypeVar
 
 from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy import func
@@ -69,12 +70,12 @@ class RepositoryIndicators(RepositoryBase[IndicatorRecordDTO, int], RepositoryIn
             self.logger.log(f"Error saving NSD data: {e}", level="error")
             raise
         return None
-    def get_last_date(self, *, ticker: str, uow: Uow):
-        """Retorna a última data persistida para o ticker ou None se não houver histórico."""
+    def get_last_date(self, *, source: str, code: str, uow: Uow) -> datetime | None:
+        """Retorna a última data persistida para a combinação ``source`` e ``code``."""
         session = uow.session
         model, _ = self.get_model_class()
         return (
             session.query(func.max(model.date))
-            .filter(model.ticker == ticker)
+            .filter(model.source == source, model.code == code)
             .scalar()
         )

--- a/infrastructure/scrapers/scraper_indicators.py
+++ b/infrastructure/scrapers/scraper_indicators.py
@@ -23,7 +23,7 @@ from domain.ports.scraper_indicators_port import ScraperIndicatorsPort
 from infrastructure.utils.byte_formatter import ByteFormatter
 from infrastructure.utils.save_strategy import SaveStrategy
 
-IndicatorsExistingItem = Tuple[str, str, str]
+IndicatorsExistingItem = Tuple[str, str, datetime | None, datetime]
 
 
 class IndicatorsScraper(ScraperIndicatorsPort):
@@ -66,6 +66,9 @@ class IndicatorsScraper(ScraperIndicatorsPort):
         # Determine persistence threshold (explicit > config > default)
         self.threshold = threshold or self.config.repository.persistence_threshold or 50
 
+        endpoint_template = self.config.indicators.endpoint["bcb"]
+        default_start_date = datetime.strptime("01/01/1900", "%d/%m/%Y")
+
         # adapter para a estratégia
         def _adapter(items: List[IndicatorRecordDTO], *, uow: Uow) -> None:
             if save_callback is not None:
@@ -92,7 +95,28 @@ class IndicatorsScraper(ScraperIndicatorsPort):
             entry = cast(IndicatorsExistingItem, task.data)
             worker_id = task.worker_id
 
-            name, code_series, url = entry
+            name, code_series, start_date, end_date = entry
+
+            start_dt = (
+                start_date
+                if isinstance(start_date, datetime)
+                else datetime.combine(start_date, datetime.min.time())
+                if isinstance(start_date, date)
+                else default_start_date
+            )
+            end_dt = (
+                end_date
+                if isinstance(end_date, datetime)
+                else datetime.combine(end_date, datetime.min.time())
+                if isinstance(end_date, date)
+                else datetime.today()
+            )
+
+            url = endpoint_template.format(
+                codigo_serie=code_series,
+                dataInicial=start_dt.strftime("%d/%m/%Y"),
+                dataFinal=end_dt.strftime("%d/%m/%Y"),
+            )
 
             try:
                 with self.http_client.borrow_session() as session:


### PR DESCRIPTION
## Summary
- replace the indicator repository contract with a `get_last_date` lookup and implement it for the SQLite adapter
- compute date windows per BCB indicator before scraping and pass them to the scraper
- adapt the indicators scraper to build URLs from date ranges instead of raw strings

## Testing
- pytest *(fails: `tests/application/processors/test_nsd_processor.py::test_run_logs_missing_nsd_with_collector_metrics` is failing in the base branch)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e49a0414832e84fdaffbf142435b