### PR TITLE
Inject ratio repository across pipeline

### DIFF
--- a/domain/services/service_ratios.py
+++ b/domain/services/service_ratios.py
@@ -28,7 +28,7 @@ class RatiosService:
         repository_stock_quote: RepositoryStockQuotePort,
         repository_indicators: RepositoryIndicatorsPort,
         repository_statements_fetched: RepositoryStatementFetchedPort,
-        repository_statements_ratio=RepositoryStatementRatioPort,
+        repository_statements_ratio: RepositoryStatementRatioPort,
 
         uow_factory: UowFactoryPort,
     ):
@@ -62,7 +62,7 @@ class RatiosService:
             repository_stock_quote=self.repository_stock_quote,
             repository_indicators=self.repository_indicators,
             repository_statements_fetched=self.repository_statements_fetched,
-            repository_statements_ratio = self.repository_statements_ratio
+            repository_statements_ratio=self.repository_statements_ratio,
 
             uow_factory=self.uow_factory,
             # http_client=self.http_client,

--- a/infrastructure/factories/cli_factory.py
+++ b/infrastructure/factories/cli_factory.py
@@ -16,6 +16,9 @@ from infrastructure.repositories.repository_nsd import RepositoryNsd
 from infrastructure.repositories.repository_statements_fetched import (
     StatementFetchedRepository,
 )
+from infrastructure.repositories.repository_statements_ratio import (
+    StatementRatioRepository,
+)
 from infrastructure.repositories.repository_statements_raw import StatementRawRepository
 from infrastructure.repositories.repository_stock_quote import RepositoryStockQuote
 from infrastructure.repositories.repository_indicators import RepositoryIndicators
@@ -52,6 +55,9 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
     repository_fetched_statements = StatementFetchedRepository(config=config, logger=logger)
     repository_stock_quote = RepositoryStockQuote(config=config, logger=logger)
     repository_indicators = RepositoryIndicators(config=config, logger=logger)
+    repository_ratio_statements = StatementRatioRepository(
+        config=config, logger=logger
+    )
 
     # Unit of Work
     uow_factory = UowFactory(session_factory=repository_nsd.Session)

--- a/presentation/controllers/cli.py
+++ b/presentation/controllers/cli.py
@@ -53,7 +53,7 @@ class Cli:
         repository_indicators: RepositoryIndicatorsPort,
         repository_statements_raw: RepositoryStatementsRawPort,
         repository_statements_fetched: RepositoryStatementFetchedPort,
-        repository_statements_ratio=RepositoryStatementRatioPort,
+        repository_statements_ratio: RepositoryStatementRatioPort,
         scraper_company_data: ScraperCompanyDataPort,
         scraper_nsd: ScraperNsdPort,
         scraper_statements_raw: ScraperStatementRawPort,


### PR DESCRIPTION
## Summary
- type the ratio repository dependency in the CLI controller and ratios service
- wire the statement ratio repository into the CLI factory so it is passed into the CLI facade

## Testing
- pytest tests/infrastructure/repositories/test_statement_ratio_repository.py

------
https://chatgpt.com/codex/tasks/task_e_68f24be25308832e861fb69dde6d7cf9