### PR TITLE
Add ratios service pipeline after indicators

### DIFF
--- a/application/usecases/sync_bcb_indicators.py
+++ b/application/usecases/sync_bcb_indicators.py
@@ -6,7 +6,6 @@ from datetime import date, datetime, timedelta
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import Uow, UowFactoryPort
-from application.services.indicator_normalizer_service import IndicatorNormalizerService
 from domain.dtos.indicators_dto import IndicatorRecordDTO
 from domain.dtos.sync_results_dto import SyncResultsDTO
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
@@ -27,7 +26,6 @@ class SyncBCBIndicatorUseCase:
 
         repository_indicators: RepositoryIndicatorsPort,
         scraper_indicators: ScraperIndicatorsPort,
-        indicator_normalizer: IndicatorNormalizerService,
 
         uow_factory: UowFactoryPort,
 
@@ -47,7 +45,6 @@ class SyncBCBIndicatorUseCase:
         self.logger = logger
         self.repository_indicators = repository_indicators
         self.scraper_indicators = scraper_indicators
-        self.indicator_normalizer = indicator_normalizer
         self.uow_factory = uow_factory
 
         self.max_workers = max_workers or (self.config.worker_pool.max_workers or 1)
@@ -134,7 +131,10 @@ class SyncBCBIndicatorUseCase:
                 raw_results = self.scraper_indicators.fetch_all(
                     existing_codes=existing_codes, save_callback=self._save_batch
                 )
-                results = self.indicator_normalizer.normalize(raw_results)
+                results = IndicatorRecordDTO.ensure_iterable(raw_results)
+                results.sort(
+                    key=lambda item: (item.source, item.code, item.observation_date)
+                )
 
         except Exception as e:
             self.logger.log(f"Erro {e}")
@@ -161,7 +161,5 @@ class SyncBCBIndicatorUseCase:
 
         # Convert raw scraper DTOs into domain-level DTOs
         raw_dtos = [IndicatorRecordDTO.from_raw(item) for item in flat_items]
-        normalized = self.indicator_normalizer.normalize(raw_dtos)
-
         # Persist the transformed DTOs in bulk
-        self.repository_indicators.save_all(normalized, uow=uow)
+        self.repository_indicators.save_all(raw_dtos, uow=uow)

--- a/domain/dtos/__init__.py
+++ b/domain/dtos/__init__.py
@@ -7,9 +7,19 @@ from .company_data_dto import (
     CompanyDataListingDTO,
 )
 from .nsd_dto import NsdDTO
+from .ratio_dto import RatioRecordDTO
 from .statement_fetched_dto import StatementFetchedDTO
 from .statement_raw_dto import StatementRawDTO
 from .worker_task_dto import WorkerTaskDTO
 
-__all__ = ["CodeDTO", "CompanyDataDetailDTO", "CompanyDataDTO", "CompanyDataListingDTO",
-           "NsdDTO", "StatementRawDTO", "StatementFetchedDTO", "WorkerTaskDTO"]
+__all__ = [
+    "CodeDTO",
+    "CompanyDataDetailDTO",
+    "CompanyDataDTO",
+    "CompanyDataListingDTO",
+    "NsdDTO",
+    "StatementRawDTO",
+    "StatementFetchedDTO",
+    "WorkerTaskDTO",
+    "RatioRecordDTO",
+]

--- a/domain/dtos/ratio_dto.py
+++ b/domain/dtos/ratio_dto.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True, kw_only=True)
+class RatioRecordDTO:
+    """Represents a computed financial ratio aligned to a common calendar."""
+
+    company_name: str
+    ticker: str
+    date: datetime
+    ratio_code: str
+    ratio_name: str
+    value: float
+    components: Dict[str, float] = field(default_factory=dict)
+    source_indicator: Optional[str] = None

--- a/domain/services/service_indicators.py
+++ b/domain/services/service_indicators.py
@@ -5,7 +5,6 @@ from application.ports.logger_port import LoggerPort
 from application.ports.worker_pool_port import WorkerPoolPort
 from application.ports.uow_port import UowFactoryPort
 from application.ports.http_client_port import AffinityHttpClientPort
-from application.services.indicator_normalizer_service import IndicatorNormalizerService
 from application.usecases.sync_bcb_indicators import SyncBCBIndicatorUseCase
 from domain.dtos.sync_results_dto import SyncResultsDTO
 from domain.dtos.indicators_dto import IndicatorRecordDTO
@@ -23,8 +22,6 @@ class IndicatorsService:
 
         repository_indicators: RepositoryIndicatorsPort,
         scraper_indicators: ScraperIndicatorsPort,
-        indicator_normalizer: IndicatorNormalizerService,
-
         uow_factory: UowFactoryPort,
         # http_client: AffinityHttpClientPort,
     ):
@@ -42,8 +39,6 @@ class IndicatorsService:
 
         self.repository_indicators = repository_indicators
         self.scraper_indicators = scraper_indicators
-        self.indicator_normalizer = indicator_normalizer
-
         self.uow_factory = uow_factory
         # self.http_client = http_client
 
@@ -54,8 +49,6 @@ class IndicatorsService:
 
             repository_indicators=self.repository_indicators,
             scraper_indicators=self.scraper_indicators,
-            indicator_normalizer=self.indicator_normalizer,
-
             uow_factory=self.uow_factory,
             # http_client=self.http_client,
 

--- a/domain/services/service_ratios.py
+++ b/domain/services/service_ratios.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+from typing import Iterable, List, Mapping, Sequence
+
+from application.ports.config_port import ConfigPort
+from application.ports.logger_port import LoggerPort
+from application.services.indicator_normalizer_service import IndicatorNormalizerService
+from domain.dtos.indicators_dto import IndicatorRecordDTO
+from domain.dtos.ratio_dto import RatioRecordDTO
+from domain.dtos.statement_fetched_dto import StatementFetchedDTO
+from domain.dtos.stock_quote_dto import StockQuoteDTO
+from domain.dtos.sync_results_dto import SyncResultsDTO
+
+
+class RatiosService:
+    """Combine statements, stock quotes and indicators into derived ratios."""
+
+    _DEFAULT_IPCA_CODES = {"433"}
+    _DEFAULT_PROFIT_KEYWORDS = ("lucro", "net income", "resultado", "profit")
+
+    def __init__(
+        self,
+        *,
+        config: ConfigPort,
+        logger: LoggerPort,
+        indicator_normalizer: IndicatorNormalizerService,
+    ) -> None:
+        self.config = config
+        self.logger = logger
+        self.indicator_normalizer = indicator_normalizer
+
+        ratios_config = getattr(getattr(config, "ratios", None), "profit_price", None)
+        self.ipca_codes = set(getattr(ratios_config, "ipca_codes", self._DEFAULT_IPCA_CODES))
+        keywords = getattr(ratios_config, "profit_keywords", self._DEFAULT_PROFIT_KEYWORDS)
+        self.profit_keywords = tuple(str(k).lower() for k in keywords)
+
+    def __call__(
+        self,
+        *,
+        statements: Sequence[StatementFetchedDTO] | None = None,
+        stock_quotes: Sequence[StockQuoteDTO] | None = None,
+        indicators: Sequence[IndicatorRecordDTO] | None = None,
+    ) -> SyncResultsDTO[RatioRecordDTO]:
+        return self.run(
+            statements=statements or (),
+            stock_quotes=stock_quotes or (),
+            indicators=indicators or (),
+        )
+
+    def run(
+        self,
+        *,
+        statements: Sequence[StatementFetchedDTO],
+        stock_quotes: Sequence[StockQuoteDTO],
+        indicators: Sequence[IndicatorRecordDTO],
+    ) -> SyncResultsDTO[RatioRecordDTO]:
+        if not stock_quotes or not statements or not indicators:
+            self.logger.log(
+                "RatiosService skipped: missing statements, stock quotes or indicators",
+                level="warning",
+            )
+            return SyncResultsDTO(items=[], metrics=0)
+
+        normalized_indicators = self.indicator_normalizer.normalize(indicators)
+        ipca_series = self._build_indicator_series(normalized_indicators)
+        if not ipca_series:
+            self.logger.log(
+                "RatiosService skipped: unable to locate IPCA indicator series",
+                level="warning",
+            )
+            return SyncResultsDTO(items=[], metrics=0)
+
+        profits = self._build_profit_series(statements)
+        if not profits:
+            self.logger.log(
+                "RatiosService skipped: unable to locate profit statements",
+                level="warning",
+            )
+            return SyncResultsDTO(items=[], metrics=0)
+
+        quotes_by_company = defaultdict(list)
+        for quote in stock_quotes:
+            key = (quote.company_name or "").strip() or quote.ticker
+            quotes_by_company[key].append(quote)
+
+        ratios: List[RatioRecordDTO] = []
+        for company, company_quotes in quotes_by_company.items():
+            profit_timeline = profits.get(company)
+            if not profit_timeline:
+                continue
+
+            profit_timeline.sort(key=lambda item: item[0])
+            for quote in sorted(company_quotes, key=lambda q: q.date):
+                quote_date = quote.date.date()
+                price = quote.adj_close or quote.close
+                if price is None or price == 0:
+                    continue
+
+                ipca_value = ipca_series.get(quote_date)
+                profit_value = self._latest_before(profit_timeline, quote_date)
+
+                if ipca_value is None or profit_value is None:
+                    continue
+
+                deflated_price = price / (ipca_value or 1.0)
+                if deflated_price == 0:
+                    continue
+
+                ratio_value = profit_value / deflated_price
+                ratios.append(
+                    RatioRecordDTO(
+                        company_name=company,
+                        ticker=quote.ticker,
+                        date=quote.date,
+                        ratio_code="profit_ipca_price",
+                        ratio_name="Profit over IPCA-deflated price",
+                        value=ratio_value,
+                        components={
+                            "profit": profit_value,
+                            "price": price,
+                            "ipca": ipca_value,
+                            "deflated_price": deflated_price,
+                        },
+                        source_indicator=next(iter(self.ipca_codes), None),
+                    )
+                )
+
+        ratios.sort(key=lambda item: (item.company_name, item.ticker, item.date))
+        return SyncResultsDTO(items=ratios, metrics=len(ratios))
+
+    def _build_indicator_series(
+        self, normalized: Iterable[IndicatorRecordDTO]
+    ) -> Mapping[date, float]:
+        series: dict[date, float] = {}
+        for record in normalized:
+            if record.code in self.ipca_codes or "ipca" in record.name.lower():
+                series[record.observation_date.date()] = float(record.value or 0.0)
+        return series
+
+    def _build_profit_series(
+        self, statements: Iterable[StatementFetchedDTO]
+    ) -> Mapping[str, List[tuple[date, float]]]:
+        profits: dict[str, List[tuple[date, float]]] = defaultdict(list)
+        for row in statements:
+            description = (row.description or "").lower()
+            if not description:
+                continue
+            if not any(keyword in description for keyword in self.profit_keywords):
+                continue
+
+            company = (row.company_name or "").strip() or row.nsd
+            profits[company].append((row.quarter.date(), float(row.value or 0.0)))
+        return profits
+
+    @staticmethod
+    def _latest_before(
+        items: Sequence[tuple[date, float]], target: date
+    ) -> float | None:
+        latest_value: float | None = None
+        for item_date, value in items:
+            if item_date <= target:
+                latest_value = value
+            else:
+                break
+        return latest_value

--- a/presentation/controllers/cli.py
+++ b/presentation/controllers/cli.py
@@ -1,10 +1,13 @@
-from typing import List
+from typing import List, Sequence
 
 from application.ports.config_port import ConfigPort
 from application.ports.http_client_port import AffinityHttpClientPort
 from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import UowFactoryPort
 from application.ports.worker_pool_port import WorkerPoolPort
+from domain.dtos.indicators_dto import IndicatorRecordDTO
+from domain.dtos.statement_fetched_dto import StatementFetchedDTO
+from domain.dtos.stock_quote_dto import StockQuoteDTO
 from domain.dtos.sync_results_dto import SyncResultsDTO
 from domain.polices.nsd_policy import NsdPolicyPort
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
@@ -26,6 +29,7 @@ from domain.services.ratios_calculator import RatiosCalculatorPort
 from domain.services.service_company_data import CompanyDataService
 from domain.services.service_indicators import IndicatorsService
 from domain.services.service_nsd import NsdService
+from domain.services.service_ratios import RatiosService
 from domain.services.service_stock_quote import StockQuoteService
 
 # from domain.ports.scraper_statements_fetched_port import ScraperStatementFetchedPort
@@ -110,35 +114,35 @@ class Cli:
         # Emit lifecycle start event
         self.logger.log("Start FLY", level="info")
 
-        # # Kick off the company data pipeline
-        # company_results: SyncResultsDTO = self._company_service()
-        # self.logger.log(
-        #     f"Total Company Download: {self.byte_formatter.format_bytes(company_results.metrics)}"
-        # )
-        # try:
-        #     total_download += company_results.metrics
-        # except:
-        #     pass
+        # Kick off the company data pipeline
+        company_results: SyncResultsDTO = self._company_service()
+        self.logger.log(
+            f"Total Company Download: {self.byte_formatter.format_bytes(company_results.metrics)}"
+        )
+        try:
+            total_download += company_results.metrics
+        except Exception:
+            pass
 
-        # # Get NSD and stataments pipeline from B3
-        # statements_results: SyncResultsDTO = self._statements_service()
-        # self.logger.log(
-        #     f"Total Statements Download: {self.byte_formatter.format_bytes(statements_results.metrics)}"
-        # )
-        # try:
-        #     total_download += statements_results.metrics
-        # except:
-        #     pass
+        # Get NSD and statements pipeline from B3
+        statements_results: SyncResultsDTO = self._statements_service()
+        self.logger.log(
+            f"Total Statements Download: {self.byte_formatter.format_bytes(statements_results.metrics)}"
+        )
+        try:
+            total_download += statements_results.metrics
+        except Exception:
+            pass
 
-        # # Get Stock Value for companies
-        # stock_quote_results: SyncResultsDTO = self._stock_quote_service()
-        # self.logger.log(
-        #     f"Total Stock Quote Download: {self.byte_formatter.format_bytes(stock_quote_results.metrics)}"
-        # )
-        # try:
-        #     total_download += stock_quote_results.metrics
-        # except:
-        #     pass
+        # Get Stock Value for companies
+        stock_quote_results: SyncResultsDTO = self._stock_quote_service()
+        self.logger.log(
+            f"Total Stock Quote Download: {self.byte_formatter.format_bytes(stock_quote_results.metrics)}"
+        )
+        try:
+            total_download += stock_quote_results.metrics
+        except Exception:
+            pass
 
         # Get Indicators companies
         indicators_results = self._indicators_service()
@@ -147,7 +151,20 @@ class Cli:
         )
         try:
             total_download += indicators_results.metrics
-        except:
+        except Exception:
+            pass
+
+        ratios_results = self._ratios_service(
+            statements=statements_results.items,
+            stock_quotes=stock_quote_results.items,
+            indicators=indicators_results.items,
+        )
+        self.logger.log(
+            f"Total Ratios Generated: {self.byte_formatter.format_bytes(ratios_results.metrics)}"
+        )
+        try:
+            total_download += ratios_results.metrics
+        except Exception:
             pass
 
         self.logger.log(
@@ -220,7 +237,6 @@ class Cli:
             logger=self.logger,
             repository_indicators=self.repository_indicators,
             scraper_indicators=self.scraper_indicators,
-            indicator_normalizer=self.indicator_normalizer,
             # worker_pool=self.worker_pool,
             uow_factory=self.uow_factory,
             # http_client=self.http_client,
@@ -228,3 +244,22 @@ class Cli:
 
         # run the service
         return indicators_service()
+
+    def _ratios_service(
+        self,
+        *,
+        statements: Sequence[StatementFetchedDTO],
+        stock_quotes: Sequence[StockQuoteDTO],
+        indicators: Sequence[IndicatorRecordDTO],
+    ) -> SyncResultsDTO:
+        ratios_service = RatiosService(
+            config=self.config,
+            logger=self.logger,
+            indicator_normalizer=self.indicator_normalizer,
+        )
+
+        return ratios_service(
+            statements=statements,
+            stock_quotes=stock_quotes,
+            indicators=indicators,
+        )


### PR DESCRIPTION
## Summary
- add a RatiosService that normalizes indicator series and calculates IPCA-deflated profit ratios
- extend the CLI flow to run company, statements, stock quote, indicator, and ratio services sequentially
- adjust the indicator sync use case to return raw records and let the ratios pipeline handle normalization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eaa3d79038832ea296b2111b9cab8f