### PR TITLE
Add helper for distinct column lookups in repositories

### DIFF
--- a/domain/ports/repository_base_port.py
+++ b/domain/ports/repository_base_port.py
@@ -76,6 +76,13 @@ class RepositoryBasePort(Protocol, Generic[T, K]):
         distinct: bool = False,
     ) -> List[Tuple]: ...
 
+    def get_distinct_column(
+        self,
+        column_name: str,
+        *,
+        uow: Uow,
+    ) -> List[Any]: ...
+
     def get_all(
         self,
         *,

--- a/infrastructure/repositories/repository_base.py
+++ b/infrastructure/repositories/repository_base.py
@@ -13,7 +13,7 @@ from typing import (
     runtime_checkable,
 )
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, select
 from sqlalchemy.engine import Row
 
 from application.ports.config_port import ConfigPort
@@ -204,6 +204,29 @@ class RepositoryBase(EngineSetup, RepositoryBasePort[T, K]):
                     distinct=distinct,
                 )
                 )
+
+    def get_distinct_column(
+        self,
+        column_name: str,
+        *,
+        uow: Uow,
+    ) -> List[Any]:
+        """Return all distinct values for a given column.
+
+        Args:
+            column_name (str): Name of the ORM column to project.
+            uow (Uow): Unit of work providing the SQLAlchemy session.
+
+        Returns:
+            List[Any]: Sequence with the distinct values in the requested column.
+        """
+
+        model, _ = self.get_model_class()
+        column = getattr(model, column_name)
+
+        stmt = select(column).distinct()
+        result = uow.session.execute(stmt)
+        return [row[0] for row in result]
 
     def get_all(
         self,


### PR DESCRIPTION
## Summary
- add a protocol method for retrieving distinct values from a repository column
- implement the helper in RepositoryBase using SQLAlchemy select distinct

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_690669a31fe0832e8f4bb599ec35830f