### PR TITLE
Align CompanyEligibleDTO with CompanyDataDTO fields

### DIFF
--- a/domain/dtos/company_eligible_dto.py
+++ b/domain/dtos/company_eligible_dto.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Dict, Tuple
 
+from domain.dtos.company_data_dto import CodeDTO
 from domain.entities import EligibleCompany
 
 
@@ -12,16 +14,48 @@ from domain.entities import EligibleCompany
 class CompanyEligibleDTO:
     """Data transfer object for the eligible companies projection."""
 
-    company_name: str
-    cvm_code: str | None
-    ticker_codes: Tuple[str, ...]
-    reason: str
-
+    id: int | None = None
+    cvm_code: str | None = None
+    issuing_company: str | None = None
     trading_name: str | None = None
+    company_name: str | None = None
+    cnpj: str | None = None
+    ticker_codes: Tuple[str, ...] = field(default_factory=tuple)
+    isin_codes: Tuple[str, ...] = field(default_factory=tuple)
+    other_codes: Tuple[CodeDTO, ...] = field(default_factory=tuple)
+    market: str | None = None
+
     industry_sector: str | None = None
     industry_subsector: str | None = None
     industry_segment: str | None = None
+    industry_classification: str | None = None
+    industry_classification_eng: str | None = None
+    activity: str | None = None
+
     company_segment: str | None = None
+    company_segment_eng: str | None = None
+    company_category: str | None = None
+    company_type: str | None = None
+
+    listing_segment: str | None = None
+    registrar: str | None = None
+    website: str | None = None
+    institution_common: str | None = None
+    institution_preferred: str | None = None
+
+    status: str | None = None
+    market_indicator: str | None = None
+    code: str | None = None
+    has_bdr: bool | None = None
+    type_bdr: str | None = None
+    has_quotation: bool | None = None
+    has_emissions: bool | None = None
+
+    date_quotation: datetime | None = None
+    last_date: datetime | None = None
+    listing_date: datetime | None = None
+
+    reason: str | None = None
 
     @staticmethod
     def from_entity(entity: EligibleCompany) -> "CompanyEligibleDTO":
@@ -41,13 +75,43 @@ class CompanyEligibleDTO:
         """Expose a plain dictionary for dataframe creation and serialization."""
 
         return {
-            "company_name": self.company_name,
+            "id": self.id,
             "cvm_code": self.cvm_code,
-            "ticker_codes": list(self.ticker_codes),
-            "reason": self.reason,
+            "issuing_company": self.issuing_company,
             "trading_name": self.trading_name,
+            "company_name": self.company_name,
+            "cnpj": self.cnpj,
+            "ticker_codes": list(self.ticker_codes),
+            "isin_codes": list(self.isin_codes),
+            "other_codes": [
+                {"code": code.code, "isin": code.isin}
+                for code in self.other_codes
+            ],
+            "market": self.market,
             "industry_sector": self.industry_sector,
             "industry_subsector": self.industry_subsector,
             "industry_segment": self.industry_segment,
+            "industry_classification": self.industry_classification,
+            "industry_classification_eng": self.industry_classification_eng,
+            "activity": self.activity,
             "company_segment": self.company_segment,
+            "company_segment_eng": self.company_segment_eng,
+            "company_category": self.company_category,
+            "company_type": self.company_type,
+            "listing_segment": self.listing_segment,
+            "registrar": self.registrar,
+            "website": self.website,
+            "institution_common": self.institution_common,
+            "institution_preferred": self.institution_preferred,
+            "status": self.status,
+            "market_indicator": self.market_indicator,
+            "code": self.code,
+            "has_bdr": self.has_bdr,
+            "type_bdr": self.type_bdr,
+            "has_quotation": self.has_quotation,
+            "has_emissions": self.has_emissions,
+            "date_quotation": self.date_quotation,
+            "last_date": self.last_date,
+            "listing_date": self.listing_date,
+            "reason": self.reason,
         }


### PR DESCRIPTION
## Summary
- align the eligible company DTO structure with CompanyDataDTO fields while keeping existing projection data
- default optional attributes to empty tuples or None so existing entity projections remain valid
- include the expanded attribute set when serializing the DTO to dictionaries

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_690789076c68832e80ca4dcb771f76e5