### PR TITLE
refactor: clean normalize use case projection flow

### DIFF
--- a/application/services/valid_companies_batch_updater_service.py
+++ b/application/services/valid_companies_batch_updater_service.py
@@ -1,0 +1,82 @@
+"""Application service responsible for rebuilding the valid companies projection."""
+
+from __future__ import annotations
+
+from typing import Collection, Iterable, Sequence
+
+from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import Uow
+from domain.dtos.company_data_dto import CompanyDataDTO
+from domain.dtos.valid_company_read_model_dto import ValidCompanyReadModelDTO
+from domain.entities import ValidCompany
+from domain.ports.valid_companies_write_port import ValidCompaniesWritePort
+from domain.services.valid_company_rules import decide_valid_company
+
+
+class ValidCompaniesBatchUpdaterService:
+    """Coordinates transformation from raw snapshots into the read-model DTOs."""
+
+    def __init__(
+        self,
+        *,
+        logger: LoggerPort,
+        write_port: ValidCompaniesWritePort,
+    ) -> None:
+        self._logger = logger
+        self._write_port = write_port
+
+    def rebuild(
+        self,
+        *,
+        uow: Uow,
+        companies: Sequence[CompanyDataDTO],
+        statement_company_names: Collection[str],
+        quote_tickers: Iterable[str],
+    ) -> list[ValidCompanyReadModelDTO]:
+        """Recompute the valid companies projection and persist it."""
+
+        statement_set = {name for name in statement_company_names if name}
+        quote_set = {str(t).strip().upper() for t in quote_tickers if t}
+
+        projection: list[ValidCompanyReadModelDTO] = []
+        seen_names: set[str] = set()
+
+        for company in companies:
+            name = (company.company_name or "").strip()
+            if not name:
+                continue
+
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+
+            is_valid, normalized_tickers, reason = decide_valid_company(
+                has_statements=name in statement_set,
+                candidate_tickers=company.ticker_codes or [],
+                available_quote_tickers=quote_set,
+            )
+
+            if not is_valid:
+                continue
+
+            entity = ValidCompany(
+                company_name=name,
+                cvm_code=company.cvm_code,
+                ticker_codes=normalized_tickers,
+                reason=reason,
+                trading_name=company.trading_name,
+                industry_sector=company.industry_sector,
+                industry_subsector=company.industry_subsector,
+                industry_segment=company.industry_segment,
+                company_segment=company.company_segment,
+            )
+
+            projection.append(ValidCompanyReadModelDTO.from_entity(entity))
+
+        self._write_port.replace_all(projection, uow=uow)
+        self._logger.log(
+            f"Valid companies projection updated with {len(projection)} entries",
+            level="info",
+        )
+
+        return projection

--- a/application/usecases/normalize_ratios.py
+++ b/application/usecases/normalize_ratios.py
@@ -13,17 +13,16 @@ from application.ports.logger_port import LoggerPort
 from application.ports.worker_pool_port import WorkerPoolPort
 from application.ports.uow_port import Uow, UowFactoryPort
 from application.services.ratios_cache_service import RatiosCacheService
-from domain.dtos.company_data_dto import CompanyDataDTO
 from domain.dtos.ratios_cache_result_dto import RatiosCacheResultDTO
 from domain.dtos.sync_results_dto import SyncResultsDTO
 from domain.dtos.worker_task_dto import WorkerTaskDTO
-from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
 from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
 from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
 from domain.ports.ratios_cache_port import RatiosCachePort
+from domain.ports.valid_companies_read_port import ValidCompaniesReadPort
+from domain.dtos.valid_company_read_model_dto import ValidCompanyReadModelDTO
 
-# from infrastructure.helpers.list_flattener import ListFlattener
 
 
 class NormalizeUseCase:
@@ -34,11 +33,11 @@ class NormalizeUseCase:
         config: ConfigPort,
         logger: LoggerPort,
 
-        repository_company: RepositoryCompanyDataPort,
         repository_stock_quote: RepositoryStockQuotePort,
         repository_indicators: RepositoryIndicatorsPort,
         repository_statements_fetched: RepositoryStatementFetchedPort,
         ratios_cache: RatiosCachePort,
+        valid_companies_read_port: ValidCompaniesReadPort,
 
         uow_factory: UowFactoryPort,
         worker_pool: WorkerPoolPort,
@@ -57,7 +56,6 @@ class NormalizeUseCase:
         """
         self.config = config
         self.logger = logger
-        self.repository_company = repository_company
         self.repository_stock_quote = repository_stock_quote
         self.repository_indicators = repository_indicators
         self.repository_statements_fetched = repository_statements_fetched
@@ -68,6 +66,7 @@ class NormalizeUseCase:
         self.worker_pool = worker_pool
 
         self.max_workers = max_workers or self.config.worker_pool.max_workers or 1
+        self.valid_companies_read_port = valid_companies_read_port
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         return self.run()
@@ -86,7 +85,6 @@ class NormalizeUseCase:
         """
         metrics = 0
         cache_results: List[RatiosCacheResultDTO] = []
-        code_parameter = re.compile(r"^[A-Z]{4}\d{1,2}[A-Z]?$")
         start_time = time.perf_counter()
 
         try:
@@ -97,44 +95,17 @@ class NormalizeUseCase:
                     for indicator, indicator_df in indicators.items()
                 }
 
-                companies_statements = self.repository_statements_fetched.get_unique_by_column(column_name='company_name', uow=bootstrap_uow)
-                companies_tickers = self.repository_stock_quote.get_unique_by_column(column_name='ticker', uow=bootstrap_uow)
-                companies_raw = self.repository_company.get_all(uow=bootstrap_uow)
-
-                valid_companies = []
-                for row in companies_raw:
-                    if row.company_name not in companies_statements:
-                        continue
-                    if not row.ticker_codes:
-                        continue
-                    tickers = [t.strip().upper() for t in row.ticker_codes if len(t) > 4]
-
-                    if not tickers:
-                        continue
-
-                    if not any(t in companies_tickers for t in tickers):
-                        continue
-
-                    valid_companies.append(row)
-
-                # companies = [
-                #     company
-                #     for (company,) in self.repository_company.iter_existing_by_columns(
-                #         "company_name", uow=bootstrap_uow
-                #     )
-                # ]
-
-                self.ratios_cache_service.invalidate_outdated(
-                    code_hash=self._ratios_code_hash,
+                valid_companies: list[ValidCompanyReadModelDTO] = self.valid_companies_read_port.list(
+                    uow=bootstrap_uow,
                 )
 
                 if valid_companies:
-                    df_company = pd.DataFrame(valid_companies)
+                    df_company = pd.DataFrame([item.to_dict() for item in valid_companies])
 
-                    columns = df_company.columns
-                    mask = df_company['cvm_code'] == '10456'
-                    df = df_company[mask]
+                    if df_company.empty:
+                        return SyncResultsDTO(items=[], metrics=0)
 
+                    df = df_company
                     total_companies = len(df)
 
                     def processor(task: WorkerTaskDTO) -> Optional[dict[str, Any]]:  # noqa: ANN401
@@ -145,43 +116,13 @@ class NormalizeUseCase:
                         metrics_value = 0
 
                         with self.uow_factory() as uow:
-                            # companies_statements = self.repository_statements_fetched.get_unique_by_column(column_name='company_name', uow=uow)
-                            # companies = self.repository_company.get_all(uow=uow)
 
-                            # valid_companies = []
-                            # for row in companies:
-                            #     if row.company_name not in companies_statements:
-                            #         continue
-                            #     if not row.ticker_codes:
-                            #         continue
-                            #     ticker_codes = [t.strip().upper() for t in row.ticker_codes if len(t) > 4]
-                            #     if ticker_codes:
-                            #         valid_companies.append(row)
                             success = False
                             try:
-                                # company_rows = self.repository_company.get_by_column_values(
-                                #     values=[("company_name", company_dto.company_name)],
-                                #     uow=uow,
-                                # )
-                                # company_row: Optional[CompanyDataDTO] = next(
-                                #     (row for row in company_rows if row.company_name == company_dto.company_name),
-                                #     None,
-                                # )
 
-                                # if company_row:
-                                #     ticker_codes = [
-                                #         code
-                                #         for code in (company_row.ticker_codes or [])
-                                #         if isinstance(code, str)
-                                #         and len(code) >= 5
-                                #         and code_parameter.match(code)
-                                #     ]
 
-                                # if ticker_codes and len(ticker_codes[0]) > 4:
                                 quotes = self._load_quotes(ticker_codes=company_dto.ticker_codes, uow=uow)
-                                #     if quotes:
                                 statements = self._load_statements(company_name=company_dto.company_name, uow=uow)
-                                #         if statements:
                                 len_s = len(statements.get("statements", []))
                                 len_q = sum(len(v) for v in quotes.values())
                                 data_snapshot = {
@@ -325,7 +266,6 @@ class NormalizeUseCase:
         statements.sort_values(["company_name", "quarter", "version_numeric"], inplace=True)
         df = statements.dropna(subset=["quarter"]).reset_index(drop=True)
 
-        # keep latest version only, just in case
         mask = df["version_numeric"] == df.groupby("quarter")["version_numeric"].transform("max")
         df = df[mask].reset_index(drop=True)
 
@@ -357,7 +297,6 @@ class NormalizeUseCase:
         for ticker in ticker_codes:
             rows = self.repository_stock_quote.get_by_column_values(values=[("ticker", ticker)], uow=uow)
             if not rows:
-                # return quotes_df
                 continue
 
             quotes = pd.DataFrame(rows)
@@ -367,8 +306,6 @@ class NormalizeUseCase:
                 quotes[col] = pd.to_numeric(quotes[col], errors="coerce")
             quotes.sort_values(["ticker", "date"], inplace=True)
 
-            # digit = re.search(r'\d+$', ticker).group() if re.search(r'\d+$', ticker) else None 
-            # quotes_df[f"stock_{digit}"] = quotes.dropna(subset=["date"]).reset_index(drop=True)
 
             m = re.search(r'\d+$', ticker)
             digit = m.group() if m else ""
@@ -378,8 +315,6 @@ class NormalizeUseCase:
         return quotes_df
 
     def _treat_quotes(self, q: pd.DataFrame, c: pd.DataFrame|None = None) -> pd.DataFrame:
-        # if c.empty:
-        #     return pd.DataFrame()
 
         if "date" in q.columns:
             q["date"] = pd.to_datetime(q["date"])
@@ -396,12 +331,9 @@ class NormalizeUseCase:
         return q
 
     def _treat_statements(self, s: pd.DataFrame, c: pd.DataFrame|None = None) -> pd.DataFrame:
-        # if c.empty:
-        #     return pd.DataFrame()
         s["quarter"] = pd.to_datetime(s["quarter"])
 
         key_columns = ["company_name", "quarter", "account"]
-        # sep = " - "
         s["account_description"] = s["account"] + " - " + s["description"] + " - " + s["grupo"] + " - " + s["quadro"]
 
         context_columns = ["nsd", "company_name", "version"]
@@ -422,12 +354,9 @@ class NormalizeUseCase:
         s = meta.join(s, how="right")
 
         if c is not None:
-            # reset_multiindex
             s = s.copy()
-            # s.index = s.index.set_names(["quarter", "nsd", "company_name", "version"])
             s = s.reset_index()
 
-            # create date index
             s["quarter"] = pd.to_datetime(s["quarter"])
             s = (
                 s.rename(columns={"quarter": "date"})
@@ -435,19 +364,15 @@ class NormalizeUseCase:
                 .sort_index()
             )
 
-            # reindex ffill bfill
             s = s.reindex(c.index, method="ffill")
             if s.iloc[0].isna().any():
                 s = s.bfill()
 
-            # recreate multiindex
             s = s.set_index(context_columns, append=True).sort_index()
 
         return s
 
     def _treat_indicators(self, i: pd.DataFrame, c: pd.DataFrame|None = None) -> pd.DataFrame:
-        # if c is None or c.empty: 
-        #     return pd.DataFrame()
         if c is None:
             i["date"] = pd.to_datetime(i["date"])
             i = i.sort_values("date").drop_duplicates(subset=["date"]).set_index("date")
@@ -544,7 +469,6 @@ class NormalizeUseCase:
 
         daily_series = pd.Series(1, index=daily_calendar) # Valor 1 em cada trading day
 
-        # Create resampled calendar if granularity coarser than 'day'
         if granularity == 'D':
             df_anchor_calendar = daily_calendar
             df_anchor_calendar = pd.DataFrame({"trading_days": daily_series}, index=daily_calendar)
@@ -570,10 +494,8 @@ class NormalizeUseCase:
                 idx = pd.to_datetime(idx, errors='coerce')
                 idx = idx[~idx.isna()]
                 if len(idx) < 2:
-                    # self.logger.log(f"Índice muito curto para inferir granularidade ({data_type})", level="warning")
                     return 'unknown'
             except Exception as e:
-                # self.logger.log(f"Erro ao converter índice para DatetimeIndex ({data_type}): {e}", level="error")
                 return 'unknown'
 
         inferred_freq = pd.infer_freq(idx)
@@ -586,17 +508,13 @@ class NormalizeUseCase:
         if inferred_freq in freq_map:
             return freq_map[inferred_freq]
 
-        # Fallback: calcula mediana dos deltas
         deltas = np.diff(idx.view("i8"))  # Diferenças em nanossegundos
         if len(deltas) == 0:
-            # self.logger.log(f"Índice muito curto para calcular deltas ({data_type})", level="warning")
             return 'unknown'
 
         med = np.median(deltas)
         d1 = pd.Timedelta(days=1).value  # 1 dia em nanossegundos
 
-        # Thresholds ajustados por tipo de dado
-        # Indicadores podem variar; thresholds mais amplos
         if med <= 7 * d1:
             return 'B'
         if med <= 45 * d1:
@@ -605,7 +523,6 @@ class NormalizeUseCase:
             return 'QE'
         return 'YE'
 
-        # return 'unknown'
 
     def _resample_series(
         self,
@@ -628,16 +545,13 @@ class NormalizeUseCase:
         """
         df_data.to_csv("df_data.csv", index=True)
         df_anchor_calendar.to_csv("df_anchor_calendar.csv", index=True)
-        # Fast exit
         if df_data.empty:
             return df_data
 
-        # Check DatetimeIndex
         if not isinstance(df_data.index, pd.DatetimeIndex):
             df_data.index = pd.to_datetime(df_data.index, errors='coerce')
             df_data = df_data.dropna(subset=[df_data.index.name])
 
-        # Detect granularity and sampling
         granularity_order = {'B': 1, 'D': 2, 'MS': 3,'ME': 4, 'QS': 5,'QE': 6, 'YS': 7,'YE': 8} # granularidade: menor significa mais fino, mais diário e detalhado
         granularity_anchor = pd.infer_freq(df_anchor_calendar.index) or 'B'
         granularity_data = self._infer_granularity(df_data.index)
@@ -650,13 +564,11 @@ class NormalizeUseCase:
         else:
             sampling_action = "same" # apenas reindexar
 
-        # Upsampling, precisa preencher
         if sampling_action == "upsampling":
             df_data = df_data.sort_index()
             df_data = df_data.reindex(df_data.index.union(df_anchor_calendar.index))
             df_data = df_data.ffill().bfill()
             df_data = df_data.reindex(df_anchor_calendar.index).sort_index()
-        # Downsampling, precisa agregar
         elif sampling_action == "downsampling":
             df_data = df_data.sort_index()
 
@@ -720,10 +632,8 @@ class NormalizeUseCase:
         source_df = c['statements']['statements'].copy()
         ratios_df = source_df.copy()
 
-        # preços por classe (fechamento), já reindexados pelo calendário em _treat_quotes
         quotes: dict[str, pd.DataFrame] = c.get("quotes", {}) or {}
 
-        # coleta e ordena chaves stock_* independentemente de quantas existam
         stock_keys = [k for k in quotes.keys() if str(k).startswith('stock_')]
         stock_keys.sort(key=lambda x: int(str(x).split('_', 1)[1]) if '_' in str(x) else float('inf'))
 
@@ -741,12 +651,10 @@ class NormalizeUseCase:
             if dfq is None or dfq.empty:
                 continue
 
-            # filtra colunas relevantes
             dfq = dfq.loc[:, [c for c in dfq.columns if c not in ignore_stock_keys_cols]].copy()
             if dfq.empty:
                 continue
 
-            # renomeia todas as colunas em bloco
             dfq.columns = [f"{code}.{c} - {qkey}" for c in dfq.columns]
             frames.append(dfq)
 
@@ -755,13 +663,9 @@ class NormalizeUseCase:
             source_df = source_df.join(price_df, how='left')
             ratios_df = ratios_df.join(price_df, how="left")
 
-        # mapeia uma vez e congela calculate_df base
-        # account_long_map_old = {c: c.split(" - ")[0] for c in source_df.columns
-        #             if " - " in c and not c.startswith("99.")}
         account_long_map = {c: c.split(" - ")[0] for c in source_df.columns if " - " in c}
         calculate_df = source_df.rename(columns=account_long_map).copy()
 
-        # percorre TODAS as listas mantendo o mesmo calculate_df
         indicator_names = [
             name
             for name in dir(intel)

--- a/application/usecases/update_valid_companies_projection.py
+++ b/application/usecases/update_valid_companies_projection.py
@@ -1,0 +1,68 @@
+"""Use case that refreshes the valid companies projection from source snapshots."""
+
+from __future__ import annotations
+
+from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import UowFactoryPort
+from application.services.valid_companies_batch_updater_service import (
+    ValidCompaniesBatchUpdaterService,
+)
+from domain.dtos.valid_company_read_model_dto import ValidCompanyReadModelDTO
+from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from domain.ports.repository_statements_fetched_port import (
+    RepositoryStatementFetchedPort,
+)
+from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
+
+
+class UpdateValidCompaniesProjectionUseCase:
+    """Coordinates the refresh of the valid companies read-model."""
+
+    def __init__(
+        self,
+        *,
+        logger: LoggerPort,
+        repository_company: RepositoryCompanyDataPort,
+        repository_statements_fetched: RepositoryStatementFetchedPort,
+        repository_stock_quote: RepositoryStockQuotePort,
+        batch_service: ValidCompaniesBatchUpdaterService,
+        uow_factory: UowFactoryPort,
+    ) -> None:
+        self._logger = logger
+        self._repository_company = repository_company
+        self._repository_statements_fetched = repository_statements_fetched
+        self._repository_stock_quote = repository_stock_quote
+        self._batch_service = batch_service
+        self._uow_factory = uow_factory
+
+    def __call__(self) -> list[ValidCompanyReadModelDTO]:
+        return self.run()
+
+    def run(self) -> list[ValidCompanyReadModelDTO]:
+        """Refresh the projection in a single transaction."""
+
+        with self._uow_factory() as uow:
+            companies = self._repository_company.get_all(uow=uow)
+            statement_names = self._repository_statements_fetched.get_unique_by_column(
+                column_name="company_name",
+                uow=uow,
+            )
+            quote_tickers = self._repository_stock_quote.get_unique_by_column(
+                column_name="ticker",
+                uow=uow,
+            )
+
+            projection = self._batch_service.rebuild(
+                uow=uow,
+                companies=companies,
+                statement_company_names=statement_names,
+                quote_tickers=quote_tickers,
+            )
+
+            uow.commit()
+            self._logger.log(
+                f"Valid companies projection refreshed: {len(projection)} items",
+                level="info",
+            )
+
+            return projection

--- a/domain/dtos/__init__.py
+++ b/domain/dtos/__init__.py
@@ -7,13 +7,14 @@ from .company_data_dto import (
     CompanyDataListingDTO,
 )
 from .nsd_dto import NsdDTO
-from .ratios_cache_context_dto import RatiosCacheContextDTO
 from .ratios_cache_entry_dto import RatiosCacheEntryDTO
 from .ratios_cache_result_dto import RatiosCacheResultDTO
 from .statement_fetched_dto import StatementFetchedDTO
 from .statement_raw_dto import StatementRawDTO
 from .sync_results_dto import SyncResultsDTO
 from .worker_task_dto import WorkerTaskDTO
+from .ratios_cache_context_dto import RatiosCacheContextDTO
+from .valid_company_read_model_dto import ValidCompanyReadModelDTO
 
 __all__ = [
     "CodeDTO",
@@ -21,11 +22,12 @@ __all__ = [
     "CompanyDataDTO",
     "CompanyDataListingDTO",
     "NsdDTO",
-    "RatiosCacheContextDTO",
     "RatiosCacheEntryDTO",
     "RatiosCacheResultDTO",
     "StatementRawDTO",
     "StatementFetchedDTO",
     "SyncResultsDTO",
     "WorkerTaskDTO",
+    "RatiosCacheContextDTO",
+    "ValidCompanyReadModelDTO",
 ]

--- a/domain/dtos/valid_company_read_model_dto.py
+++ b/domain/dtos/valid_company_read_model_dto.py
@@ -1,0 +1,53 @@
+"""DTO representing the valid company read-model projection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+from domain.entities import ValidCompany
+
+
+@dataclass(frozen=True)
+class ValidCompanyReadModelDTO:
+    """Data transfer object for the valid companies projection."""
+
+    company_name: str
+    cvm_code: str | None
+    ticker_codes: Tuple[str, ...]
+    reason: str
+
+    trading_name: str | None = None
+    industry_sector: str | None = None
+    industry_subsector: str | None = None
+    industry_segment: str | None = None
+    company_segment: str | None = None
+
+    @staticmethod
+    def from_entity(entity: ValidCompany) -> "ValidCompanyReadModelDTO":
+        return ValidCompanyReadModelDTO(
+            company_name=entity.company_name,
+            cvm_code=entity.cvm_code,
+            ticker_codes=entity.ticker_codes,
+            reason=entity.reason,
+            trading_name=entity.trading_name,
+            industry_sector=entity.industry_sector,
+            industry_subsector=entity.industry_subsector,
+            industry_segment=entity.industry_segment,
+            company_segment=entity.company_segment,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Expose a plain dictionary for dataframe creation and serialization."""
+
+        return {
+            "company_name": self.company_name,
+            "cvm_code": self.cvm_code,
+            "ticker_codes": list(self.ticker_codes),
+            "reason": self.reason,
+            "trading_name": self.trading_name,
+            "industry_sector": self.industry_sector,
+            "industry_subsector": self.industry_subsector,
+            "industry_segment": self.industry_segment,
+            "company_segment": self.company_segment,
+        }

--- a/domain/entities/__init__.py
+++ b/domain/entities/__init__.py
@@ -1,0 +1,5 @@
+"""Domain entities package."""
+
+from .valid_company import ValidCompany
+
+__all__ = ["ValidCompany"]

--- a/domain/entities/valid_company.py
+++ b/domain/entities/valid_company.py
@@ -1,0 +1,22 @@
+"""Domain entity representing a valid company for ratios processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class ValidCompany:
+    """Immutable representation of a company deemed valid for processing."""
+
+    company_name: str
+    cvm_code: str | None
+    ticker_codes: Tuple[str, ...]
+    reason: str
+
+    trading_name: str | None = None
+    industry_sector: str | None = None
+    industry_subsector: str | None = None
+    industry_segment: str | None = None
+    company_segment: str | None = None

--- a/domain/ports/valid_companies_read_port.py
+++ b/domain/ports/valid_companies_read_port.py
@@ -1,0 +1,24 @@
+"""Port definition for querying the valid companies read-model."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from application.ports.uow_port import Uow
+from domain.dtos.valid_company_read_model_dto import ValidCompanyReadModelDTO
+
+
+@runtime_checkable
+class ValidCompaniesReadPort(Protocol):
+    """Read port exposing filters for the valid companies projection."""
+
+    def list(
+        self,
+        *,
+        uow: Uow,
+        cvm_code: str | None = None,
+        company_name: str | None = None,
+        segment: str | None = None,
+    ) -> list[ValidCompanyReadModelDTO]:
+        """Return projected companies using optional filters."""
+

--- a/domain/ports/valid_companies_write_port.py
+++ b/domain/ports/valid_companies_write_port.py
@@ -1,0 +1,22 @@
+"""Port definition for persisting the valid companies projection."""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+from application.ports.uow_port import Uow
+from domain.dtos.valid_company_read_model_dto import ValidCompanyReadModelDTO
+
+
+@runtime_checkable
+class ValidCompaniesWritePort(Protocol):
+    """Write port exposing idempotent replace operations for the projection."""
+
+    def replace_all(
+        self,
+        items: Sequence[ValidCompanyReadModelDTO],
+        *,
+        uow: Uow,
+    ) -> None:
+        """Atomically replace the projection with the provided items."""
+

--- a/domain/services/service_ratios.py
+++ b/domain/services/service_ratios.py
@@ -5,12 +5,20 @@ from application.ports.logger_port import LoggerPort
 from application.ports.worker_pool_port import WorkerPoolPort
 from application.ports.uow_port import UowFactoryPort
 from application.usecases.normalize_ratios import NormalizeUseCase
+from application.usecases.update_valid_companies_projection import (
+    UpdateValidCompaniesProjectionUseCase,
+)
 from domain.dtos import RatiosCacheResultDTO, SyncResultsDTO
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
 from domain.ports.repository_statements_fetched_port import RepositoryStatementFetchedPort
 from domain.ports.ratios_cache_port import RatiosCachePort
+from domain.ports.valid_companies_read_port import ValidCompaniesReadPort
+from domain.ports.valid_companies_write_port import ValidCompaniesWritePort
+from application.services.valid_companies_batch_updater_service import (
+    ValidCompaniesBatchUpdaterService,
+)
 
 
 class RatiosService:
@@ -29,6 +37,8 @@ class RatiosService:
 
         uow_factory: UowFactoryPort,
         worker_pool: WorkerPoolPort,
+        valid_companies_read_port: ValidCompaniesReadPort,
+        valid_companies_write_port: ValidCompaniesWritePort,
     ):
         """Initialize the service with required dependencies.
 
@@ -52,16 +62,30 @@ class RatiosService:
         self.worker_pool = worker_pool
         # self.http_client = http_client
 
+        self._valid_companies_batch_service = ValidCompaniesBatchUpdaterService(
+            logger=self.logger,
+            write_port=valid_companies_write_port,
+        )
+
+        self._valid_companies_update_usecase = UpdateValidCompaniesProjectionUseCase(
+            logger=self.logger,
+            repository_company=self.repository_company,
+            repository_statements_fetched=self.repository_statements_fetched,
+            repository_stock_quote=self.repository_stock_quote,
+            batch_service=self._valid_companies_batch_service,
+            uow_factory=self.uow_factory,
+        )
+
         # Initialize the use case responsible for company synchronization
         self.normalize_usecase = NormalizeUseCase(
             config=self.config,
             logger=self.logger,
 
-            repository_company=self.repository_company,
             repository_stock_quote=self.repository_stock_quote,
             repository_indicators=self.repository_indicators,
             repository_statements_fetched=self.repository_statements_fetched,
             ratios_cache=self.ratios_cache,
+            valid_companies_read_port=valid_companies_read_port,
 
             uow_factory=self.uow_factory,
             worker_pool=self.worker_pool,
@@ -79,4 +103,5 @@ class RatiosService:
         Returns:
             Any: The result of the synchronization use case execution.
         """
+        self._valid_companies_update_usecase()
         return self.normalize_usecase()

--- a/domain/services/valid_company_rules.py
+++ b/domain/services/valid_company_rules.py
@@ -1,0 +1,64 @@
+"""Pure domain rules for validating companies."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Sequence, Tuple
+
+_TICKER_PATTERN = re.compile(r"^[A-Z]{4}\d{1,2}[A-Z]?$")
+
+
+def _normalize_tickers(codes: Iterable[str]) -> Tuple[str, ...]:
+    """Normalize raw ticker codes into a deterministic tuple of candidates."""
+
+    seen: set[str] = set()
+    normalized: list[str] = []
+
+    for raw in codes:
+        if not raw:
+            continue
+
+        ticker = str(raw).strip().upper()
+        if not ticker or not _TICKER_PATTERN.match(ticker):
+            continue
+
+        if ticker in seen:
+            continue
+
+        seen.add(ticker)
+        normalized.append(ticker)
+
+    return tuple(normalized)
+
+
+def decide_valid_company(
+    *,
+    has_statements: bool,
+    candidate_tickers: Sequence[str],
+    available_quote_tickers: Iterable[str],
+) -> tuple[bool, Tuple[str, ...], str]:
+    """Evaluate if a company should be considered valid.
+
+    Args:
+        has_statements: Whether the company has any financial statements.
+        candidate_tickers: Raw ticker codes associated with the company.
+        available_quote_tickers: Tickers with available stock quote data.
+
+    Returns:
+        Tuple with validity flag, normalized tickers and textual reason.
+    """
+
+    if not has_statements:
+        return False, tuple(), "missing_statements"
+
+    normalized = _normalize_tickers(candidate_tickers)
+    if not normalized:
+        return False, tuple(), "no_valid_tickers"
+
+    available_set = {str(t).strip().upper() for t in available_quote_tickers if t}
+    intersection = tuple(t for t in normalized if t in available_set)
+
+    if not intersection:
+        return False, tuple(), "no_quotes_available"
+
+    return True, intersection, "statements_and_quotes"

--- a/infrastructure/cache/ratios_cache.py
+++ b/infrastructure/cache/ratios_cache.py
@@ -152,10 +152,15 @@ class RatiosCacheAdapter(RatiosCachePort):
             )
 
         entry_dto = entry.to_dto()
+        self._invalidate_outdated(code_hash=context.code_hash)
         self._evict_cache_if_needed()
         return entry_dto
 
     def invalidate_outdated(self, *, code_hash: str) -> None:
+        self._invalidate_outdated(code_hash=code_hash)
+        self._evict_cache_if_needed()
+
+    def _invalidate_outdated(self, *, code_hash: str) -> None:
         cutoff = datetime.now() - self._max_age
 
         with self._session_factory.begin() as session:
@@ -169,8 +174,6 @@ class RatiosCacheAdapter(RatiosCachePort):
             for entry in entries:
                 Path(entry.file_path).unlink(missing_ok=True)
                 session.delete(entry)
-
-        self._evict_cache_if_needed()
 
     def _evict_cache_if_needed(self) -> None:
         with self._session_factory.begin() as session:

--- a/infrastructure/factories/cli_factory.py
+++ b/infrastructure/factories/cli_factory.py
@@ -18,6 +18,9 @@ from infrastructure.repositories.repository_statements_fetched import StatementF
 from infrastructure.repositories.repository_statements_raw import StatementRawRepository
 from infrastructure.repositories.repository_stock_quote import RepositoryStockQuote
 from infrastructure.repositories.repository_indicators import RepositoryIndicators
+from infrastructure.repositories.valid_companies_projection_repository import (
+    ValidCompaniesProjectionRepository,
+)
 from infrastructure.scrapers.scraper_company_data import CompanyDataScraper
 from infrastructure.scrapers.scraper_nsd import NsdScraper
 from infrastructure.scrapers.scraper_statements_raw import ScraperStatementRaw
@@ -56,6 +59,11 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
 
     # Unit of Work
     uow_factory = UowFactory(session_factory=repository_nsd.Session)
+
+    valid_companies_projection = ValidCompaniesProjectionRepository(
+        config=config,
+        logger=logger,
+    )
 
     # Compose the data-cleaning pipeline used before mapping/persisting
     datacleaner = datacleaner_factory(config, logger)
@@ -136,6 +144,8 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
         policy=policy,
         uow_factory=uow_factory,
         http_client=http_client,
+        valid_companies_read_port=valid_companies_projection,
+        valid_companies_write_port=valid_companies_projection,
     )
 
     return cli

--- a/infrastructure/models/__init__.py
+++ b/infrastructure/models/__init__.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
 from .base_model import BaseModel
+from .valid_company_read_model import ValidCompanyReadModel
 
-__all__ = ["BaseModel"]
+__all__ = [
+    "BaseModel",
+    "ValidCompanyReadModel",
+]

--- a/infrastructure/models/valid_company_read_model.py
+++ b/infrastructure/models/valid_company_read_model.py
@@ -1,0 +1,59 @@
+"""SQLAlchemy model for the valid companies read projection."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, Index, Integer, JSON, String
+
+from domain.dtos.valid_company_read_model_dto import ValidCompanyReadModelDTO
+from .base_model import BaseModel
+
+
+class ValidCompanyReadModel(BaseModel):
+    """ORM mapping for the ``read_valid_companies`` table."""
+
+    __tablename__ = "read_valid_companies"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    company_name = Column(String, nullable=False, unique=True)
+    cvm_code = Column(String, nullable=True)
+    trading_name = Column(String, nullable=True)
+    industry_sector = Column(String, nullable=True)
+    industry_subsector = Column(String, nullable=True)
+    industry_segment = Column(String, nullable=True)
+    company_segment = Column(String, nullable=True)
+    ticker_codes = Column(JSON, nullable=False, default=list)
+    reason = Column(String, nullable=False)
+
+    __table_args__ = (
+        Index("ix_read_valid_companies_company_name", "company_name"),
+        Index("ix_read_valid_companies_cvm_code", "cvm_code"),
+        Index("ix_read_valid_companies_segment", "company_segment"),
+    )
+
+    @classmethod
+    def from_dto(cls, dto: ValidCompanyReadModelDTO) -> "ValidCompanyReadModel":
+        return cls(
+            company_name=dto.company_name,
+            cvm_code=dto.cvm_code,
+            trading_name=dto.trading_name,
+            industry_sector=dto.industry_sector,
+            industry_subsector=dto.industry_subsector,
+            industry_segment=dto.industry_segment,
+            company_segment=dto.company_segment,
+            ticker_codes=list(dto.ticker_codes),
+            reason=dto.reason,
+        )
+
+    def to_dto(self) -> ValidCompanyReadModelDTO:
+        tickers = tuple(self.ticker_codes or [])
+        return ValidCompanyReadModelDTO(
+            company_name=self.company_name,
+            cvm_code=self.cvm_code,
+            trading_name=self.trading_name,
+            industry_sector=self.industry_sector,
+            industry_subsector=self.industry_subsector,
+            industry_segment=self.industry_segment,
+            company_segment=self.company_segment,
+            ticker_codes=tickers,
+            reason=self.reason,
+        )

--- a/infrastructure/repositories/valid_companies_projection_repository.py
+++ b/infrastructure/repositories/valid_companies_projection_repository.py
@@ -1,0 +1,78 @@
+"""Repository implementing the valid companies read/write ports."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from application.ports.config_port import ConfigPort
+from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import Uow
+from domain.dtos.valid_company_read_model_dto import ValidCompanyReadModelDTO
+from domain.ports.valid_companies_read_port import ValidCompaniesReadPort
+from domain.ports.valid_companies_write_port import ValidCompaniesWritePort
+from infrastructure.adapters.engine_setup import EngineSetup
+from infrastructure.models.valid_company_read_model import ValidCompanyReadModel
+
+
+class ValidCompaniesProjectionRepository(
+    EngineSetup,
+    ValidCompaniesReadPort,
+    ValidCompaniesWritePort,
+):
+    """SQLite-backed repository for the valid companies projection."""
+
+    def __init__(self, *, config: ConfigPort, logger: LoggerPort) -> None:
+        super().__init__(config.database.connection_string, logger)
+        self._logger = logger
+
+    def list(
+        self,
+        *,
+        uow: Uow,
+        cvm_code: str | None = None,
+        company_name: str | None = None,
+        segment: str | None = None,
+    ) -> list[ValidCompanyReadModelDTO]:
+        session: Session = uow.session
+        query = session.query(ValidCompanyReadModel)
+
+        if cvm_code:
+            query = query.filter(ValidCompanyReadModel.cvm_code == cvm_code)
+
+        if company_name:
+            like = f"%{company_name}%"
+            query = query.filter(ValidCompanyReadModel.company_name.ilike(like))
+
+        if segment:
+            like = f"%{segment}%"
+            query = query.filter(
+                (ValidCompanyReadModel.company_segment.ilike(like))
+                | (ValidCompanyReadModel.industry_segment.ilike(like))
+            )
+
+        query = query.order_by(ValidCompanyReadModel.company_name)
+        rows = query.all()
+
+        return [row.to_dto() for row in rows]
+
+    def replace_all(
+        self,
+        items: Sequence[ValidCompanyReadModelDTO],
+        *,
+        uow: Uow,
+    ) -> None:
+        session: Session = uow.session
+
+        session.execute(delete(ValidCompanyReadModel))
+
+        if items:
+            objects = [ValidCompanyReadModel.from_dto(item) for item in items]
+            session.bulk_save_objects(objects)
+
+        self._logger.log(
+            f"Projection read_valid_companies replaced with {len(items)} rows",
+            level="debug",
+        )

--- a/presentation/controllers/cli.py
+++ b/presentation/controllers/cli.py
@@ -12,6 +12,8 @@ from domain.ports.ratios_cache_port import RatiosCachePort
 
 from domain.ports.repository_stock_quote_port import RepositoryStockQuotePort
 from domain.ports.repository_indicators_port import RepositoryIndicatorsPort
+from domain.ports.valid_companies_read_port import ValidCompaniesReadPort
+from domain.ports.valid_companies_write_port import ValidCompaniesWritePort
 
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
 from domain.ports.scraper_nsd_port import ScraperNsdPort
@@ -62,6 +64,8 @@ class Cli:
         policy: NsdPolicyPort,
         uow_factory: UowFactoryPort,
         http_client: AffinityHttpClientPort,
+        valid_companies_read_port: ValidCompaniesReadPort,
+        valid_companies_write_port: ValidCompaniesWritePort,
     ) -> None:
         """Initialize the CLI with injected ports."""
         # Store injected dependencies for later composition
@@ -88,6 +92,8 @@ class Cli:
         self.uow_factory = uow_factory
 
         self.byte_formatter = ByteFormatter()
+        self.valid_companies_read_port = valid_companies_read_port
+        self.valid_companies_write_port = valid_companies_write_port
 
     def __call__(self) -> None:
         return self.run()
@@ -198,6 +204,8 @@ class Cli:
 
             uow_factory=self.uow_factory,
             worker_pool=self.worker_pool,
+            valid_companies_read_port=self.valid_companies_read_port,
+            valid_companies_write_port=self.valid_companies_write_port,
         )
 
         # run the service

--- a/tests/application/usecases/test_normalize_ratios_flow.py
+++ b/tests/application/usecases/test_normalize_ratios_flow.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Iterable, Sequence
+
+import pandas as pd
+import pytest
+
+from application.services.valid_companies_batch_updater_service import (
+    ValidCompaniesBatchUpdaterService,
+)
+from application.usecases.normalize_ratios import NormalizeUseCase
+from application.usecases.update_valid_companies_projection import (
+    UpdateValidCompaniesProjectionUseCase,
+)
+from domain.dtos import (
+    CompanyDataDTO,
+    RatiosCacheEntryDTO,
+    RatiosCacheResultDTO,
+    StatementFetchedDTO,
+    WorkerTaskDTO,
+)
+from domain.dtos.stock_quote_dto import StockQuoteDTO
+from infrastructure.repositories.valid_companies_projection_repository import (
+    ValidCompaniesProjectionRepository,
+)
+from infrastructure.uow.uow import UowFactory
+
+
+class DummyLogger:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str]] = []
+
+    def log(self, message: str, level: str = "info", **_: object) -> None:
+        self.records.append((message, level))
+
+
+class InMemoryCompanyRepository:
+    def __init__(self, companies: Sequence[CompanyDataDTO]) -> None:
+        self._companies = list(companies)
+
+    def get_all(self, *, uow, batch_size: int | None = None) -> list[CompanyDataDTO]:  # noqa: ARG002
+        return list(self._companies)
+
+
+class InMemoryStatementRepository:
+    def __init__(self, statements: Sequence[StatementFetchedDTO]) -> None:
+        self._statements = list(statements)
+
+    def get_unique_by_column(self, column_name: str, *, uow) -> list[str]:  # noqa: ARG002
+        if column_name != "company_name":
+            return []
+        return sorted({row.company_name for row in self._statements if row.company_name})
+
+    def get_by_column_values(self, values, *, uow, batch_size=None):  # noqa: ANN001, ARG002, D417
+        criteria = dict(values) if not isinstance(values, dict) else values
+        target = criteria.get("company_name")
+        if target is None:
+            return []
+        if isinstance(target, Iterable) and not isinstance(target, str):
+            names = {name for name in target if name}
+        else:
+            names = {target}
+        return [row for row in self._statements if row.company_name in names]
+
+
+class InMemoryStockQuoteRepository:
+    def __init__(self, quotes: Sequence[StockQuoteDTO]) -> None:
+        self._quotes = list(quotes)
+
+    def get_unique_by_column(self, column_name: str, *, uow) -> list[str]:  # noqa: ARG002
+        if column_name != "ticker":
+            return []
+        return sorted({row.ticker for row in self._quotes if row.ticker})
+
+    def get_by_column_values(self, values, *, uow, batch_size=None):  # noqa: ANN001, ARG002, D417
+        criteria = dict(values) if not isinstance(values, dict) else values
+        target = criteria.get("ticker")
+        if target is None:
+            return []
+        if isinstance(target, Iterable) and not isinstance(target, str):
+            tickers = {ticker for ticker in target if ticker}
+        else:
+            tickers = {target}
+        return [row for row in self._quotes if row.ticker in tickers]
+
+
+class DummyIndicatorsRepository:
+    def get_all(self, *, uow, batch_size=None):  # noqa: ANN001, ARG002, D417
+        return []
+
+
+class DummyRatiosCachePort:
+    def initialize(self) -> None:
+        return None
+
+    def load(self, cache_key: str):  # noqa: D401
+        return None
+
+    def store(self, *, context, df, company_name):  # noqa: ANN001, ARG002, D401
+        raise NotImplementedError
+
+    def invalidate_outdated(self, *, code_hash: str) -> None:  # noqa: ARG002
+        return None
+
+
+class FakeRatiosCacheService:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def get_or_compute(
+        self,
+        *,
+        company_name: str,
+        quotes,
+        statements,
+        indicators,
+        compute_fn,
+        code_hash: str,
+    ) -> tuple[pd.DataFrame, RatiosCacheResultDTO]:
+        del quotes, statements, indicators, compute_fn
+        self.calls.append(company_name)
+        entry = RatiosCacheEntryDTO(
+            cache_key=f"{company_name}-cache",
+            file_path="/tmp/fake",
+            size_bytes=0,
+            created_at=datetime.now(),
+            accessed_at=datetime.now(),
+            access_count=1,
+            code_hash=code_hash,
+        )
+        result = RatiosCacheResultDTO(
+            company_name=company_name,
+            cache_key=entry.cache_key,
+            hit=False,
+            entry=entry,
+        )
+        return pd.DataFrame({"company": [company_name]}), result
+
+
+class SequentialWorkerPool:
+    def __call__(
+        self,
+        *,
+        logger,
+        tasks,
+        processor,
+        on_result,
+        post_callback,
+        max_workers,
+        total_size,
+    ):
+        del logger, post_callback, max_workers, total_size
+        for index, data in tasks:
+            task = WorkerTaskDTO(
+                index=index,
+                data=data,
+                worker_id="worker",
+                total_size=total_size,
+            )
+            result = processor(task)
+            if callable(on_result):
+                on_result(result)
+        return []
+
+
+@pytest.fixture()
+def config(tmp_path):
+    db_path = tmp_path / "valid_companies.db"
+    return SimpleNamespace(
+        database=SimpleNamespace(connection_string=f"sqlite:///{db_path}"),
+        worker_pool=SimpleNamespace(max_workers=1),
+        repository=SimpleNamespace(batch_size=50, persistence_threshold=1),
+    )
+
+
+def test_normalize_pipeline_reads_projection(config):
+    logger = DummyLogger()
+
+    valid_repo = ValidCompaniesProjectionRepository(config=config, logger=logger)
+    uow_factory = UowFactory(session_factory=valid_repo.Session)
+
+    companies = [
+        CompanyDataDTO(
+            company_name="ACME SA",
+            cvm_code="12345",
+            ticker_codes=["ACME3"],
+            trading_name="ACME",
+            industry_sector="Sector",
+            industry_subsector="Subsector",
+            industry_segment="Segment",
+            company_segment="Segment",
+        )
+    ]
+
+    statements = [
+        StatementFetchedDTO(
+            nsd="1",
+            company_name="ACME SA",
+            quarter=datetime(2023, 12, 31),
+            version="1",
+            grupo="DFs Consolidadas",
+            quadro="Balanço",
+            account="ACC",
+            description="Account",
+            value=100.0,
+        )
+    ]
+
+    quotes = [
+        StockQuoteDTO(
+            company_name="ACME SA",
+            ticker="ACME3",
+            date=datetime(2023, 12, 15),
+            open=10.0,
+            high=11.0,
+            low=9.5,
+            close=10.5,
+            adj_close=10.5,
+            volume=1_000,
+            currency="BRL",
+        )
+    ]
+
+    company_repo = InMemoryCompanyRepository(companies)
+    statement_repo = InMemoryStatementRepository(statements)
+    quote_repo = InMemoryStockQuoteRepository(quotes)
+    indicator_repo = DummyIndicatorsRepository()
+
+    batch_service = ValidCompaniesBatchUpdaterService(
+        logger=logger,
+        write_port=valid_repo,
+    )
+
+    update_usecase = UpdateValidCompaniesProjectionUseCase(
+        logger=logger,
+        repository_company=company_repo,
+        repository_statements_fetched=statement_repo,
+        repository_stock_quote=quote_repo,
+        batch_service=batch_service,
+        uow_factory=uow_factory,
+    )
+
+    projection = update_usecase()
+    assert len(projection) == 1
+    assert projection[0].ticker_codes == ("ACME3",)
+
+    normalize_usecase = NormalizeUseCase(
+        config=config,
+        logger=logger,
+        repository_stock_quote=quote_repo,
+        repository_indicators=indicator_repo,
+        repository_statements_fetched=statement_repo,
+        ratios_cache=DummyRatiosCachePort(),
+        valid_companies_read_port=valid_repo,
+        uow_factory=uow_factory,
+        worker_pool=SequentialWorkerPool(),
+    )
+    fake_cache = FakeRatiosCacheService()
+    normalize_usecase.ratios_cache_service = fake_cache
+    normalize_usecase._ratios_code_hash = "fake-code"
+
+    results = normalize_usecase.run()
+
+    assert len(results.items) == 1
+    assert fake_cache.calls == ["ACME SA"]


### PR DESCRIPTION
## Summary
- clean NormalizeUseCase to rely exclusively on the valid companies projection for company iteration
- move ratios cache invalidation into the cache adapter to encapsulate cache lifecycle
- add an integration-style test that refreshes the projection before invoking normalization via the read port

## Testing
- pytest tests/application/usecases/test_normalize_ratios_flow.py *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6907234cde70832e9475860e96cddd64