### PR TITLE
Persist ratios in long format

### DIFF
--- a/application/usecases/normalize_ratios.py
+++ b/application/usecases/normalize_ratios.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 import time
 from datetime import datetime, timedelta
@@ -11,7 +12,9 @@ import domain.utils.intel as intel
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import Uow, UowFactoryPort
+from domain.dtos.company_data_dto import CompanyDataDTO
 from domain.dtos.indicators_dto import IndicatorsDTO
+from domain.dtos.ratio_dto import RatioDTO
 from domain.dtos.sync_results_dto import SyncResultsDTO
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
@@ -77,6 +80,7 @@ class NormalizeUseCase:
         """
         data:dict = {}
         metrics=0
+        all_ratios: List[RatioDTO] = []
         code_parameter = re.compile(r"^[A-Z]{4}\d{1,2}[A-Z]?$")
         start_time = time.perf_counter()
         with self.uow_factory() as uow:
@@ -98,7 +102,8 @@ class NormalizeUseCase:
                     # if i > 30:
                     #     break
                     rows = self.repository_company.get_by_column_values(values=[("company_name", company_name)], uow=uow)
-                    pre_ticker_codes:List = next((row.ticker_codes for row in rows if row.company_name == company_name),[],)
+                    company_row: Optional[CompanyDataDTO] = next((row for row in rows if row.company_name == company_name), None)
+                    pre_ticker_codes:List = company_row.ticker_codes if company_row else []
                     ticker_codes = [
                         code for code in pre_ticker_codes
                         if isinstance(code, str) and len(code) >= 5 and code_parameter.match(code)
@@ -112,6 +117,15 @@ class NormalizeUseCase:
                                 len_q = len(data['quotes'])
                                 company_data = self._treat_data(data)
                                 df_ratios:pd.DataFrame = self._create_ratios(company_data)
+                                ratios_long = self._build_ratio_dtos(
+                                    df_ratios=df_ratios,
+                                    company=company_row,
+                                    ticker_codes=ticker_codes,
+                                )
+                                if ratios_long:
+                                    self.repository_indicators.save_ratios_batch(ratios_long, uow=uow)
+                                    all_ratios.extend(ratios_long)
+                                    metrics += len(ratios_long)
 
                     progress={
                             "index": i,
@@ -133,7 +147,7 @@ class NormalizeUseCase:
                 raise
 
         results:SyncResultsDTO = SyncResultsDTO(
-            items=df_ratios,
+            items=all_ratios,
             metrics=metrics,
         )
 
@@ -332,6 +346,147 @@ class NormalizeUseCase:
             ratios_df = self._calculate_ratios(ratios_df, source_df, indicator_list)
 
         return ratios_df
+
+    def _build_ratio_dtos(
+        self,
+        *,
+        df_ratios: pd.DataFrame,
+        company: Optional[CompanyDataDTO],
+        ticker_codes: List[str],
+    ) -> List[RatioDTO]:
+        if company is None or df_ratios.empty:
+            return []
+
+        idx_name = df_ratios.index.name or "date"
+        tidy = df_ratios.reset_index()
+        if idx_name != "date":
+            tidy = tidy.rename(columns={idx_name: "date"})
+
+        tidy["date"] = pd.to_datetime(tidy["date"], errors="coerce")
+        tidy = tidy.dropna(subset=["date"])
+
+        melted = tidy.melt(id_vars=["date"], var_name="metric_full_name", value_name="value")
+        melted = melted.dropna(subset=["value"])
+
+        if melted.empty:
+            return []
+
+        company_id, cnpj_root = self._resolve_company_identifiers(company)
+        scope = "IND"
+        ticker = ticker_codes[0] if ticker_codes else ""
+        version = getattr(getattr(self.config, "fly_settings", None), "version", None) or "1.0"
+        created_at = datetime.utcnow()
+
+        ratios: List[RatioDTO] = []
+        for record in melted.to_dict("records"):
+            metric_code, metric_name = self._split_metric_name(record["metric_full_name"])
+            value = record["value"]
+            if pd.isna(value):
+                continue
+
+            try:
+                value_float = float(value)
+            except (TypeError, ValueError):
+                continue
+
+            date_value = record["date"]
+            if isinstance(date_value, pd.Timestamp):
+                date_value = date_value.to_pydatetime()
+
+            if not isinstance(date_value, datetime):
+                continue
+
+            date_value = date_value.replace(hour=0, minute=0, second=0, microsecond=0)
+
+            hash_value = self._generate_ratio_hash(
+                company_id=company_id,
+                cnpj_root=cnpj_root,
+                scope=scope,
+                ticker=ticker,
+                metric_code=metric_code,
+                version=version,
+                date_value=date_value,
+                value=value_float,
+            )
+
+            ratios.append(
+                RatioDTO(
+                    company_id=company_id,
+                    cnpj_root=cnpj_root,
+                    date=date_value,
+                    scope=scope,
+                    ticker=ticker,
+                    metric_code=metric_code,
+                    metric_name=metric_name,
+                    value=value_float,
+                    unit=None,
+                    version=version,
+                    is_current=True,
+                    hash=hash_value,
+                    created_at=created_at,
+                )
+            )
+
+        return ratios
+
+    @staticmethod
+    def _resolve_company_identifiers(company: CompanyDataDTO) -> tuple[str, Optional[str]]:
+        cnpj_root = NormalizeUseCase._compute_cnpj_root(company.cnpj)
+        company_id = (
+            cnpj_root
+            or (company.cvm_code or "")
+            or (company.issuing_company or "")
+            or (company.company_name or "UNKNOWN")
+        )
+        if not company_id:
+            company_id = "UNKNOWN"
+        return company_id, cnpj_root
+
+    @staticmethod
+    def _compute_cnpj_root(cnpj: Optional[str]) -> Optional[str]:
+        if not cnpj:
+            return None
+        digits = re.sub(r"\D", "", str(cnpj))
+        root = digits[:8]
+        return root or None
+
+    @staticmethod
+    def _split_metric_name(metric_full_name: str) -> tuple[str, str]:
+        if not metric_full_name:
+            return "", ""
+        parts = [p.strip() for p in str(metric_full_name).split(" - ", 1)]
+        if len(parts) == 2:
+            code = parts[0] or parts[1]
+            name = parts[1] or parts[0]
+            return code, name
+        cleaned = str(metric_full_name).strip()
+        return cleaned, cleaned
+
+    @staticmethod
+    def _generate_ratio_hash(
+        *,
+        company_id: str,
+        cnpj_root: Optional[str],
+        scope: str,
+        ticker: Optional[str],
+        metric_code: str,
+        version: str,
+        date_value: datetime,
+        value: float,
+    ) -> str:
+        payload = "|".join(
+            [
+                company_id,
+                cnpj_root or "",
+                scope,
+                ticker or "",
+                metric_code,
+                version,
+                date_value.strftime("%Y-%m-%d"),
+                f"{value:.10f}",
+            ]
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
     def _calculate_ratios(self, ratios_df: pd.DataFrame, source_df: pd.DataFrame, indicators_list: list) -> pd.DataFrame:
         # 1 Mapeamento

--- a/domain/dtos/ratio_dto.py
+++ b/domain/dtos/ratio_dto.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True, kw_only=True)
+class RatioDTO:
+    """Canonical DTO for financial ratios persisted in long format."""
+
+    id: Optional[int] = None
+    company_id: str
+    cnpj_root: Optional[str]
+    date: datetime
+    scope: str
+    ticker: Optional[str]
+    metric_code: str
+    metric_name: str
+    value: Optional[float]
+    unit: Optional[str]
+    version: str
+    is_current: bool
+    hash: str
+    created_at: datetime

--- a/domain/ports/repository_indicators_port.py
+++ b/domain/ports/repository_indicators_port.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import List, Protocol, runtime_checkable
 
 # from application.ports.uow_port import Uow
 from domain.dtos.indicators_dto import IndicatorsDTO
+from domain.dtos.ratio_dto import RatioDTO
 from domain.ports.repository_base_port import RepositoryBasePort
 from application.ports.uow_port import Uow
 
@@ -12,3 +13,6 @@ from application.ports.uow_port import Uow
 class RepositoryIndicatorsPort(RepositoryBasePort[IndicatorsDTO, int], Protocol):
     """
     """
+
+    def save_ratios_batch(self, ratios: List[RatioDTO], *, uow: Uow) -> None:
+        """Persist ratios already normalized to long format."""

--- a/infrastructure/models/ratio_model.py
+++ b/infrastructure/models/ratio_model.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Float, Index, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from domain.dtos.ratio_dto import RatioDTO
+from infrastructure.models.base_model import BaseModel, _YMDDate
+
+
+class RatioModel(BaseModel):
+    """SQLAlchemy model that stores financial ratios in long (tidy) format."""
+
+    __tablename__ = "tbl_ratios"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    company_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    cnpj_root: Mapped[str | None] = mapped_column(String(16))
+    date: Mapped[datetime] = mapped_column(_YMDDate(), nullable=False, index=True)
+    scope: Mapped[str] = mapped_column(String(8), nullable=False)
+    ticker: Mapped[str | None] = mapped_column(String(32))
+    metric_code: Mapped[str] = mapped_column(String(64), nullable=False)
+    metric_name: Mapped[str] = mapped_column(String(), nullable=False)
+    value: Mapped[float | None] = mapped_column(Float)
+    unit: Mapped[str | None] = mapped_column(String(16))
+    version: Mapped[str] = mapped_column(String(32), nullable=False, default="1.0")
+    is_current: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    hash: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "company_id",
+            "date",
+            "scope",
+            "ticker",
+            "metric_code",
+            "version",
+            name="uq_ratios_natural_key",
+        ),
+        Index("ix_ratios_company_metric_date", "company_id", "metric_code", "date"),
+    )
+
+    @staticmethod
+    def from_dto(dto: RatioDTO) -> "RatioModel":
+        return RatioModel(
+            id=dto.id,
+            company_id=dto.company_id,
+            cnpj_root=dto.cnpj_root,
+            date=dto.date,
+            scope=dto.scope,
+            ticker=dto.ticker,
+            metric_code=dto.metric_code,
+            metric_name=dto.metric_name,
+            value=dto.value,
+            unit=dto.unit,
+            version=dto.version,
+            is_current=dto.is_current,
+            hash=dto.hash,
+            created_at=dto.created_at,
+        )
+
+    def to_dto(self) -> RatioDTO:
+        return RatioDTO(
+            id=self.id,
+            company_id=self.company_id,
+            cnpj_root=self.cnpj_root,
+            date=self.date,
+            scope=self.scope,
+            ticker=self.ticker,
+            metric_code=self.metric_code,
+            metric_name=self.metric_name,
+            value=self.value,
+            unit=self.unit,
+            version=self.version,
+            is_current=self.is_current,
+            hash=self.hash,
+            created_at=self.created_at,
+        )

--- a/infrastructure/repositories/repository_indicators.py
+++ b/infrastructure/repositories/repository_indicators.py
@@ -11,8 +11,10 @@ from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import Uow
 from domain.dtos.indicators_dto import IndicatorsDTO
+from domain.dtos.ratio_dto import RatioDTO
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
 from infrastructure.models.indicators_model import IndicatorModel
+from infrastructure.models.ratio_model import RatioModel
 from infrastructure.repositories.repository_base import RepositoryBase
 from infrastructure.utils.list_flatenner import ListFlattener
 
@@ -67,4 +69,41 @@ class RepositoryIndicators(RepositoryBase[IndicatorsDTO, int], RepositoryIndicat
                 session.execute(stmt)
         except Exception as e:
             self.logger.log(f"Error saving NSD data: {e}", level="error")
+            raise
+
+    def save_ratios_batch(self, ratios: List[RatioDTO], *, uow: Uow) -> None:
+        try:
+            session = uow.session
+            flat_items = ListFlattener.flatten(ratios)
+            valid_items = [i for i in flat_items if i is not None]
+
+            if not valid_items:
+                return
+
+            for dto in valid_items:
+                obj = RatioModel.from_dto(dto)
+                data = {c.name: getattr(obj, c.name) for c in RatioModel.__table__.columns}
+
+                stmt = insert(RatioModel).values(**data)
+                update_dict = {
+                    c.name: getattr(stmt.excluded, c.name)
+                    for c in RatioModel.__table__.columns
+                    if c.name not in {"id", "created_at"}
+                }
+
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=[
+                        "company_id",
+                        "date",
+                        "scope",
+                        "ticker",
+                        "metric_code",
+                        "version",
+                    ],
+                    set_=update_dict,
+                )
+
+                session.execute(stmt)
+        except Exception as e:
+            self.logger.log(f"Error saving ratios: {e}", level="error")
             raise


### PR DESCRIPTION
## Summary
- add a dedicated RatioDTO/RatioModel pair to persist ratios in tidy (long) format with natural keys
- extend the indicators repository and port to support batch persistence of melted ratios
- update the normalize ratios use case to melt the wide DataFrame into RatioDTOs and persist them while tracking metrics

## Testing
- pytest *(fails: tests/application/processors/test_nsd_processor.py::test_run_logs_missing_nsd_with_collector_metrics due to existing expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ef70c1f880832eb415dfc1c6bdb601