### PR TITLE
Add daily ratio computation pipeline

### DIFF
--- a/application/services/daily_series_normalizer_service.py
+++ b/application/services/daily_series_normalizer_service.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import hashlib
+from bisect import bisect_right
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence, Tuple
+
+from application.services.indicator_normalizer_service import IndicatorNormalizerService
+from domain.dtos.indicators_dto import IndicatorRecordDTO
+from domain.dtos.normalized_series_dto import (
+    NormalizedMetricSeriesDTO,
+    NormalizedSeriesBundleDTO,
+)
+from domain.dtos.statement_fetched_dto import StatementFetchedDTO
+from domain.dtos.stock_quote_dto import StockQuoteDTO
+
+
+@dataclass(frozen=True)
+class IndicatorFactorRule:
+    """Describe how to transform an indicator into a multiplicative factor."""
+
+    code: str
+    output_code: str
+    method: str  # "index" or "rate"
+    scale: float = 1.0
+
+
+class DailySeriesNormalizerService:
+    """Expand financial, market, and macro series to a shared daily calendar."""
+
+    def __init__(
+        self,
+        *,
+        indicator_normalizer: IndicatorNormalizerService,
+        indicator_factor_rules: Sequence[IndicatorFactorRule] | None = None,
+    ) -> None:
+        self._indicator_normalizer = indicator_normalizer
+        self._indicator_factor_rules = {
+            rule.code: rule for rule in indicator_factor_rules or ()
+        }
+
+    def normalize(
+        self,
+        *,
+        company_id: str,
+        statements: Sequence[StatementFetchedDTO],
+        quotes: Sequence[StockQuoteDTO],
+        indicators: Sequence[IndicatorRecordDTO],
+        start_date: datetime,
+        end_date: datetime,
+    ) -> NormalizedSeriesBundleDTO:
+        if start_date > end_date:
+            raise ValueError("start_date must be earlier than end_date")
+
+        calendar = tuple(self._iter_calendar(start_date, end_date))
+
+        series_map: MutableMapping[str, NormalizedMetricSeriesDTO] = {}
+
+        series_map.update(
+            self._normalize_statements(company_id=company_id, statements=statements, calendar=calendar)
+        )
+        series_map.update(
+            self._normalize_quotes(company_id=company_id, quotes=quotes, calendar=calendar)
+        )
+        series_map.update(
+            self._normalize_indicators(
+                company_id=company_id, indicators=indicators, calendar=calendar
+            )
+        )
+
+        return NormalizedSeriesBundleDTO(
+            company_id=company_id,
+            calendar=calendar,
+            series_map=dict(series_map),
+        )
+
+    @staticmethod
+    def _iter_calendar(start: datetime, end: datetime) -> Iterable[datetime]:
+        current = start
+        while current <= end:
+            yield current
+            current += timedelta(days=1)
+
+    def _normalize_statements(
+        self,
+        *,
+        company_id: str,
+        statements: Sequence[StatementFetchedDTO],
+        calendar: Tuple[datetime, ...],
+    ) -> Mapping[str, NormalizedMetricSeriesDTO]:
+        grouped: Dict[str, Dict[datetime, tuple[float | None, str | None, str | None]]] = {}
+        for row in statements:
+            if row.quarter is None:
+                continue
+            account = str(row.account or "").strip()
+            if not account:
+                continue
+            value = float(row.value) if row.value is not None else None
+            version = str(row.version) if row.version is not None else None
+            digest = self._hash_parts(
+                company_id,
+                "statement",
+                account,
+                row.quarter.isoformat(),
+                value,
+                version,
+            )
+            grouped.setdefault(account, {})[row.quarter] = (value, version, digest)
+
+        series: Dict[str, NormalizedMetricSeriesDTO] = {}
+        for account, points in grouped.items():
+            filled = self._fill_series(calendar, points)
+            series[account] = NormalizedMetricSeriesDTO(
+                company_id=company_id,
+                metric_code=account,
+                calendar=calendar,
+                values=filled[0],
+                versions=filled[1],
+                hashes=filled[2],
+                source="statement",
+            )
+        return series
+
+    def _normalize_quotes(
+        self,
+        *,
+        company_id: str,
+        quotes: Sequence[StockQuoteDTO],
+        calendar: Tuple[datetime, ...],
+    ) -> Mapping[str, NormalizedMetricSeriesDTO]:
+        metrics: Dict[str, Dict[datetime, tuple[float | None, str | None, str | None]]] = {
+            "QUOTE.CLOSE": {},
+            "QUOTE.ADJ_CLOSE": {},
+        }
+
+        for quote in quotes:
+            date = quote.date
+            version = date.date().isoformat()
+            entries = {
+                "QUOTE.CLOSE": quote.close,
+                "QUOTE.ADJ_CLOSE": quote.adj_close,
+            }
+            for metric_code, raw_value in entries.items():
+                if raw_value is None:
+                    continue
+                value = float(raw_value)
+                digest = self._hash_parts(
+                    company_id,
+                    "quote",
+                    metric_code,
+                    date.isoformat(),
+                    value,
+                    quote.ticker,
+                )
+                metrics[metric_code][date] = (value, version, digest)
+
+        series: Dict[str, NormalizedMetricSeriesDTO] = {}
+        for metric_code, points in metrics.items():
+            if not points:
+                continue
+            filled = self._fill_series(calendar, points)
+            series[metric_code] = NormalizedMetricSeriesDTO(
+                company_id=company_id,
+                metric_code=metric_code,
+                calendar=calendar,
+                values=filled[0],
+                versions=filled[1],
+                hashes=filled[2],
+                source="stock_quote",
+            )
+        return series
+
+    def _normalize_indicators(
+        self,
+        *,
+        company_id: str,
+        indicators: Sequence[IndicatorRecordDTO],
+        calendar: Tuple[datetime, ...],
+    ) -> Mapping[str, NormalizedMetricSeriesDTO]:
+        normalized = self._indicator_normalizer.normalize(indicators)
+
+        grouped: Dict[str, Dict[datetime, tuple[float | None, str | None, str | None]]] = {}
+        for record in normalized:
+            date = record.observation_date
+            code = record.code
+            value = float(record.value) if record.value is not None else None
+            version = record.availability_date.isoformat()
+            digest = self._hash_parts(
+                company_id,
+                record.source,
+                code,
+                date.isoformat(),
+                value,
+                version,
+            )
+            grouped.setdefault(code, {})[date] = (value, version, digest)
+
+        base_series: Dict[str, NormalizedMetricSeriesDTO] = {}
+        for code, points in grouped.items():
+            filled = self._fill_series(calendar, points)
+            base_series[code] = NormalizedMetricSeriesDTO(
+                company_id=company_id,
+                metric_code=code,
+                calendar=calendar,
+                values=filled[0],
+                versions=filled[1],
+                hashes=filled[2],
+                source="indicator",
+            )
+
+        derived = self._build_indicator_factors(base_series)
+
+        merged: Dict[str, NormalizedMetricSeriesDTO] = {}
+        merged.update(base_series)
+        merged.update(derived)
+        return merged
+
+    def _build_indicator_factors(
+        self, base_series: Mapping[str, NormalizedMetricSeriesDTO]
+    ) -> Mapping[str, NormalizedMetricSeriesDTO]:
+        derived: Dict[str, NormalizedMetricSeriesDTO] = {}
+        for code, rule in self._indicator_factor_rules.items():
+            series = base_series.get(code)
+            if series is None:
+                continue
+            factor_values: List[float | None] = []
+            base_value: float | None = None
+            cumulative = 1.0
+            for value in series.values:
+                if rule.method == "index":
+                    if base_value is None and value is not None and value != 0:
+                        base_value = value
+                    if base_value in (None, 0) or value is None:
+                        factor_values.append(None if not factor_values else factor_values[-1])
+                    else:
+                        factor_values.append(value / base_value)
+                elif rule.method == "rate":
+                    if value is None:
+                        factor_values.append(cumulative)
+                    else:
+                        cumulative *= 1 + (value * rule.scale)
+                        factor_values.append(cumulative)
+                else:
+                    factor_values.append(None)
+            derived[rule.output_code] = NormalizedMetricSeriesDTO(
+                company_id=series.company_id,
+                metric_code=rule.output_code,
+                calendar=series.calendar,
+                values=tuple(factor_values),
+                versions=series.versions,
+                hashes=series.hashes,
+                source="indicator",
+            )
+        return derived
+
+    @staticmethod
+    def _hash_parts(*parts: object) -> str:
+        payload = "|".join("" if part is None else str(part) for part in parts)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _fill_series(
+        calendar: Tuple[datetime, ...],
+        points: Mapping[datetime, tuple[float | None, str | None, str | None]],
+    ) -> Tuple[Tuple[float | None, ...], Tuple[str | None, ...], Tuple[str | None, ...]]:
+        if not points:
+            size = len(calendar)
+            empty: Tuple[float | None, ...] = tuple(None for _ in range(size))
+            none_str: Tuple[str | None, ...] = tuple(None for _ in range(size))
+            return empty, none_str, none_str
+
+        ordered_dates = sorted(points.keys())
+        values: List[float | None] = []
+        versions: List[str | None] = []
+        hashes: List[str | None] = []
+
+        for day in calendar:
+            idx = bisect_right(ordered_dates, day) - 1
+            if idx < 0:
+                idx = 0
+            elif idx >= len(ordered_dates):
+                idx = len(ordered_dates) - 1
+            key = ordered_dates[idx]
+            value, version, digest = points[key]
+            values.append(value)
+            versions.append(version)
+            hashes.append(digest)
+
+        return tuple(values), tuple(versions), tuple(hashes)

--- a/application/usecases/calculate_ratios.py
+++ b/application/usecases/calculate_ratios.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Sequence
+
+from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import UowFactoryPort
+from application.services.daily_series_normalizer_service import DailySeriesNormalizerService
+from domain.dtos.ratio_result_dto import RatioResultDTO
+from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
+from domain.ports.repository_ratios_port import RepositoryRatiosPort
+from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
+from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
+from domain.services.ratio_service import RatioService
+
+
+class CalculateRatiosUseCase:
+    """Orchestrate calendar normalization and ratio computation for a company."""
+
+    def __init__(
+        self,
+        *,
+        logger: LoggerPort,
+        normalizer: DailySeriesNormalizerService,
+        ratio_service: RatioService,
+        repository_statements: RepositoryStatementFetchedPort,
+        repository_quotes: RepositoryStockQuotePort,
+        repository_indicators: RepositoryIndicatorsPort,
+        repository_ratios: RepositoryRatiosPort,
+        uow_factory: UowFactoryPort,
+    ) -> None:
+        self._logger = logger
+        self._normalizer = normalizer
+        self._ratio_service = ratio_service
+        self._repository_statements = repository_statements
+        self._repository_quotes = repository_quotes
+        self._repository_indicators = repository_indicators
+        self._repository_ratios = repository_ratios
+        self._uow_factory = uow_factory
+
+    def __call__(
+        self,
+        *,
+        company_name: str,
+        start_date: datetime,
+        end_date: datetime,
+        indicator_codes: Iterable[str],
+        indicator_source: str | None = None,
+    ) -> Sequence[RatioResultDTO]:
+        return self.run(
+            company_name=company_name,
+            start_date=start_date,
+            end_date=end_date,
+            indicator_codes=indicator_codes,
+            indicator_source=indicator_source,
+        )
+
+    def run(
+        self,
+        *,
+        company_name: str,
+        start_date: datetime,
+        end_date: datetime,
+        indicator_codes: Iterable[str],
+        indicator_source: str | None = None,
+    ) -> Sequence[RatioResultDTO]:
+        self._logger.log(
+            f"Calculating ratios for {company_name} between {start_date.date()} and {end_date.date()}",
+            level="info",
+        )
+
+        statements = self._repository_statements.get_by_company_and_period(
+            company_name,
+            start=start_date,
+            end=end_date,
+        )
+        quotes = self._repository_quotes.get_by_company_and_period(
+            company_name,
+            start=start_date,
+            end=end_date,
+        )
+        indicators = self._repository_indicators.get_by_codes_and_period(
+            source=indicator_source,
+            codes=indicator_codes,
+            start=start_date,
+            end=end_date,
+        )
+
+        bundle = self._normalizer.normalize(
+            company_id=company_name,
+            statements=statements,
+            quotes=quotes,
+            indicators=indicators,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        ratios = self._ratio_service.calculate(bundle)
+        filtered = [ratio for ratio in ratios if ratio.value is not None]
+
+        with self._uow_factory() as uow:
+            self._repository_ratios.save_all(filtered, uow=uow)
+
+        self._logger.log(
+            f"Computed {len(filtered)} ratio points for {company_name}",
+            level="info",
+        )
+        return filtered

--- a/domain/dtos/__init__.py
+++ b/domain/dtos/__init__.py
@@ -7,9 +7,22 @@ from .company_data_dto import (
     CompanyDataListingDTO,
 )
 from .nsd_dto import NsdDTO
+from .normalized_series_dto import NormalizedMetricSeriesDTO, NormalizedSeriesBundleDTO
+from .ratio_result_dto import RatioResultDTO
 from .statement_fetched_dto import StatementFetchedDTO
 from .statement_raw_dto import StatementRawDTO
 from .worker_task_dto import WorkerTaskDTO
 
-__all__ = ["CodeDTO", "CompanyDataDetailDTO", "CompanyDataDTO", "CompanyDataListingDTO",
-           "NsdDTO", "StatementRawDTO", "StatementFetchedDTO", "WorkerTaskDTO"]
+__all__ = [
+    "CodeDTO",
+    "CompanyDataDetailDTO",
+    "CompanyDataDTO",
+    "CompanyDataListingDTO",
+    "NsdDTO",
+    "StatementRawDTO",
+    "StatementFetchedDTO",
+    "WorkerTaskDTO",
+    "NormalizedMetricSeriesDTO",
+    "NormalizedSeriesBundleDTO",
+    "RatioResultDTO",
+]

--- a/domain/dtos/normalized_series_dto.py
+++ b/domain/dtos/normalized_series_dto.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Mapping, Sequence, Tuple
+
+
+@dataclass(frozen=True, kw_only=True)
+class NormalizedMetricSeriesDTO:
+    """Daily view of a single metric after calendar normalization."""
+
+    company_id: str
+    metric_code: str
+    calendar: Tuple[datetime, ...]
+    values: Tuple[float | None, ...]
+    versions: Tuple[str | None, ...]
+    hashes: Tuple[str | None, ...]
+    source: str
+
+    def __post_init__(self) -> None:
+        size = len(self.calendar)
+        if not (
+            len(self.values) == len(self.versions) == len(self.hashes) == size
+        ):
+            raise ValueError("Normalized series arrays must share the same length")
+
+    @property
+    def length(self) -> int:
+        return len(self.calendar)
+
+    def iter_rows(self) -> Iterable[tuple[datetime, float | None, str | None, str | None]]:
+        return zip(self.calendar, self.values, self.versions, self.hashes)
+
+
+@dataclass(frozen=True, kw_only=True)
+class NormalizedSeriesBundleDTO:
+    """Collection of normalized metric series sharing a daily calendar."""
+
+    company_id: str
+    calendar: Tuple[datetime, ...]
+    series_map: Mapping[str, NormalizedMetricSeriesDTO]
+
+    def __post_init__(self) -> None:
+        for metric, series in self.series_map.items():
+            if series.calendar != self.calendar:
+                raise ValueError(
+                    "All normalized series must share the bundle calendar"
+                )
+            if series.metric_code != metric:
+                raise ValueError(
+                    "Series map keys must match the contained metric codes"
+                )
+
+    def get(self, metric_code: str) -> NormalizedMetricSeriesDTO | None:
+        return self.series_map.get(metric_code)
+
+    def required(self, metric_code: str) -> NormalizedMetricSeriesDTO:
+        series = self.get(metric_code)
+        if series is None:
+            raise KeyError(metric_code)
+        return series
+
+    def keys(self) -> Sequence[str]:
+        return tuple(self.series_map.keys())
+
+    def __len__(self) -> int:
+        return len(self.calendar)

--- a/domain/dtos/ratio_result_dto.py
+++ b/domain/dtos/ratio_result_dto.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping, Optional, Tuple
+
+
+@dataclass(frozen=True, kw_only=True)
+class RatioResultDTO:
+    """Daily ratio computed from normalized financial and market series."""
+
+    id: Optional[int] = None
+    company_id: str
+    ratio_code: str
+    date: datetime
+    value: float | None
+    version: str
+    calculation_hash: str
+    input_versions: Tuple[Tuple[str, str | None], ...]
+    input_hashes: Tuple[Tuple[str, str | None], ...]
+    is_current: bool = True
+
+    @staticmethod
+    def serialize_mapping(data: Mapping[str, str | None]) -> Tuple[Tuple[str, str | None], ...]:
+        return tuple(sorted(data.items()))

--- a/domain/ports/repository_ratios_port.py
+++ b/domain/ports/repository_ratios_port.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from domain.dtos.ratio_result_dto import RatioResultDTO
+from domain.ports.repository_base_port import RepositoryBasePort
+
+
+@runtime_checkable
+class RepositoryRatiosPort(RepositoryBasePort[RatioResultDTO, int], Protocol):
+    """Persistence port for computed ratio metrics."""
+

--- a/domain/services/__init__.py
+++ b/domain/services/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from domain.services.service_company_data import CompanyDataService
+from domain.services.service_ratios import RatiosService
 
-__all__ = ["CompanyDataService"]
+__all__ = ["CompanyDataService", "RatiosService"]

--- a/domain/services/ratio_service.py
+++ b/domain/services/ratio_service.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from importlib import import_module
+from typing import Dict, List, Mapping, Sequence, Set, Tuple
+
+import numpy as np
+
+from application.ports.logger_port import LoggerPort
+from domain.dtos.normalized_series_dto import NormalizedSeriesBundleDTO
+from domain.dtos.ratio_result_dto import RatioResultDTO
+
+
+_METRIC_TOKEN = re.compile(r"^(?P<code>[^()]+?)(?:\((?P<offset>[-+]?\d+)\))?$")
+
+
+@dataclass(frozen=True)
+class _FormulaDefinition:
+    account: str
+    description: str
+    formula: object
+    dependencies: Tuple[str, ...]
+
+
+class _DailyFrame:
+    def __init__(self, bundle: NormalizedSeriesBundleDTO) -> None:
+        self._bundle = bundle
+        self._calendar = bundle.calendar
+        self._company = bundle.company_id
+
+    def __len__(self) -> int:
+        return len(self._calendar)
+
+    @property
+    def index(self) -> List[Tuple[str, datetime]]:
+        return [(self._company, day) for day in self._calendar]
+
+    def __getitem__(self, key: str) -> np.ndarray:
+        code, offset = _parse_metric_token(key)
+        series = self._bundle.get(code)
+        size = len(self._calendar)
+        if series is None:
+            return np.full(size, np.nan)
+
+        base_array = np.array(
+            [np.nan if value is None else float(value) for value in series.values],
+            dtype=float,
+        )
+        if offset == 0:
+            return base_array
+        return _shift_array(base_array, offset)
+
+
+def _parse_metric_token(token: str) -> Tuple[str, int]:
+    match = _METRIC_TOKEN.match(token.strip())
+    if match is None:
+        return token, 0
+    code = match.group("code")
+    offset_raw = match.group("offset")
+    offset = int(offset_raw) if offset_raw is not None else 0
+    return code, offset
+
+
+def _shift_array(array: np.ndarray, offset: int) -> np.ndarray:
+    result = np.full_like(array, np.nan)
+    if offset == 0:
+        return array
+    size = len(array)
+    for idx in range(size):
+        src = idx - offset
+        if 0 <= src < size:
+            result[idx] = array[src]
+    return result
+
+
+def _extract_dependencies(obj: object) -> Set[str]:
+    if isinstance(obj, str):
+        return {obj}
+    if isinstance(obj, (int, float)):
+        return set()
+    deps: Set[str] = set()
+    if isinstance(obj, (list, tuple)):
+        for item in obj:
+            deps.update(_extract_dependencies(item))
+        return deps
+    for value in vars(obj).values():
+        deps.update(_extract_dependencies(value))
+    return deps
+
+
+class RatioService:
+    """Evaluate ratio formulas over normalized daily series."""
+
+    def __init__(
+        self,
+        *,
+        intel_module_path: str | None = None,
+        logger: LoggerPort | None = None,
+    ) -> None:
+        module_path = intel_module_path or "domain.utils.intel"
+        self._module = import_module(module_path)
+        self._logger = logger
+        self._definitions = self._load_definitions()
+
+    def _load_definitions(self) -> Tuple[_FormulaDefinition, ...]:
+        definitions: List[_FormulaDefinition] = []
+        for name in dir(self._module):
+            if not name.startswith("ratios_"):
+                continue
+            value = getattr(self._module, name, None)
+            if not isinstance(value, list):
+                continue
+            for entry in value:
+                account = str(entry.get("account"))
+                description = str(entry.get("description", ""))
+                formula = entry.get("formula")
+                dependencies = tuple(sorted(_extract_dependencies(formula)))
+                definitions.append(
+                    _FormulaDefinition(
+                        account=account,
+                        description=description,
+                        formula=formula,
+                        dependencies=dependencies,
+                    )
+                )
+        return tuple(definitions)
+
+    def calculate(self, bundle: NormalizedSeriesBundleDTO) -> Sequence[RatioResultDTO]:
+        if len(bundle.calendar) == 0:
+            return []
+        frame = _DailyFrame(bundle)
+        results: List[RatioResultDTO] = []
+
+        for definition in self._definitions:
+            try:
+                values = definition.formula(frame)
+            except KeyError as exc:
+                if self._logger is not None:
+                    self._logger.log(
+                        f"Missing metric {exc} for ratio {definition.account}",
+                        level="warning",
+                    )
+                continue
+
+            if not isinstance(values, np.ndarray):
+                values = np.array(values, dtype=float)
+
+            for idx, (company_id, day) in enumerate(frame.index):
+                versions_map: Dict[str, str | None] = {}
+                hashes_map: Dict[str, str | None] = {}
+                missing: List[str] = []
+
+                for token in definition.dependencies:
+                    code, offset = _parse_metric_token(token)
+                    series = bundle.get(code)
+                    if series is None:
+                        versions_map[token] = None
+                        hashes_map[token] = None
+                        missing.append(token)
+                        continue
+                    target = idx + offset
+                    if target < 0 or target >= len(series.values):
+                        versions_map[token] = None
+                        hashes_map[token] = None
+                        missing.append(token)
+                        continue
+                    value = series.values[target]
+                    versions_map[token] = series.versions[target]
+                    hashes_map[token] = series.hashes[target]
+                    if value is None:
+                        missing.append(token)
+
+                ratio_value: float | None
+                raw_value = values[idx]
+                if missing:
+                    ratio_value = None
+                    self._log_gap(definition.account, company_id, day, missing)
+                else:
+                    ratio_value = None if (raw_value is None or math.isnan(raw_value)) else float(raw_value)
+
+                version_token = self._compute_version(definition.account, versions_map)
+                hash_token = self._compute_hash(definition.account, hashes_map, ratio_value)
+
+                results.append(
+                    RatioResultDTO(
+                        company_id=company_id,
+                        ratio_code=definition.account,
+                        date=day,
+                        value=ratio_value,
+                        version=version_token,
+                        calculation_hash=hash_token,
+                        input_versions=RatioResultDTO.serialize_mapping(versions_map),
+                        input_hashes=RatioResultDTO.serialize_mapping(hashes_map),
+                        is_current=True,
+                    )
+                )
+
+        return results
+
+    def _log_gap(
+        self,
+        ratio_code: str,
+        company_id: str,
+        day: datetime,
+        missing: Sequence[str],
+    ) -> None:
+        if self._logger is None:
+            return
+        missing_tokens = ", ".join(sorted(missing))
+        self._logger.log(
+            f"Missing inputs for ratio {ratio_code} company={company_id} date={day.date()}: {missing_tokens}",
+            level="warning",
+        )
+
+    @staticmethod
+    def _compute_version(
+        ratio_code: str,
+        versions: Mapping[str, str | None],
+    ) -> str:
+        ordered = sorted((key, value or "") for key, value in versions.items())
+        payload = "|".join(f"{key}:{value}" for key, value in ordered)
+        digest = hashlib.sha256(f"{ratio_code}|{payload}".encode("utf-8")).hexdigest()
+        return digest
+
+    @staticmethod
+    def _compute_hash(
+        ratio_code: str,
+        hashes: Mapping[str, str | None],
+        value: float | None,
+    ) -> str:
+        ordered = sorted((key, value or "") for key, value in hashes.items())
+        value_token = "" if value is None else f"{value:.12g}"
+        payload = "|".join(f"{key}:{val}" for key, val in ordered)
+        digest = hashlib.sha256(
+            f"{ratio_code}|{payload}|{value_token}".encode("utf-8")
+        ).hexdigest()
+        return digest

--- a/domain/services/service_ratios.py
+++ b/domain/services/service_ratios.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List, Sequence
+
+from application.usecases.calculate_ratios import CalculateRatiosUseCase
+from domain.dtos.ratio_result_dto import RatioResultDTO
+from application.ports.logger_port import LoggerPort
+
+
+class RatiosService:
+    """Application service to trigger ratio computations for one or more companies."""
+
+    def __init__(
+        self,
+        *,
+        logger: LoggerPort,
+        calculate_usecase: CalculateRatiosUseCase,
+    ) -> None:
+        self._logger = logger
+        self._calculate = calculate_usecase
+
+    def run(
+        self,
+        companies: Sequence[str],
+        *,
+        start_date: datetime,
+        end_date: datetime,
+        indicator_codes: Iterable[str],
+        indicator_source: str | None = None,
+    ) -> List[RatioResultDTO]:
+        results: List[RatioResultDTO] = []
+        for company in companies:
+            try:
+                ratios = self._calculate(
+                    company_name=company,
+                    start_date=start_date,
+                    end_date=end_date,
+                    indicator_codes=indicator_codes,
+                    indicator_source=indicator_source,
+                )
+                results.extend(ratios)
+            except Exception as exc:
+                self._logger.log(
+                    f"Ratio computation failed for {company}: {exc}",
+                    level="error",
+                )
+        return results

--- a/domain/utils/intel.py
+++ b/domain/utils/intel.py
@@ -4170,3 +4170,27 @@ indicators_30 = [
         ),
     },
 ]
+
+
+ratios_daily_core = [
+    {
+        "account": "R.EPS",
+        "description": "Lucro por Ação Diário",
+        "formula": Addition("21.01"),
+    },
+    {
+        "account": "R.PE",
+        "description": "Preço/Lucro (P/L) Diário",
+        "formula": Division("QUOTE.CLOSE", "21.01"),
+    },
+    {
+        "account": "R.EPS.IPCA",
+        "description": "Lucro por Ação Deflacionado pelo IPCA",
+        "formula": Division("21.01", "IND.IPCA_FACTOR"),
+    },
+    {
+        "account": "R.EPS.SELIC",
+        "description": "Lucro por Ação Corrigido pela Selic",
+        "formula": Multiplication("21.01", "IND.SELIC_FACTOR"),
+    },
+]

--- a/infrastructure/factories/cli_factory.py
+++ b/infrastructure/factories/cli_factory.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 from application.mappers.company_data_mapper import CompanyDataMapper
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
+from application.services.daily_series_normalizer_service import (
+    DailySeriesNormalizerService,
+    IndicatorFactorRule,
+)
 from application.services.indicator_normalizer_service import IndicatorNormalizerService
+from application.usecases.calculate_ratios import CalculateRatiosUseCase
 from domain.polices.nsd_policy import NsdPolicy
 from domain.services.financial_normalizer import FinancialNormalizer
+from domain.services.ratio_service import RatioService
 from domain.services.ratios_calculator import RatiosCalculator
+from domain.services.service_ratios import RatiosService
 
 # from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
 # from domain.ports.repository_statements_raw_port import RepositoryStatementsRawPort
@@ -20,6 +27,7 @@ from infrastructure.repositories.repository_statements_fetched import StatementF
 from infrastructure.repositories.repository_statements_raw import StatementRawRepository
 from infrastructure.repositories.repository_stock_quote import RepositoryStockQuote
 from infrastructure.repositories.repository_indicators import RepositoryIndicators
+from infrastructure.repositories.repository_ratios import RepositoryRatios
 from infrastructure.scrapers.scraper_company_data import CompanyDataScraper
 from infrastructure.scrapers.scraper_nsd import NsdScraper
 from infrastructure.scrapers.scraper_statements_raw import ScraperStatementRaw
@@ -54,6 +62,7 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
     repository_fetched_statements = StatementFetchedRepository(config=config, logger=logger)
     repository_stock_quote = RepositoryStockQuote(config=config, logger=logger)
     repository_indicators = RepositoryIndicators(config=config, logger=logger)
+    repository_ratios = RepositoryRatios(config=config, logger=logger)
 
     # Unit of Work
     uow_factory = UowFactory(session_factory=repository_nsd.Session)
@@ -137,6 +146,30 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
     )
 
     indicator_normalizer = IndicatorNormalizerService()
+    factor_rules = [
+        IndicatorFactorRule(code="433", output_code="IND.IPCA_FACTOR", method="index"),
+        IndicatorFactorRule(code="11", output_code="IND.SELIC_FACTOR", method="rate", scale=0.01),
+    ]
+    daily_series_normalizer = DailySeriesNormalizerService(
+        indicator_normalizer=indicator_normalizer,
+        indicator_factor_rules=factor_rules,
+    )
+
+    ratio_domain_service = RatioService(logger=logger)
+    calculate_ratios_usecase = CalculateRatiosUseCase(
+        logger=logger,
+        normalizer=daily_series_normalizer,
+        ratio_service=ratio_domain_service,
+        repository_statements=repository_fetched_statements,
+        repository_quotes=repository_stock_quote,
+        repository_indicators=repository_indicators,
+        repository_ratios=repository_ratios,
+        uow_factory=uow_factory,
+    )
+    ratios_service = RatiosService(
+        logger=logger,
+        calculate_usecase=calculate_ratios_usecase,
+    )
 
     # Return the CLI controller with its dependencies injected
     cli = Cli(
@@ -148,6 +181,7 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
         repository_statements_raw=repository_raw_statements,
         repository_statements_fetched=repository_fetched_statements,
         repository_stock_quote=repository_stock_quote,
+        repository_ratios=repository_ratios,
         repository_indicators=repository_indicators,
 
         scraper_company_data=scraper_company_data,
@@ -163,6 +197,7 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
         financial_normalizer=financial_normalizer,
         ratios_calculator=ratios_calculator,
         indicator_normalizer=indicator_normalizer,
+        ratios_service=ratios_service,
     )
 
     return cli

--- a/infrastructure/models/ratio_metric_model.py
+++ b/infrastructure/models/ratio_metric_model.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from sqlalchemy import Boolean, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from domain.dtos.ratio_result_dto import RatioResultDTO
+from infrastructure.models.base_model import BaseModel, _YMDDate
+
+
+class RatioMetricModel(BaseModel):
+    __tablename__ = "tbl_ratio_metric"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    company_name: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("tbl_company.company_name", ondelete="RESTRICT"),
+        index=True,
+        nullable=False,
+    )
+    ratio_code: Mapped[str] = mapped_column(String(64), nullable=False)
+    date: Mapped[datetime] = mapped_column(_YMDDate(), nullable=False, index=True)
+    value: Mapped[float | None] = mapped_column(Float)
+    version: Mapped[str] = mapped_column(String(128), nullable=False)
+    calculation_hash: Mapped[str] = mapped_column(String(128), nullable=False)
+    input_versions: Mapped[str] = mapped_column(Text, nullable=False)
+    input_hashes: Mapped[str] = mapped_column(Text, nullable=False)
+    is_current: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False, index=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "company_name", "ratio_code", "date", "version", name="uq_ratio_metric_versioned"
+        ),
+        Index("ix_ratio_metric_current", "company_name", "ratio_code", "date", "is_current"),
+    )
+
+    @staticmethod
+    def _serialize_pairs(pairs: tuple[tuple[str, str | None], ...]) -> str:
+        return json.dumps([[k, v] for k, v in pairs])
+
+    @staticmethod
+    def _deserialize_pairs(data: str) -> tuple[tuple[str, str | None], ...]:
+        loaded = json.loads(data or "[]")
+        return tuple((str(k), v if v is None else str(v)) for k, v in loaded)
+
+    @classmethod
+    def from_dto(cls, dto: RatioResultDTO) -> "RatioMetricModel":
+        return cls(
+            id=dto.id,
+            company_name=dto.company_id,
+            ratio_code=dto.ratio_code,
+            date=dto.date,
+            value=dto.value,
+            version=dto.version,
+            calculation_hash=dto.calculation_hash,
+            input_versions=cls._serialize_pairs(dto.input_versions),
+            input_hashes=cls._serialize_pairs(dto.input_hashes),
+            is_current=dto.is_current,
+        )
+
+    def to_dto(self) -> RatioResultDTO:
+        return RatioResultDTO(
+            id=self.id,
+            company_id=self.company_name,
+            ratio_code=self.ratio_code,
+            date=self.date,
+            value=self.value,
+            version=self.version,
+            calculation_hash=self.calculation_hash,
+            input_versions=self._deserialize_pairs(self.input_versions),
+            input_hashes=self._deserialize_pairs(self.input_hashes),
+            is_current=self.is_current,
+        )

--- a/infrastructure/repositories/repository_indicators.py
+++ b/infrastructure/repositories/repository_indicators.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, Tuple, TypeVar
+from typing import Iterable, List, Sequence, Tuple, TypeVar
 
 from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy import func
@@ -79,3 +79,24 @@ class RepositoryIndicators(RepositoryBase[IndicatorRecordDTO, int], RepositoryIn
             .filter(model.source == source, model.code == code)
             .scalar()
         )
+
+    def get_by_codes_and_period(
+        self,
+        *,
+        source: str | None,
+        codes: Iterable[str],
+        start: datetime,
+        end: datetime,
+    ) -> Sequence[IndicatorRecordDTO]:
+        with self.Session() as session:
+            query = session.query(IndicatorModel).filter(
+                IndicatorModel.observation_date >= start,
+                IndicatorModel.observation_date <= end,
+            )
+            if source is not None:
+                query = query.filter(IndicatorModel.source == source)
+            code_list = list(codes)
+            if code_list:
+                query = query.filter(IndicatorModel.code.in_(code_list))
+            results = query.order_by(IndicatorModel.observation_date).all()
+            return [row.to_dto() for row in results]

--- a/infrastructure/repositories/repository_ratios.py
+++ b/infrastructure/repositories/repository_ratios.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple, TypeVar
+
+from sqlalchemy import update
+from sqlalchemy.dialects.sqlite import insert
+
+from application.ports.config_port import ConfigPort
+from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import Uow
+from domain.dtos.ratio_result_dto import RatioResultDTO
+from domain.ports.repository_ratios_port import RepositoryRatiosPort
+from infrastructure.models.ratio_metric_model import RatioMetricModel
+from infrastructure.repositories.repository_base import RepositoryBase
+from infrastructure.utils.list_flatenner import ListFlattener
+
+T = TypeVar("T")
+
+
+class RepositoryRatios(RepositoryBase[RatioResultDTO, int], RepositoryRatiosPort):
+    """SQLite-backed repository for ratio metrics."""
+
+    def __init__(self, config: ConfigPort, logger: LoggerPort) -> None:
+        super().__init__(config, logger)
+        self.config = config
+        self.logger = logger
+
+    def get_model_class(self) -> Tuple[type, tuple]:
+        return RatioMetricModel, (RatioMetricModel.id,)
+
+    def save_all(self, items: List[T], *, uow: Uow) -> None:
+        if uow is None:
+            raise RuntimeError("Ratio repository requires an explicit unit of work")
+
+        session = uow.session
+        model, _ = self.get_model_class()
+        flat_items = ListFlattener.flatten(items)
+        valid_items: Iterable[RatioResultDTO] = [
+            i for i in flat_items if isinstance(i, RatioResultDTO)
+        ]
+
+        for dto in valid_items:
+            obj = model.from_dto(dto)
+            data = {c.name: getattr(obj, c.name) for c in model.__table__.columns}
+
+            stmt = insert(model).values(**data)
+            update_payload = {
+                c.name: getattr(stmt.excluded, c.name)
+                for c in model.__table__.columns
+                if c.name not in {"id", "version"}
+            }
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["company_name", "ratio_code", "date", "version"],
+                set_=update_payload,
+            )
+            session.execute(stmt)
+
+            session.execute(
+                update(model)
+                .where(
+                    model.company_name == dto.company_id,
+                    model.ratio_code == dto.ratio_code,
+                    model.date == dto.date,
+                    model.version != dto.version,
+                    model.is_current.is_(True),
+                )
+                .values(is_current=False)
+            )

--- a/infrastructure/repositories/repository_statements_fetched.py
+++ b/infrastructure/repositories/repository_statements_fetched.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from datetime import datetime
+from typing import List, Sequence, Tuple
 
 from sqlalchemy.dialects.sqlite import insert
 
@@ -78,4 +79,23 @@ class StatementFetchedRepository(
                 .all()
             )
             return [r.to_dto() for r in results]
+
+    def get_by_company_and_period(
+        self,
+        company_name: str,
+        *,
+        start: datetime,
+        end: datetime,
+    ) -> Sequence[StatementFetchedDTO]:
+        """Return statements within the provided date range (inclusive)."""
+
+        with self.Session() as session:
+            results = (
+                session.query(StatementFetchedModel)
+                .filter(StatementFetchedModel.company_name == company_name)
+                .filter(StatementFetchedModel.quarter >= start)
+                .filter(StatementFetchedModel.quarter <= end)
+                .all()
+            )
+            return [row.to_dto() for row in results]
 

--- a/infrastructure/repositories/repository_stock_quote.py
+++ b/infrastructure/repositories/repository_stock_quote.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Set, Tuple, TypeVar
+from datetime import datetime
+from typing import List, Sequence, Set, Tuple, TypeVar
 
 from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy import func
@@ -78,3 +79,21 @@ class RepositoryStockQuote(RepositoryBase[StockQuoteDTO, int], RepositoryStockQu
             .filter(model.ticker == ticker)
             .scalar()
         )
+
+    def get_by_company_and_period(
+        self,
+        company_name: str,
+        *,
+        start: datetime,
+        end: datetime,
+    ) -> Sequence[StockQuoteDTO]:
+        with self.Session() as session:
+            results = (
+                session.query(StockQuoteModel)
+                .filter(StockQuoteModel.company_name == company_name)
+                .filter(StockQuoteModel.date >= start)
+                .filter(StockQuoteModel.date <= end)
+                .order_by(StockQuoteModel.date)
+                .all()
+            )
+            return [row.to_dto() for row in results]

--- a/presentation/controllers/cli.py
+++ b/presentation/controllers/cli.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from typing import List
 
 from application.ports.config_port import ConfigPort
@@ -14,6 +15,7 @@ from domain.ports.repository_statements_fetched_port import (
     RepositoryStatementFetchedPort,
 )
 from domain.ports.repository_statements_raw_port import RepositoryStatementsRawPort
+from domain.ports.repository_ratios_port import RepositoryRatiosPort
 from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
 from domain.ports.scraper_indicators_port import ScraperIndicatorsPort
@@ -26,6 +28,7 @@ from domain.services.ratios_calculator import RatiosCalculatorPort
 from domain.services.service_company_data import CompanyDataService
 from domain.services.service_indicators import IndicatorsService
 from domain.services.service_nsd import NsdService
+from domain.services.service_ratios import RatiosService
 from domain.services.service_stock_quote import StockQuoteService
 
 # from domain.ports.scraper_statements_fetched_port import ScraperStatementFetchedPort
@@ -55,6 +58,7 @@ class Cli:
         repository_statements_raw: RepositoryStatementsRawPort,
         repository_statements_fetched: RepositoryStatementFetchedPort,
         repository_stock_quote: RepositoryStockQuotePort,
+        repository_ratios: RepositoryRatiosPort,
         repository_indicators: RepositoryIndicatorsPort,
 
         scraper_nsd: ScraperNsdPort,
@@ -70,6 +74,7 @@ class Cli:
         financial_normalizer: FinancialNormalizerPort,
         ratios_calculator: RatiosCalculatorPort,
         indicator_normalizer: IndicatorNormalizerService,
+        ratios_service: RatiosService,
     ) -> None:
         """Initialize the CLI with injected ports."""
         # Store injected dependencies for later composition
@@ -81,6 +86,7 @@ class Cli:
         self.repository_statements_raw = repository_statements_raw
         self.repository_statements_fetched = repository_statements_fetched
         self.repository_stock_quote = repository_stock_quote
+        self.repository_ratios = repository_ratios
         self.repository_indicators = repository_indicators
 
         self.scraper_company_data = scraper_company_data
@@ -97,6 +103,7 @@ class Cli:
         self.financial_normalizer = financial_normalizer
         self.ratios_calculator = ratios_calculator
         self.indicator_normalizer = indicator_normalizer
+        self.ratios_service = ratios_service
 
         self.byte_formatter = ByteFormatter()
 
@@ -149,6 +156,12 @@ class Cli:
             total_download += indicators_results.metrics
         except:
             pass
+
+        ratio_results = self._ratio_service()
+        self.logger.log(
+            f"Total ratios computed: {len(ratio_results)}",
+            level="info",
+        )
 
         self.logger.log(
             f"Total Download: {self.byte_formatter.format_bytes(total_download)}"
@@ -228,3 +241,37 @@ class Cli:
 
         # run the service
         return indicators_service()
+
+    def _ratio_service(self) -> list:
+        companies = self._load_company_names()
+        if not companies:
+            self.logger.log(
+                "No companies available for ratio computation",
+                level="warning",
+            )
+            return []
+
+        end_date = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+        start_date = end_date - timedelta(days=365)
+        indicator_codes = self._default_indicator_codes()
+
+        return self.ratios_service.run(
+            companies,
+            start_date=start_date,
+            end_date=end_date,
+            indicator_codes=indicator_codes,
+            indicator_source=None,
+        )
+
+    def _load_company_names(self) -> list[str]:
+        with self.uow_factory() as uow:
+            rows = self.repository_company.get_all_by_columns(
+                "company_name",
+                uow=uow,
+                include_nulls=False,
+            )
+        return [row[0] for row in rows if row and row[0]]
+
+    @staticmethod
+    def _default_indicator_codes() -> list[str]:
+        return ["433", "11"]


### PR DESCRIPTION
## Summary
- add daily calendar normalizer and ratio domain service to evaluate intel formulas on unified data
- persist ratio outputs with version and hash tracking via a new repository and model
- wire the CLI pipeline to trigger ratio calculations after the indicators sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eaab057b04832ea56459593960de79