### PR TITLE
feat: aggregate quarter prices from daily quotes

### DIFF
--- a/domain/dtos/__init__.py
+++ b/domain/dtos/__init__.py
@@ -7,9 +7,19 @@ from .company_data_dto import (
     CompanyDataListingDTO,
 )
 from .nsd_dto import NsdDTO
+from .quarter_price_dto import QuarterPriceDTO
 from .statement_fetched_dto import StatementFetchedDTO
 from .statement_raw_dto import StatementRawDTO
 from .worker_task_dto import WorkerTaskDTO
 
-__all__ = ["CodeDTO", "CompanyDataDetailDTO", "CompanyDataDTO", "CompanyDataListingDTO",
-           "NsdDTO", "StatementRawDTO", "StatementFetchedDTO", "WorkerTaskDTO"]
+__all__ = [
+    "CodeDTO",
+    "CompanyDataDetailDTO",
+    "CompanyDataDTO",
+    "CompanyDataListingDTO",
+    "NsdDTO",
+    "QuarterPriceDTO",
+    "StatementRawDTO",
+    "StatementFetchedDTO",
+    "WorkerTaskDTO",
+]

--- a/domain/dtos/quarter_price_dto.py
+++ b/domain/dtos/quarter_price_dto.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True, kw_only=True)
+class QuarterPriceDTO:
+    """Immutable snapshot of the aggregated price for a fiscal quarter."""
+
+    id: Optional[int] = None
+    company_name: str
+    quarter: datetime
+    method: str
+    price: float
+    asof: datetime
+    currency: Optional[str] = None
+    version: Optional[int] = None
+

--- a/domain/dtos/statement_ratio_dto.py
+++ b/domain/dtos/statement_ratio_dto.py
@@ -25,7 +25,7 @@ class StatementRatioDTO:
     id: Optional[int] = None
     nsd: str
     company_name: str
-    ticker: str
+    ticker: str = ""
     date: datetime
     version: str
     grupo: str

--- a/domain/ports/repository_quarter_price_port.py
+++ b/domain/ports/repository_quarter_price_port.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+from application.ports.uow_port import Uow
+from domain.dtos.quarter_price_dto import QuarterPriceDTO
+from domain.ports.repository_base_port import RepositoryBasePort
+
+
+@runtime_checkable
+class RepositoryQuarterPricePort(RepositoryBasePort[QuarterPriceDTO, int], Protocol):
+    def insert_or_update(self, dto: QuarterPriceDTO, *, uow: Uow) -> QuarterPriceDTO: ...
+
+    def get_for_quarter(
+        self,
+        *,
+        company_name: str,
+        quarter: datetime,
+        method: str,
+        uow: Uow,
+    ) -> QuarterPriceDTO | None: ...

--- a/domain/ports/repository_stock_quote_port.py
+++ b/domain/ports/repository_stock_quote_port.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from datetime import datetime
+from typing import Protocol, Sequence, runtime_checkable
 
 # from application.ports.uow_port import Uow
 from domain.dtos.stock_quote_dto import StockQuoteDTO
@@ -13,3 +14,13 @@ class RepositoryStockQuotePort(RepositoryBasePort[StockQuoteDTO, int], Protocol)
     """
     """
     def get_last_date(self, *, ticker: str, uow: Uow):...
+
+    def list_between_dates(
+        self,
+        *,
+        company_name: str,
+        start: datetime,
+        end: datetime,
+        uow: Uow,
+    ) -> Sequence[StockQuoteDTO]:
+        """Return the adjusted daily quotes for the given company and period."""

--- a/domain/services/__init__.py
+++ b/domain/services/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from domain.services.quarter_price_aggregator import QuarterPriceAggregator
 from domain.services.service_company_data import CompanyDataService
 
-__all__ = ["CompanyDataService"]
+__all__ = ["CompanyDataService", "QuarterPriceAggregator"]

--- a/domain/services/quarter_price_aggregator.py
+++ b/domain/services/quarter_price_aggregator.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from application.ports.uow_port import Uow
+from domain.dtos.quarter_price_dto import QuarterPriceDTO
+from domain.dtos.stock_quote_dto import StockQuoteDTO
+from domain.ports.repository_quarter_price_port import RepositoryQuarterPricePort
+from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
+from domain.value_objects import QuarterPriceMethod, QuarterPricePolicy, QuarterPriceUnavailableError
+
+
+@dataclass(slots=True)
+class QuarterPriceAggregator:
+    """Aggregates daily quotes into a quarterly price snapshot."""
+
+    stock_quote_repository: RepositoryStockQuotePort
+    quarter_price_repository: RepositoryQuarterPricePort
+    default_policy: QuarterPricePolicy = QuarterPricePolicy.default()
+
+    def __call__(
+        self,
+        *,
+        company_name: str,
+        quarter: datetime,
+        policy: QuarterPricePolicy | QuarterPriceMethod | str | None = None,
+        uow: Uow,
+    ) -> QuarterPriceDTO:
+        return self.aggregate(
+            company_name=company_name,
+            quarter=quarter,
+            policy=policy,
+            uow=uow,
+        )
+
+    def aggregate(
+        self,
+        *,
+        company_name: str,
+        quarter: datetime,
+        policy: QuarterPricePolicy | QuarterPriceMethod | str | None = None,
+        uow: Uow,
+    ) -> QuarterPriceDTO:
+        policy_obj = QuarterPricePolicy.ensure(policy or self.default_policy)
+        start, end = self._quarter_boundaries(quarter)
+
+        quotes = list(
+            self.stock_quote_repository.list_between_dates(
+            company_name=company_name,
+            start=start,
+            end=end,
+            uow=uow,
+        )
+        )
+        if not quotes:
+            raise QuarterPriceUnavailableError(
+                f"No quotes found for {company_name} between {start.date()} and {end.date()}"
+            )
+
+        price, asof = policy_obj.aggregate(quotes, quarter_end=end)
+        currency = self._resolve_currency(quotes, asof)
+
+        existing = self.quarter_price_repository.get_for_quarter(
+            company_name=company_name,
+            quarter=end,
+            method=policy_obj.method.value,
+            uow=uow,
+        )
+
+        next_version = 1
+        if existing is not None:
+            if (
+                existing.price == price
+                and existing.asof == asof
+                and existing.currency == currency
+            ):
+                return existing
+            next_version = (existing.version or 0) + 1
+
+        dto = QuarterPriceDTO(
+            id=existing.id if existing else None,
+            company_name=company_name,
+            quarter=end,
+            method=policy_obj.method.value,
+            price=price,
+            asof=asof,
+            currency=currency,
+            version=next_version,
+        )
+
+        saved = self.quarter_price_repository.insert_or_update(dto, uow=uow)
+        return saved
+
+    @staticmethod
+    def _quarter_boundaries(quarter_end: datetime) -> tuple[datetime, datetime]:
+        quarter_end = QuarterPriceAggregator._normalize_date(quarter_end)
+        quarter_start_month = ((quarter_end.month - 1) // 3) * 3 + 1
+        quarter_start = quarter_end.replace(month=quarter_start_month, day=1)
+        return quarter_start, quarter_end
+
+    @staticmethod
+    def _normalize_date(raw: datetime) -> datetime:
+        return raw.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    @staticmethod
+    def _resolve_currency(quotes: list[StockQuoteDTO], asof: datetime) -> Optional[str]:
+        for quote in reversed(quotes):
+            if quote.date == asof and quote.currency:
+                return quote.currency
+        for quote in reversed(quotes):
+            if quote.currency:
+                return quote.currency
+        return None

--- a/domain/value_objects/__init__.py
+++ b/domain/value_objects/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .quarter_price_policy import (
+    QuarterPriceMethod,
+    QuarterPricePolicy,
+    QuarterPriceUnavailableError,
+)
+
+__all__ = ["QuarterPricePolicy", "QuarterPriceMethod", "QuarterPriceUnavailableError"]

--- a/domain/value_objects/quarter_price_policy.py
+++ b/domain/value_objects/quarter_price_policy.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from statistics import mean
+from typing import Iterable, Sequence
+
+from domain.dtos.stock_quote_dto import StockQuoteDTO
+
+
+class QuarterPriceUnavailableError(RuntimeError):
+    """Raised when it is not possible to derive an aggregated quarter price."""
+
+
+class QuarterPriceMethod(str, Enum):
+    EOP = "EOP"
+    AVG_TRAD = "AVG_TRAD"
+
+
+@dataclass(frozen=True)
+class QuarterPricePolicy:
+    """Encapsulates the business rule used to derive a quarter price."""
+
+    method: QuarterPriceMethod = QuarterPriceMethod.EOP
+
+    @staticmethod
+    def default() -> "QuarterPricePolicy":
+        return QuarterPricePolicy(method=QuarterPriceMethod.EOP)
+
+    def aggregate(self, quotes: Sequence[StockQuoteDTO], *, quarter_end: datetime) -> tuple[float, datetime]:
+        """Derive the representative price for the quarter.
+
+        Args:
+            quotes: Sequence of quotes belonging to the quarter.
+            quarter_end: The last calendar day of the quarter.
+
+        Returns:
+            A tuple ``(price, asof)``.
+
+        Raises:
+            QuarterPriceUnavailableError: If there are no usable quotes.
+        """
+
+        cleaned = [q for q in quotes if q and q.date and (q.adj_close is not None or q.close is not None)]
+        if not cleaned:
+            raise QuarterPriceUnavailableError("No quotes available for aggregation")
+
+        if self.method == QuarterPriceMethod.EOP:
+            return self._aggregate_eop(cleaned, quarter_end=quarter_end)
+
+        if self.method == QuarterPriceMethod.AVG_TRAD:
+            return self._aggregate_avg(cleaned)
+
+        raise QuarterPriceUnavailableError(f"Unsupported quarter price method: {self.method}")
+
+    def _aggregate_eop(
+        self, quotes: Sequence[StockQuoteDTO], *, quarter_end: datetime
+    ) -> tuple[float, datetime]:
+        ordered = sorted(quotes, key=lambda q: q.date)
+        eligible = [q for q in ordered if q.date <= quarter_end]
+        if not eligible:
+            raise QuarterPriceUnavailableError("No quotes prior to quarter end")
+        selected = eligible[-1]
+        price = self._resolve_price(selected)
+        if price is None:
+            raise QuarterPriceUnavailableError("Selected quote lacks price data")
+        return price, selected.date
+
+    def _aggregate_avg(self, quotes: Sequence[StockQuoteDTO]) -> tuple[float, datetime]:
+        prices: list[float] = []
+        asof = None
+        for quote in quotes:
+            price = self._resolve_price(quote)
+            if price is not None:
+                prices.append(price)
+                asof = quote.date
+        if not prices or asof is None:
+            raise QuarterPriceUnavailableError("Unable to compute average price for quarter")
+        return mean(prices), asof
+
+    @staticmethod
+    def _resolve_price(quote: StockQuoteDTO) -> float | None:
+        return quote.adj_close if quote.adj_close not in (None, 0) else quote.close
+
+    def accepts(self, method: QuarterPriceMethod | str) -> bool:
+        return QuarterPriceMethod(method) == self.method
+
+    @classmethod
+    def ensure(cls, policy: "QuarterPricePolicy | QuarterPriceMethod | str | None") -> "QuarterPricePolicy":
+        if policy is None:
+            return cls.default()
+        if isinstance(policy, QuarterPricePolicy):
+            return policy
+        return QuarterPricePolicy(method=QuarterPriceMethod(policy))
+
+    def allowed_methods(self) -> Iterable[str]:
+        return [m.value for m in QuarterPriceMethod]

--- a/infrastructure/models/quarter_price_model.py
+++ b/infrastructure/models/quarter_price_model.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from sqlalchemy import Float, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from domain.dtos.quarter_price_dto import QuarterPriceDTO
+from infrastructure.models.base_model import BaseModel, _YMDDate
+
+
+class QuarterPriceModel(BaseModel):
+    __tablename__ = "tbl_quarter_price"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    company_name: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("tbl_company.company_name", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    quarter: Mapped[object] = mapped_column(_YMDDate(), nullable=False, index=True)
+    method: Mapped[str] = mapped_column(String(16), nullable=False)
+    price: Mapped[float] = mapped_column(Float, nullable=False)
+    asof: Mapped[object] = mapped_column(_YMDDate(), nullable=False)
+    currency: Mapped[str | None] = mapped_column(String(3))
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    __table_args__ = (
+        UniqueConstraint("company_name", "quarter", "method", name="uq_quarter_price_identity"),
+    )
+
+    @staticmethod
+    def from_dto(dto: QuarterPriceDTO) -> "QuarterPriceModel":
+        return QuarterPriceModel(
+            id=dto.id,
+            company_name=dto.company_name,
+            quarter=dto.quarter,
+            method=dto.method,
+            price=dto.price,
+            asof=dto.asof,
+            currency=dto.currency,
+            version=dto.version or 1,
+        )
+
+    def to_dto(self) -> QuarterPriceDTO:
+        return QuarterPriceDTO(
+            id=self.id,
+            company_name=self.company_name,
+            quarter=self.quarter,
+            method=self.method,
+            price=self.price,
+            asof=self.asof,
+            currency=self.currency,
+            version=self.version,
+        )

--- a/infrastructure/repositories/__init__.py
+++ b/infrastructure/repositories/__init__.py
@@ -1,4 +1,5 @@
 from infrastructure.repositories.repository_base import RepositoryBase
 from infrastructure.repositories.repository_company_data import RepositoryCompanyData
+from infrastructure.repositories.repository_quarter_price import QuarterPriceRepository
 
-__all__ = ["RepositoryBase", "RepositoryCompanyData"]
+__all__ = ["RepositoryBase", "RepositoryCompanyData", "QuarterPriceRepository"]

--- a/infrastructure/repositories/repository_quarter_price.py
+++ b/infrastructure/repositories/repository_quarter_price.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Tuple
+
+from sqlalchemy import select
+
+from application.ports.config_port import ConfigPort
+from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import Uow
+from domain.dtos.quarter_price_dto import QuarterPriceDTO
+from domain.ports.repository_quarter_price_port import RepositoryQuarterPricePort
+from infrastructure.models.quarter_price_model import QuarterPriceModel
+from infrastructure.repositories.repository_base import RepositoryBase
+
+
+class QuarterPriceRepository(
+    RepositoryBase[QuarterPriceDTO, int], RepositoryQuarterPricePort
+):
+    def __init__(self, config: ConfigPort, logger: LoggerPort) -> None:
+        super().__init__(config, logger)
+        self.config = config
+        self.logger = logger
+
+    def get_model_class(self) -> Tuple[type, tuple]:
+        return QuarterPriceModel, (QuarterPriceModel.id,)
+
+    def insert_or_update(self, dto: QuarterPriceDTO, *, uow: Uow) -> QuarterPriceDTO:
+        session = uow.session
+        model, _ = self.get_model_class()
+        existing = (
+            session.query(model)
+            .filter(model.company_name == dto.company_name)
+            .filter(model.quarter == dto.quarter)
+            .filter(model.method == dto.method)
+            .one_or_none()
+        )
+        if existing is None:
+            obj = model.from_dto(dto)
+            session.add(obj)
+            session.flush()
+            return obj.to_dto()
+
+        updated = False
+        if existing.price != dto.price:
+            existing.price = dto.price
+            updated = True
+        if existing.asof != dto.asof:
+            existing.asof = dto.asof
+            updated = True
+        if existing.currency != dto.currency:
+            existing.currency = dto.currency
+            updated = True
+        if updated:
+            existing.version = (existing.version or 0) + 1
+        session.flush()
+        return existing.to_dto()
+
+    def get_for_quarter(
+        self,
+        *,
+        company_name: str,
+        quarter: datetime,
+        method: str,
+        uow: Uow,
+    ) -> QuarterPriceDTO | None:
+        session = uow.session
+        model, _ = self.get_model_class()
+        stmt = (
+            select(model)
+            .where(model.company_name == company_name)
+            .where(model.quarter == quarter)
+            .where(model.method == method)
+        )
+        result = session.execute(stmt).scalar_one_or_none()
+        return result.to_dto() if result is not None else None

--- a/infrastructure/repositories/repository_stock_quote.py
+++ b/infrastructure/repositories/repository_stock_quote.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Set, Tuple, TypeVar
+from datetime import datetime
+from typing import List, Sequence, Tuple, TypeVar
 
 from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy import func
@@ -44,7 +45,7 @@ class RepositoryStockQuote(RepositoryBase[StockQuoteDTO, int], RepositoryStockQu
         """
         try:
             session = uow.session
-            model, pk_columns = self.get_model_class()
+            model, _ = self.get_model_class()
 
             flat_items = ListFlattener.flatten(items)
             valid_items = [i for i in flat_items if i is not None]
@@ -78,3 +79,23 @@ class RepositoryStockQuote(RepositoryBase[StockQuoteDTO, int], RepositoryStockQu
             .filter(model.ticker == ticker)
             .scalar()
         )
+
+    def list_between_dates(
+        self,
+        *,
+        company_name: str,
+        start: datetime,
+        end: datetime,
+        uow: Uow,
+    ) -> Sequence[StockQuoteDTO]:
+        session = uow.session
+        model, _ = self.get_model_class()
+        rows = (
+            session.query(model)
+            .filter(model.company_name == company_name)
+            .filter(model.date >= start)
+            .filter(model.date <= end)
+            .order_by(model.date.asc())
+            .all()
+        )
+        return [row.to_dto() for row in rows]


### PR DESCRIPTION
## Summary
- add a quarter price DTO, policy, and aggregator to derive quarterly prices from daily quotes
- persist aggregated quarter prices with a dedicated repository/model and version bumping
- expose quote range retrieval and default optional ticker handling for ratio DTO consumers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9300cc7d0832eb708cb088096a895