### PR TITLE
Add Selic-deflated revenue-to-price ratio per ticker

### DIFF
--- a/application/services/daily_series_normalizer_service.py
+++ b/application/services/daily_series_normalizer_service.py
@@ -129,10 +129,7 @@ class DailySeriesNormalizerService:
         quotes: Sequence[StockQuoteDTO],
         calendar: Tuple[datetime, ...],
     ) -> Mapping[str, NormalizedMetricSeriesDTO]:
-        metrics: Dict[str, Dict[datetime, tuple[float | None, str | None, str | None]]] = {
-            "QUOTE.CLOSE": {},
-            "QUOTE.ADJ_CLOSE": {},
-        }
+        metrics: Dict[str, Dict[datetime, tuple[float | None, str | None, str | None]]] = {}
 
         for quote in quotes:
             date = quote.date
@@ -140,6 +137,8 @@ class DailySeriesNormalizerService:
             entries = {
                 "QUOTE.CLOSE": quote.close,
                 "QUOTE.ADJ_CLOSE": quote.adj_close,
+                f"QUOTE.{quote.ticker}.CLOSE": quote.close,
+                f"QUOTE.{quote.ticker}.ADJ_CLOSE": quote.adj_close,
             }
             for metric_code, raw_value in entries.items():
                 if raw_value is None:
@@ -153,7 +152,8 @@ class DailySeriesNormalizerService:
                     value,
                     quote.ticker,
                 )
-                metrics[metric_code][date] = (value, version, digest)
+                bucket = metrics.setdefault(metric_code, {})
+                bucket[date] = (value, version, digest)
 
         series: Dict[str, NormalizedMetricSeriesDTO] = {}
         for metric_code, points in metrics.items():

--- a/domain/services/ratio_domain_service.py
+++ b/domain/services/ratio_domain_service.py
@@ -11,7 +11,10 @@ from typing import Dict, List, Mapping, Sequence, Set, Tuple
 import numpy as np
 
 from application.ports.logger_port import LoggerPort
-from domain.dtos.normalized_series_dto import NormalizedSeriesBundleDTO
+from domain.dtos.normalized_series_dto import (
+    NormalizedMetricSeriesDTO,
+    NormalizedSeriesBundleDTO,
+)
 from domain.dtos.ratio_result_dto import RatioResultDTO
 
 
@@ -199,7 +202,114 @@ class RatioDomainService:
                     )
                 )
 
+        results.extend(self._calculate_revenue_price_ratios(frame, bundle))
+
         return results
+
+    def _calculate_revenue_price_ratios(
+        self,
+        frame: _DailyFrame,
+        bundle: NormalizedSeriesBundleDTO,
+    ) -> List[RatioResultDTO]:
+        revenue_series = bundle.get("03.01")
+        selic_series = bundle.get("IND.SELIC_FACTOR")
+        if revenue_series is None or selic_series is None:
+            return []
+
+        tickers = sorted(
+            {
+                code.split(".")[1]
+                for code in bundle.keys()
+                if code.startswith("QUOTE.") and code.endswith(".CLOSE") and code.count(".") == 2
+            }
+        )
+        if not tickers:
+            return []
+
+        revenue_array = frame["03.01"]
+        selic_array = frame["IND.SELIC_FACTOR"]
+        results: List[RatioResultDTO] = []
+
+        for ticker in tickers:
+            price_code = f"QUOTE.{ticker}.CLOSE"
+            price_series = bundle.get(price_code)
+            if price_series is None:
+                continue
+            price_array = frame[price_code]
+            ratio_values = self._compute_revenue_price_values(
+                revenue_array,
+                price_array,
+                selic_array,
+            )
+
+            dependencies: List[tuple[str, NormalizedMetricSeriesDTO]] = [
+                ("03.01", revenue_series),
+                (price_code, price_series),
+                ("IND.SELIC_FACTOR", selic_series),
+            ]
+
+            ratio_code = f"R.REV_PRICE.{ticker}"
+            for idx, (company_id, day) in enumerate(frame.index):
+                versions_map: Dict[str, str | None] = {}
+                hashes_map: Dict[str, str | None] = {}
+                missing: List[str] = []
+
+                for token, series in dependencies:
+                    versions_map[token] = series.versions[idx]
+                    hashes_map[token] = series.hashes[idx]
+                    value = series.values[idx]
+                    if value is None:
+                        missing.append(token)
+                    elif token == price_code and value <= 0:
+                        missing.append(token)
+                    elif token == "IND.SELIC_FACTOR" and value <= 0:
+                        missing.append(token)
+
+                raw_value = ratio_values[idx]
+                if missing or raw_value is None or math.isnan(raw_value):
+                    ratio_value = None
+                    if missing:
+                        self._log_gap(ratio_code, company_id, day, missing)
+                else:
+                    ratio_value = float(raw_value)
+
+                version_token = self._compute_version(ratio_code, versions_map)
+                hash_token = self._compute_hash(ratio_code, hashes_map, ratio_value)
+
+                results.append(
+                    RatioResultDTO(
+                        company_id=company_id,
+                        ratio_code=ratio_code,
+                        date=day,
+                        value=ratio_value,
+                        version=version_token,
+                        calculation_hash=hash_token,
+                        input_versions=RatioResultDTO.serialize_mapping(versions_map),
+                        input_hashes=RatioResultDTO.serialize_mapping(hashes_map),
+                        is_current=True,
+                    )
+                )
+
+        return results
+
+    @staticmethod
+    def _compute_revenue_price_values(
+        revenue: np.ndarray,
+        price: np.ndarray,
+        selic: np.ndarray,
+    ) -> np.ndarray:
+        size = len(revenue)
+        ratios = np.full(size, np.nan, dtype=float)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            valid_price = ~np.isnan(revenue) & ~np.isnan(price) & (price > 0)
+            ratios[valid_price] = revenue[valid_price] / price[valid_price]
+
+            valid_selic = ~np.isnan(selic) & (selic > 0)
+            combined_valid = valid_price & valid_selic
+            ratios[combined_valid] = ratios[combined_valid] / selic[combined_valid]
+            ratios[valid_price & ~combined_valid] = np.nan
+
+        return ratios
 
     def _log_gap(
         self,

--- a/tests/application/services/test_daily_series_normalizer_service.py
+++ b/tests/application/services/test_daily_series_normalizer_service.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+
+from application.services.daily_series_normalizer_service import (
+    DailySeriesNormalizerService,
+)
+from application.services.indicator_normalizer_service import (
+    IndicatorNormalizerService,
+)
+from domain.dtos.stock_quote_dto import StockQuoteDTO
+
+
+def test_normalize_quotes_creates_ticker_specific_metrics() -> None:
+    normalizer = DailySeriesNormalizerService(
+        indicator_normalizer=IndicatorNormalizerService(),
+        indicator_factor_rules=(),
+    )
+
+    quotes = [
+        StockQuoteDTO(
+            company_name="COMPANY",
+            ticker="ABCD3",
+            date=datetime(2023, 1, 1),
+            open=10.0,
+            low=9.5,
+            high=10.5,
+            close=10.2,
+            adj_close=10.1,
+            volume=1000,
+            currency="BRL",
+        ),
+        StockQuoteDTO(
+            company_name="COMPANY",
+            ticker="ABCD4",
+            date=datetime(2023, 1, 2),
+            open=20.0,
+            low=19.5,
+            high=20.5,
+            close=20.2,
+            adj_close=20.0,
+            volume=2000,
+            currency="BRL",
+        ),
+    ]
+
+    bundle = normalizer.normalize(
+        company_id="COMPANY",
+        statements=[],
+        quotes=quotes,
+        indicators=[],
+        start_date=datetime(2023, 1, 1),
+        end_date=datetime(2023, 1, 3),
+    )
+
+    assert bundle.get("QUOTE.ABCD3.CLOSE") is not None
+    assert bundle.get("QUOTE.ABCD4.CLOSE") is not None

--- a/tests/domain/services/test_ratio_domain_service.py
+++ b/tests/domain/services/test_ratio_domain_service.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+
+import pytest
+
+from domain.dtos.normalized_series_dto import (
+    NormalizedMetricSeriesDTO,
+    NormalizedSeriesBundleDTO,
+)
+from domain.services.ratio_domain_service import RatioDomainService
+
+
+def _make_series(
+    *,
+    code: str,
+    company_id: str,
+    calendar: tuple[datetime, ...],
+    values: tuple[float | None, ...],
+    versions: tuple[str | None, ...],
+    hashes: tuple[str | None, ...],
+    source: str,
+) -> NormalizedMetricSeriesDTO:
+    return NormalizedMetricSeriesDTO(
+        company_id=company_id,
+        metric_code=code,
+        calendar=calendar,
+        values=values,
+        versions=versions,
+        hashes=hashes,
+        source=source,
+    )
+
+
+def test_revenue_price_ratio_per_ticker() -> None:
+    company_id = "COMPANY"
+    calendar = (
+        datetime(2023, 1, 1),
+        datetime(2023, 1, 2),
+    )
+
+    series_map = {
+        "03.01": _make_series(
+            code="03.01",
+            company_id=company_id,
+            calendar=calendar,
+            values=(100.0, 200.0),
+            versions=("rev-1", "rev-2"),
+            hashes=("hash-rev-1", "hash-rev-2"),
+            source="statement",
+        ),
+        "QUOTE.ABC3.CLOSE": _make_series(
+            code="QUOTE.ABC3.CLOSE",
+            company_id=company_id,
+            calendar=calendar,
+            values=(10.0, 20.0),
+            versions=("px3-1", "px3-2"),
+            hashes=("hash-px3-1", "hash-px3-2"),
+            source="stock_quote",
+        ),
+        "QUOTE.ABC4.CLOSE": _make_series(
+            code="QUOTE.ABC4.CLOSE",
+            company_id=company_id,
+            calendar=calendar,
+            values=(25.0, 40.0),
+            versions=("px4-1", "px4-2"),
+            hashes=("hash-px4-1", "hash-px4-2"),
+            source="stock_quote",
+        ),
+        "IND.SELIC_FACTOR": _make_series(
+            code="IND.SELIC_FACTOR",
+            company_id=company_id,
+            calendar=calendar,
+            values=(1.0, 1.1),
+            versions=("selic-1", "selic-2"),
+            hashes=("hash-selic-1", "hash-selic-2"),
+            source="indicator",
+        ),
+    }
+
+    bundle = NormalizedSeriesBundleDTO(
+        company_id=company_id,
+        calendar=calendar,
+        series_map=series_map,
+    )
+
+    service = RatioDomainService(logger=None)
+
+    ratios = service.calculate(bundle)
+    revenue_price_ratios = sorted(
+        [r for r in ratios if r.ratio_code.startswith("R.REV_PRICE.")],
+        key=lambda item: (item.ratio_code, item.date),
+    )
+
+    assert len(revenue_price_ratios) == 4
+
+    expected = {
+        ("R.REV_PRICE.ABC3", calendar[0]): pytest.approx(10.0),
+        ("R.REV_PRICE.ABC3", calendar[1]): pytest.approx(200.0 / 20.0 / 1.1),
+        ("R.REV_PRICE.ABC4", calendar[0]): pytest.approx(4.0),
+        ("R.REV_PRICE.ABC4", calendar[1]): pytest.approx(200.0 / 40.0 / 1.1),
+    }
+
+    for ratio in revenue_price_ratios:
+        key = (ratio.ratio_code, ratio.date)
+        assert key in expected
+        assert ratio.value == expected[key]
+        inputs = dict(ratio.input_versions)
+        assert inputs["03.01"]
+        assert any(token.endswith(".CLOSE") for token in inputs)
+        assert inputs["IND.SELIC_FACTOR"]


### PR DESCRIPTION
## Summary
- extend quote normalization to keep ticker-specific closing and adjusted closing series
- compute a revenue-to-price ratio per ticker deflated by the Selic factor and persist the results
- cover the new behavior with unit tests for the normalizer and the ratio domain service

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68eaf57820bc832eb08e89a09127b305