### PR TITLE
Refactor ratios normalization to use cached storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,10 @@ MANIFEST
 *.csv
 *.db-journal
 
+# Cache artifacts
+/cache/
+*.parquet
+
 # Binary and Temp directories
 bin/
 temp/

--- a/application/services/__init__.py
+++ b/application/services/__init__.py
@@ -1,0 +1,5 @@
+"""Application service layer helpers."""
+
+from .ratios_cache_service import RatiosCacheService
+
+__all__ = ["RatiosCacheService"]

--- a/application/services/ratios_cache_service.py
+++ b/application/services/ratios_cache_service.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import pandas as pd
+
+from domain.dtos import (
+    RatiosCacheContextDTO,
+    RatiosCacheResultDTO,
+)
+from domain.ports.ratios_cache_port import RatiosCachePort
+
+
+class RatiosCacheService:
+    """High-level helper responsible for caching ratios computations."""
+
+    def __init__(
+        self,
+        *,
+        cache_port: RatiosCachePort,
+        logical_name: str = "statements_ratio",
+        version: int = 1,
+    ) -> None:
+        self._cache_port = cache_port
+        self._logical_name = logical_name
+        self._version = version
+        self._cache_port.initialize()
+
+    @staticmethod
+    def build_code_hash(func: Callable[..., Any]) -> str:
+        """Return a deterministic hash for the provided callable."""
+
+        source = inspect.getsource(func)
+        return hashlib.sha256(source.encode()).hexdigest()
+
+    def get_or_compute(
+        self,
+        *,
+        company_name: str,
+        quotes: Mapping[str, pd.DataFrame] | None,
+        statements: Mapping[str, pd.DataFrame] | None,
+        indicators: Mapping[str, pd.DataFrame] | None,
+        compute_fn: Callable[[], pd.DataFrame],
+        code_hash: str,
+    ) -> tuple[pd.DataFrame, RatiosCacheResultDTO]:
+        """Return cached ratios or compute and persist them when absent."""
+
+        context = RatiosCacheContextDTO(
+            logical_name=self._logical_name,
+            version=self._version,
+            quotes_hash=self._hash_mapping(quotes),
+            statements_hash=self._hash_mapping(statements),
+            indicators_hash=self._hash_mapping(indicators),
+            code_hash=code_hash,
+        )
+        cache_key = context.cache_key
+
+        cached = self._cache_port.load(cache_key)
+        if cached is not None:
+            df_cached, entry = cached
+            return df_cached, RatiosCacheResultDTO(
+                company_name=company_name,
+                cache_key=cache_key,
+                hit=True,
+                entry=entry,
+            )
+
+        self._cache_port.invalidate_outdated(code_hash=code_hash)
+        df = compute_fn()
+        entry = self._cache_port.store(cache_key, df, code_hash)
+        return df, RatiosCacheResultDTO(
+            company_name=company_name,
+            cache_key=cache_key,
+            hit=False,
+            entry=entry,
+        )
+
+    def _hash_mapping(self, data: Mapping[str, pd.DataFrame] | None) -> str:
+        if not data:
+            return self._empty_hash()
+
+        parts: list[str] = []
+        for key in sorted(data):
+            df = data[key]
+            if df is None or df.empty:
+                continue
+            parts.append(f"{key}:{self._hash_dataframe(df)}")
+
+        if not parts:
+            return self._empty_hash()
+
+        payload = "|".join(parts).encode()
+        return hashlib.sha256(payload).hexdigest()
+
+    @staticmethod
+    def _hash_dataframe(df: pd.DataFrame) -> str:
+        if df is None or df.empty:
+            return RatiosCacheService._empty_hash()
+
+        normalized = df.copy()
+        normalized = normalized.sort_index()
+        normalized = normalized.sort_index(axis=1)
+
+        if isinstance(normalized.index, pd.DatetimeIndex):
+            normalized.index = normalized.index.tz_localize(None)
+
+        for column in normalized.columns:
+            series = normalized[column]
+            if pd.api.types.is_datetime64_any_dtype(series):
+                normalized[column] = pd.to_datetime(series, errors="coerce")
+
+        hashed = pd.util.hash_pandas_object(normalized, index=True).values.tobytes()
+        return hashlib.sha256(hashed).hexdigest()
+
+    @staticmethod
+    def _empty_hash() -> str:
+        return hashlib.sha256(b"EMPTY").hexdigest()

--- a/application/usecases/normalize_ratios.py
+++ b/application/usecases/normalize_ratios.py
@@ -1,9 +1,7 @@
-from calendar import calendar
-import hashlib
 import re
 import time
 from datetime import datetime, timedelta
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -14,17 +12,18 @@ from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
 from application.ports.worker_pool_port import WorkerPoolPort
 from application.ports.uow_port import Uow, UowFactoryPort
-from domain.dtos.worker_task_dto import WorkerTaskDTO
-from domain.dtos.company_data_dto import CompanyDataDTO
-from domain.dtos.statement_ratio_dto import StatementRatioDTO
-from domain.dtos.sync_results_dto import SyncResultsDTO
+from application.services import RatiosCacheService
+from domain.dtos import (
+    CompanyDataDTO,
+    RatiosCacheResultDTO,
+    SyncResultsDTO,
+    WorkerTaskDTO,
+)
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
-from domain.ports.repository_statements_ratio_port import RepositoryStatementRatioPort
 from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
 from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
-from infrastructure.utils.list_flatenner import ListFlattener
-from infrastructure.utils.save_strategy import SaveStrategy
+from domain.ports.ratios_cache_port import RatiosCachePort
 
 # from infrastructure.helpers.list_flattener import ListFlattener
 
@@ -40,8 +39,8 @@ class NormalizeUseCase:
         repository_company: RepositoryCompanyDataPort,
         repository_stock_quote: RepositoryStockQuotePort,
         repository_indicators: RepositoryIndicatorsPort,
-        repository_statements_ratio: RepositoryStatementRatioPort,
         repository_statements_fetched: RepositoryStatementFetchedPort,
+        ratios_cache: RatiosCachePort,
 
         uow_factory: UowFactoryPort,
         worker_pool: WorkerPoolPort,
@@ -63,8 +62,9 @@ class NormalizeUseCase:
         self.repository_company = repository_company
         self.repository_stock_quote = repository_stock_quote
         self.repository_indicators = repository_indicators
-        self.repository_statements_ratio = repository_statements_ratio
         self.repository_statements_fetched = repository_statements_fetched
+        self.ratios_cache_service = RatiosCacheService(cache_port=ratios_cache)
+        self._ratios_code_hash = RatiosCacheService.build_code_hash(self._create_ratios)
 
         self.uow_factory = uow_factory
         self.worker_pool = worker_pool
@@ -78,26 +78,18 @@ class NormalizeUseCase:
         """Run the full synchronization pipeline.
 
         Steps:
-            1. Retrieve company data from the scraper.
-            2. Transform results into ``CompanyDataDTO`` objects.
-            3. Save them into the repository in batches.
+            1. Retrieve company data from the persistence layer.
+            2. Transform results into normalized ``pandas`` data structures.
+            3. Cache the calculated ratios for reuse across runs.
 
         Returns:
             SyncCompanyDataResultDTO: Summary of the synchronization process,
             including counts and network usage metrics.
         """
         metrics = 0
-        all_ratios: List[StatementRatioDTO] = []
+        cache_results: List[RatiosCacheResultDTO] = []
         code_parameter = re.compile(r"^[A-Z]{4}\d{1,2}[A-Z]?$")
         start_time = time.perf_counter()
-
-        strategy: SaveStrategy[StatementRatioDTO] = SaveStrategy.from_config(
-            self._save_ratios_batch,
-            threshold=self.config.repository.persistence_threshold,
-            config=self.config,
-            auto_flush=False,
-            uow_factory=self.uow_factory,
-        )
 
         try:
             with self.uow_factory() as bootstrap_uow:
@@ -128,7 +120,8 @@ class NormalizeUseCase:
             company_name = task.data["company_name"]
             len_s = 0
             len_q = 0
-            ratios_dtos: List[StatementRatioDTO] = []
+            cache_result: RatiosCacheResultDTO | None = None
+            metrics_value = 0
             ticker_codes: List[str] = []
 
             with self.uow_factory() as uow:
@@ -157,11 +150,6 @@ class NormalizeUseCase:
                         if quotes:
                             statements = self._load_statements(company_name=company_name, uow=uow)
                             if statements:
-                                # check if need to update
-                                with self.uow_factory() as uow:
-                                    if not self._should_process(company_name, uow=uow):
-                                        return  # sai antes de _treat_data
-
                                 len_s = len(statements.get("statements", []))
                                 len_q = sum(len(v) for v in quotes.values())
                                 data_snapshot = {
@@ -169,17 +157,17 @@ class NormalizeUseCase:
                                     "statements": statements,
                                     "quotes": quotes,
                                 }
-                                data_snapshot['indicators']['11'].to_csv('indicators.csv', index=True)
-                                data_snapshot['statements']['statements'].to_csv('statements.csv', index=False)
-                                data_snapshot['quotes']['stock_3'].to_csv('quotes.csv', index=False)
 
                                 company_data = self._treat_data(data_snapshot)
-                                df_ratios = self._create_ratios(company_data)
-                                ratios_dtos = self._build_ratio_dtos(
-                                    df_ratios=df_ratios,
-                                    company=company_row,
-                                    ticker_codes=ticker_codes,
+                                _, cache_result = self.ratios_cache_service.get_or_compute(
+                                    company_name=company_name,
+                                    quotes=company_data.get("quotes"),
+                                    statements=company_data.get("statements"),
+                                    indicators=company_data.get("indicators"),
+                                    compute_fn=lambda: self._create_ratios(company_data),
+                                    code_hash=self._ratios_code_hash,
                                 )
+                                metrics_value = cache_result.entry.size_bytes
 
                     success = True
 
@@ -199,6 +187,7 @@ class NormalizeUseCase:
                         "Indicators": len(treated_indicators) or 0,
                         "Statements": len_s,
                         "Quotes": len_q,
+                        "Cache": "hit" if cache_result and cache_result.hit else "miss" if cache_result else "skip",
                     }
                     ticker_str = " ".join(ticker_codes).strip() if ticker_codes else ""
                     self.logger.log(
@@ -211,43 +200,22 @@ class NormalizeUseCase:
                     if success:
                         uow.commit()
 
-            if not ratios_dtos:
+            if not cache_result:
                 return None
 
             return {
                 "company_name": company_name,
-                "ratios": ratios_dtos,
+                "cache_result": cache_result,
+                "metrics": metrics_value,
             }
-
-        local_buffer: list[Any] = []
-        def handle_batch(item: Optional[dict[str, Any]]) -> None:  # noqa: ANN401
-            if not item:
-                return
-
-            local_buffer.append(item.get("ratios", []))  # mantém bloco de listas
-
-            # Flush imediatamente se atingir o limite e auto_flush estiver ativo
-            if len(local_buffer) >= strategy.threshold:
-                # strategy.handle(item.get("ratios", []))  # enfileira o bloco de 3 dtos
-                strategy.handle_many(local_buffer)
-                strategy.flush()
-                local_buffer.clear()
-            # with self.uow_factory() as uow:
-            #     strategy.handle(item.get("ratios", []))
-            #     # strategy.handle_many(item.get("ratios", []))
-            #     # strategy.flush(uow=uow)
-            #     # uow.commit()
-            #     pass
 
         def on_result(item: Optional[dict[str, Any]]) -> None:  # noqa: ANN401
             nonlocal metrics
-            handle_batch(item)
             if not item:
                 return
 
-            ratios = item.get("ratios", [])
-            all_ratios.extend(ratios)
-            metrics += len(ratios)
+            cache_results.append(item["cache_result"])
+            metrics += int(item.get("metrics", 0))
 
         tasks = (
             (index, {"company_name": company_name})
@@ -270,37 +238,13 @@ class NormalizeUseCase:
                 level="error",
             )
             raise
-        finally:
-            strategy.finalize()
 
         results: SyncResultsDTO = SyncResultsDTO(
-            items=all_ratios,
+            items=cache_results,
             metrics=metrics,
         )
 
         return results
-
-    def _should_process(self, company: str, *, uow: Uow) -> bool:
-        fetched_head = self.repository_statements_fetched.get_head(company, uow=uow)
-        if not fetched_head:
-            return False
-
-        ratio_head = self.repository_statements_ratio.get_head(company, uow=uow)
-        if not ratio_head:
-            return True
-
-        return fetched_head > ratio_head
-
-    def _save_ratios_batch(
-        self,
-        items: List[StatementRatioDTO],
-        *,
-        uow: Uow,
-    ) -> None:
-        if not items:
-            return
-
-        self.repository_statements_ratio.save_all(items, uow=uow)
 
     def _load_indicators(self, uow: Uow) -> dict[str, pd.DataFrame]:
         indicators: dict[str, pd.DataFrame] = {}
@@ -806,84 +750,4 @@ class NormalizeUseCase:
                     calculate_df[account_name] = np.nan   # persiste para loops
             
         return ratios_df.fillna(0)
-
-    def _build_ratio_dtos(
-        self,
-        *,
-        df_ratios: pd.DataFrame,
-        company: Optional[CompanyDataDTO],
-        ticker_codes: List[str],
-    ) -> List[StatementRatioDTO]:
-        if company is None or df_ratios.empty:
-            return []
-        tidy = df_ratios.reset_index()
-        tidy["date"] = pd.to_datetime(tidy["date"], errors="coerce")
-
-        tidy = tidy.dropna(subset=["date"])
-        tidy['nsd'] = tidy['nsd'].astype(str)
-        tidy['company_name'] = tidy['company_name'].astype(str)
-        tidy['version'] = tidy['version'].astype(str)
-
-        context_columns = ["nsd", "company_name", "version"] # quarter, account e value vão ser pivotados
-        melted = tidy.melt(id_vars=["date"] + context_columns, var_name="account_description", value_name="value")
-        if melted.empty:
-            return []
-
-        sep = " - "
-        cols = ["account", "description", "grupo", "quadro"]
-        parts = melted["account_description"].str.split(sep, n=3, expand=True)
-        parts.columns = cols[:parts.shape[1]]
-        for col in parts.columns:
-            parts[col] = parts[col].str.strip()
-        melted = melted.drop(columns=["account_description"]).join(parts)
-        for col in cols:
-            if col not in melted.columns:
-                melted[col] = pd.NA
-        melted[cols] = melted[cols].astype("string")
-        melted = melted[[
-            "company_name", "nsd", "date", "grupo", "quadro", "account", "description", "value", "version",
-        ]]
-        melted["grupo"] = melted["grupo"].replace("", pd.NA)
-        melted["quadro"] = melted["quadro"].replace("", pd.NA)
-        melted["grupo"] = melted["grupo"].fillna("Indicadores")
-        suffix = melted["account"].fillna("").str[:2]
-        melted["quadro"] = melted["quadro"].fillna("Indicador " + suffix)
-        melted["value"] = pd.to_numeric(melted["value"], errors="coerce").fillna(0.0)
-        melted = melted.sort_values(["company_name", "nsd", "date", "account"]).reset_index(drop=True)
-        # melted.to_csv("melted.csv")
-
-        ticker = ticker_codes[0] if ticker_codes else ""
-
-        chunk_size = 100000
-        start_time = time.perf_counter()
-        dtos: list[StatementRatioDTO] = []
-        for start in range(0, len(melted), chunk_size):
-            chunk = melted.iloc[start:start + chunk_size]
-            for company_name, nsd, d, grupo, quadro, account, description, value, version in chunk.itertuples(index=False, name=None):
-                dto = StatementRatioDTO(
-                    nsd=nsd,
-                    company_name=company_name,
-                    ticker=ticker,
-                    date=d,
-                    grupo=grupo,
-                    quadro=quadro,
-                    account=account,
-                    description=description,
-                    value=float(value) if value else 0.00,
-                    version=version,
-                )
-                dtos.append(dto)
-            progress={
-                "index": start + len(chunk) - 1,
-                "size": len(melted),
-                "start_time": start_time,  # noqa: F821 (assumed provided in context)
-            }
-            extra_info = {
-                "Info": "",
-            }
-
-            self.logger.log(f"{ticker}", level="info", progress=progress, extra=extra_info)
-            pass
-
-        return dtos
 

--- a/domain/dtos/__init__.py
+++ b/domain/dtos/__init__.py
@@ -7,9 +7,25 @@ from .company_data_dto import (
     CompanyDataListingDTO,
 )
 from .nsd_dto import NsdDTO
+from .ratios_cache_context_dto import RatiosCacheContextDTO
+from .ratios_cache_entry_dto import RatiosCacheEntryDTO
+from .ratios_cache_result_dto import RatiosCacheResultDTO
 from .statement_fetched_dto import StatementFetchedDTO
 from .statement_raw_dto import StatementRawDTO
+from .sync_results_dto import SyncResultsDTO
 from .worker_task_dto import WorkerTaskDTO
 
-__all__ = ["CodeDTO", "CompanyDataDetailDTO", "CompanyDataDTO", "CompanyDataListingDTO",
-           "NsdDTO", "StatementRawDTO", "StatementFetchedDTO", "WorkerTaskDTO"]
+__all__ = [
+    "CodeDTO",
+    "CompanyDataDetailDTO",
+    "CompanyDataDTO",
+    "CompanyDataListingDTO",
+    "NsdDTO",
+    "RatiosCacheContextDTO",
+    "RatiosCacheEntryDTO",
+    "RatiosCacheResultDTO",
+    "StatementRawDTO",
+    "StatementFetchedDTO",
+    "SyncResultsDTO",
+    "WorkerTaskDTO",
+]

--- a/domain/dtos/ratios_cache_context_dto.py
+++ b/domain/dtos/ratios_cache_context_dto.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+
+
+@dataclass(frozen=True, kw_only=True)
+class RatiosCacheContextDTO:
+    """Hashes describing the inputs used to compute ratios for caching."""
+
+    logical_name: str
+    version: int
+    quotes_hash: str
+    statements_hash: str
+    indicators_hash: str
+    code_hash: str
+
+    @property
+    def app_hash(self) -> str:
+        payload = f"{self.logical_name}|{self.version}".encode()
+        return hashlib.sha256(payload).hexdigest()
+
+    @property
+    def cache_key(self) -> str:
+        payload = (
+            f"{self.app_hash}{self.quotes_hash}{self.statements_hash}{self.indicators_hash}{self.code_hash}".encode()
+        )
+        return hashlib.sha256(payload).hexdigest()

--- a/domain/dtos/ratios_cache_entry_dto.py
+++ b/domain/dtos/ratios_cache_entry_dto.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True, kw_only=True)
+class RatiosCacheEntryDTO:
+    """Metadata describing a cached ratios artifact."""
+
+    cache_key: str
+    file_path: str
+    size_bytes: int
+    created_at: datetime
+    accessed_at: datetime
+    access_count: int
+    code_hash: str

--- a/domain/dtos/ratios_cache_result_dto.py
+++ b/domain/dtos/ratios_cache_result_dto.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .ratios_cache_entry_dto import RatiosCacheEntryDTO
+
+
+@dataclass(frozen=True, kw_only=True)
+class RatiosCacheResultDTO:
+    """Outcome of attempting to obtain ratios data from the cache."""
+
+    company_name: str
+    cache_key: str
+    hit: bool
+    entry: RatiosCacheEntryDTO

--- a/domain/ports/ratios_cache_port.py
+++ b/domain/ports/ratios_cache_port.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import pandas as pd
+
+from domain.dtos import RatiosCacheEntryDTO
+
+
+@runtime_checkable
+class RatiosCachePort(Protocol):
+    """Port that abstracts the storage used to cache ratio calculations."""
+
+    def initialize(self) -> None:
+        """Ensure the underlying cache storage is ready for use."""
+
+    def load(self, cache_key: str) -> tuple[pd.DataFrame, RatiosCacheEntryDTO] | None:
+        """Retrieve a cached DataFrame and its metadata."""
+
+    def store(self, cache_key: str, df: pd.DataFrame, code_hash: str) -> RatiosCacheEntryDTO:
+        """Persist the DataFrame in the cache and return its metadata."""
+
+    def invalidate_outdated(self, *, code_hash: str) -> None:
+        """Remove cache artifacts that belong to outdated code versions."""

--- a/domain/services/service_ratios.py
+++ b/domain/services/service_ratios.py
@@ -4,16 +4,13 @@ from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
 from application.ports.worker_pool_port import WorkerPoolPort
 from application.ports.uow_port import UowFactoryPort
-from application.ports.http_client_port import AffinityHttpClientPort
 from application.usecases.normalize_ratios import NormalizeUseCase
-from domain.dtos.sync_results_dto import SyncResultsDTO
-from domain.dtos.stock_quote_dto import StockQuoteDTO
+from domain.dtos import RatiosCacheResultDTO, SyncResultsDTO
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
 from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
-from domain.ports.repository_statements_ratio_port import RepositoryStatementRatioPort
-from domain.ports.scraper_stock_quote_port import ScraperStockQuotePort
+from domain.ports.ratios_cache_port import RatiosCachePort
 
 
 class RatiosService:
@@ -28,7 +25,7 @@ class RatiosService:
         repository_stock_quote: RepositoryStockQuotePort,
         repository_indicators: RepositoryIndicatorsPort,
         repository_statements_fetched: RepositoryStatementFetchedPort,
-        repository_statements_ratio: RepositoryStatementRatioPort,
+        ratios_cache: RatiosCachePort,
 
         uow_factory: UowFactoryPort,
         worker_pool: WorkerPoolPort,
@@ -49,7 +46,7 @@ class RatiosService:
         self.repository_stock_quote = repository_stock_quote
         self.repository_indicators = repository_indicators
         self.repository_statements_fetched = repository_statements_fetched
-        self.repository_statements_ratio = repository_statements_ratio
+        self.ratios_cache = ratios_cache
 
         self.uow_factory = uow_factory
         self.worker_pool = worker_pool
@@ -64,7 +61,7 @@ class RatiosService:
             repository_stock_quote=self.repository_stock_quote,
             repository_indicators=self.repository_indicators,
             repository_statements_fetched=self.repository_statements_fetched,
-            repository_statements_ratio=self.repository_statements_ratio,
+            ratios_cache=self.ratios_cache,
 
             uow_factory=self.uow_factory,
             worker_pool=self.worker_pool,
@@ -73,10 +70,10 @@ class RatiosService:
             # max_workers=self.config.worker_pool.max_workers,
         )
 
-    def __call__(self, *args: Any, **kwds: Any) -> SyncResultsDTO:
+    def __call__(self, *args: Any, **kwds: Any) -> SyncResultsDTO[RatiosCacheResultDTO]:
         return self.run()
 
-    def run(self) -> SyncResultsDTO[StockQuoteDTO]:
+    def run(self) -> SyncResultsDTO[RatiosCacheResultDTO]:
         """Trigger company synchronization workflow.
 
         Returns:

--- a/infrastructure/cache/__init__.py
+++ b/infrastructure/cache/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure cache adapters."""
+
+from .ratios_cache import RatiosCacheAdapter
+
+__all__ = ["RatiosCacheAdapter"]

--- a/infrastructure/cache/ratios_cache.py
+++ b/infrastructure/cache/ratios_cache.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+
+from domain.dtos import RatiosCacheEntryDTO
+from domain.ports.ratios_cache_port import RatiosCachePort
+
+
+class RatiosCacheAdapter(RatiosCachePort):
+    """SQLite-backed cache storing ratios as parquet files."""
+
+    TABLE_NAME = "cache"
+
+    def __init__(
+        self,
+        *,
+        base_dir: Path,
+        max_cache_size_bytes: int = 1_000_000_000,
+        max_age_days: int = 30,
+    ) -> None:
+        self._base_dir = Path(base_dir)
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+        self._cache_dir = self._base_dir
+        self._db_path = self._base_dir / "fly_cache.db"
+        self._max_cache_size_bytes = max_cache_size_bytes
+        self._max_age = timedelta(days=max_age_days)
+
+    def initialize(self) -> None:
+        with sqlite3.connect(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+                    cache_key TEXT PRIMARY KEY,
+                    file_path TEXT NOT NULL,
+                    size_bytes INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    accessed_at TEXT NOT NULL,
+                    access_count INTEGER DEFAULT 0,
+                    code_hash TEXT NOT NULL
+                )
+                """
+            )
+            try:
+                cursor.execute(
+                    f"ALTER TABLE {self.TABLE_NAME} ADD COLUMN code_hash TEXT"
+                )
+            except sqlite3.OperationalError:
+                pass
+            conn.commit()
+
+    def load(self, cache_key: str) -> tuple[pd.DataFrame, RatiosCacheEntryDTO] | None:
+        with sqlite3.connect(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"SELECT file_path, size_bytes, created_at, accessed_at, access_count, code_hash FROM {self.TABLE_NAME} WHERE cache_key = ?",
+                (cache_key,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+
+            file_path = Path(row[0])
+            if not file_path.exists():
+                cursor.execute(
+                    f"DELETE FROM {self.TABLE_NAME} WHERE cache_key = ?",
+                    (cache_key,),
+                )
+                conn.commit()
+                return None
+
+            try:
+                df = pd.read_parquet(file_path)
+            except Exception:
+                file_path.unlink(missing_ok=True)
+                cursor.execute(
+                    f"DELETE FROM {self.TABLE_NAME} WHERE cache_key = ?",
+                    (cache_key,),
+                )
+                conn.commit()
+                return None
+
+            accessed_at = datetime.now()
+            cursor.execute(
+                f"UPDATE {self.TABLE_NAME} SET accessed_at = ?, access_count = access_count + 1 WHERE cache_key = ?",
+                (accessed_at.isoformat(), cache_key),
+            )
+            conn.commit()
+
+            entry = RatiosCacheEntryDTO(
+                cache_key=cache_key,
+                file_path=str(file_path),
+                size_bytes=row[1],
+                created_at=datetime.fromisoformat(row[2]),
+                accessed_at=accessed_at,
+                access_count=row[4] + 1,
+                code_hash=row[5],
+            )
+            return df, entry
+
+    def store(self, cache_key: str, df: pd.DataFrame, code_hash: str) -> RatiosCacheEntryDTO:
+        file_path = self._cache_dir / f"{cache_key}.parquet"
+        df.to_parquet(file_path, compression="zstd")
+        size_bytes = file_path.stat().st_size
+        now = datetime.now()
+
+        with sqlite3.connect(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                INSERT INTO {self.TABLE_NAME} (cache_key, file_path, size_bytes, created_at, accessed_at, access_count, code_hash)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(cache_key) DO UPDATE SET
+                    file_path=excluded.file_path,
+                    size_bytes=excluded.size_bytes,
+                    created_at=excluded.created_at,
+                    accessed_at=excluded.accessed_at,
+                    access_count=excluded.access_count,
+                    code_hash=excluded.code_hash
+                """,
+                (
+                    cache_key,
+                    str(file_path),
+                    size_bytes,
+                    now.isoformat(),
+                    now.isoformat(),
+                    1,
+                    code_hash,
+                ),
+            )
+            conn.commit()
+            self._evict_cache_if_needed(conn)
+
+        return RatiosCacheEntryDTO(
+            cache_key=cache_key,
+            file_path=str(file_path),
+            size_bytes=size_bytes,
+            created_at=now,
+            accessed_at=now,
+            access_count=1,
+            code_hash=code_hash,
+        )
+
+    def invalidate_outdated(self, *, code_hash: str) -> None:
+        cutoff = datetime.now() - self._max_age
+        with sqlite3.connect(self._db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"SELECT cache_key, file_path, code_hash, accessed_at FROM {self.TABLE_NAME}"
+            )
+            rows = cursor.fetchall()
+            for cache_key, file_path, stored_hash, accessed_at in rows:
+                remove = stored_hash != code_hash
+                if not remove:
+                    try:
+                        last_access = datetime.fromisoformat(accessed_at)
+                    except Exception:
+                        last_access = datetime.min
+                    remove = last_access < cutoff
+                if remove:
+                    Path(file_path).unlink(missing_ok=True)
+                    cursor.execute(
+                        f"DELETE FROM {self.TABLE_NAME} WHERE cache_key = ?",
+                        (cache_key,),
+                    )
+            conn.commit()
+            self._evict_cache_if_needed(conn)
+
+    def _evict_cache_if_needed(self, conn: sqlite3.Connection) -> None:
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT SUM(size_bytes) FROM {self.TABLE_NAME}")
+        total_size = cursor.fetchone()[0] or 0
+        while total_size > self._max_cache_size_bytes:
+            cursor.execute(
+                f"""
+                SELECT cache_key, file_path, size_bytes
+                FROM {self.TABLE_NAME}
+                ORDER BY access_count ASC, created_at ASC
+                LIMIT 1
+                """
+            )
+            row = cursor.fetchone()
+            if not row:
+                break
+            cache_key, file_path, size_bytes = row
+            Path(file_path).unlink(missing_ok=True)
+            cursor.execute(
+                f"DELETE FROM {self.TABLE_NAME} WHERE cache_key = ?",
+                (cache_key,),
+            )
+            conn.commit()
+            total_size -= size_bytes or 0

--- a/infrastructure/factories/cli_factory.py
+++ b/infrastructure/factories/cli_factory.py
@@ -7,6 +7,7 @@ from domain.polices.nsd_policy import NsdPolicy
 
 # from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
 # from domain.ports.repository_statements_raw_port import RepositoryStatementsRawPort
+from infrastructure.cache import RatiosCacheAdapter
 from infrastructure.factories.datacleaner_factory import datacleaner_factory
 
 # from infrastructure.http.affinity_http_client import RequestsAffinityHttpClient
@@ -15,9 +16,6 @@ from infrastructure.repositories.repository_company_data import RepositoryCompan
 from infrastructure.repositories.repository_nsd import RepositoryNsd
 from infrastructure.repositories.repository_statements_fetched import (
     StatementFetchedRepository,
-)
-from infrastructure.repositories.repository_statements_ratio import (
-    StatementRatioRepository,
 )
 from infrastructure.repositories.repository_statements_raw import StatementRawRepository
 from infrastructure.repositories.repository_stock_quote import RepositoryStockQuote
@@ -55,9 +53,7 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
     repository_fetched_statements = StatementFetchedRepository(config=config, logger=logger)
     repository_stock_quote = RepositoryStockQuote(config=config, logger=logger)
     repository_indicators = RepositoryIndicators(config=config, logger=logger)
-    repository_ratio_statements = StatementRatioRepository(
-        config=config, logger=logger
-    )
+    ratios_cache = RatiosCacheAdapter(base_dir=config.paths.root_dir / "cache")
 
     # Unit of Work
     uow_factory = UowFactory(session_factory=repository_nsd.Session)
@@ -132,7 +128,7 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
         repository_indicators=repository_indicators,
         repository_statements_raw=repository_raw_statements,
         repository_statements_fetched=repository_fetched_statements,
-        repository_statements_ratio=repository_ratio_statements,
+        ratios_cache=ratios_cache,
         scraper_company_data=scraper_company_data,
         scraper_nsd=scraper_nsd,
         scraper_statements_raw=scraper_statements_raw,

--- a/presentation/controllers/cli.py
+++ b/presentation/controllers/cli.py
@@ -8,7 +8,7 @@ from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_nsd_port import RepositoryNsdPort
 from domain.ports.repository_statements_raw_port import RepositoryStatementsRawPort
 from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
-from domain.ports.repository_statements_ratio_port import RepositoryStatementRatioPort
+from domain.ports.ratios_cache_port import RatiosCachePort
 
 from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
@@ -53,7 +53,7 @@ class Cli:
         repository_indicators: RepositoryIndicatorsPort,
         repository_statements_raw: RepositoryStatementsRawPort,
         repository_statements_fetched: RepositoryStatementFetchedPort,
-        repository_statements_ratio: RepositoryStatementRatioPort,
+        ratios_cache: RatiosCachePort,
         scraper_company_data: ScraperCompanyDataPort,
         scraper_nsd: ScraperNsdPort,
         scraper_statements_raw: ScraperStatementRawPort,
@@ -74,7 +74,7 @@ class Cli:
         self.repository_indicators = repository_indicators
         self.repository_statements_raw = repository_statements_raw
         self.repository_statements_fetched = repository_statements_fetched
-        self.repository_statements_ratio = repository_statements_ratio
+        self.ratios_cache = ratios_cache
 
         self.scraper_company_data = scraper_company_data
         self.scraper_nsd = scraper_nsd
@@ -194,7 +194,7 @@ class Cli:
             repository_stock_quote=self.repository_stock_quote,
             repository_indicators=self.repository_indicators,
             repository_statements_fetched=self.repository_statements_fetched,
-            repository_statements_ratio=self.repository_statements_ratio,
+            ratios_cache=self.ratios_cache,
 
             uow_factory=self.uow_factory,
             worker_pool=self.worker_pool,

--- a/tests/infrastructure/repositories/test_statement_ratio_repository.py
+++ b/tests/infrastructure/repositories/test_statement_ratio_repository.py
@@ -47,6 +47,7 @@ def _make_ratio(value: float = 10.0) -> StatementRatioDTO:
     return StatementRatioDTO(
         nsd="123",
         company_name="Example SA",
+        ticker="TEST3",
         date=datetime(2024, 1, 31),
         version="1",
         grupo="G",


### PR DESCRIPTION
## Summary
- add dedicated caching DTOs, service, and SQLite-backed adapter for ratio results
- refactor the normalize ratios use case to compute via the cache and stop writing to the ratios repository
- wire the cache through the service/CLI layers, ignore cache artifacts, and update repository tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69060453ecd8832e81cbe7eaddf976b5