### PR TITLE
Refine engine setup and cache initialization

### DIFF
--- a/infrastructure/adapters/engine_setup.py
+++ b/infrastructure/adapters/engine_setup.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import MetaData, create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from application.ports.logger_port import LoggerPort
@@ -10,15 +10,24 @@ from infrastructure.models import BaseModel
 class EngineSetup:
     """Reusable mixin for adapters that need SQLAlchemy engine setup."""
 
-    def __init__(self, connection_string: str, logger: LoggerPort) -> None:
+    def __init__(
+        self,
+        connection_string: str,
+        logger: LoggerPort | None,
+        *,
+        metadata: MetaData | None = None,
+    ) -> None:
         """Initialize engine, session factory and schema.
 
         Args:
             connection_string: Connection string for the target database.
             logger: Logger adapter for emitting lifecycle messages.
+            metadata: SQLAlchemy metadata to use when creating tables. Defaults
+                to the project's base model metadata.
         """
 
         self.logger = logger
+        self._metadata = metadata or BaseModel.metadata
 
         # Create SQLAlchemy engine for SQLite with thread-safe settings
         self.engine = create_engine(
@@ -50,6 +59,6 @@ class EngineSetup:
         )
 
         # Automatically create all tables defined in the SQLAlchemy models
-        BaseModel.metadata.create_all(self.engine)
+        self._metadata.create_all(self.engine)
 
         # self.logger.log(f"Create Instance Base Class {self.__class__.__name__}", level="info")

--- a/infrastructure/cache/ratios_cache.py
+++ b/infrastructure/cache/ratios_cache.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
-from sqlalchemy import create_engine, func, select
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
 
 from application.ports.config_port import ConfigPort
 from application.ports.logger_port import LoggerPort
@@ -16,34 +16,31 @@ from application.ports.logger_port import LoggerPort
 from domain.dtos.ratios_cache_context_dto import RatiosCacheContextDTO
 from domain.dtos.ratios_cache_entry_dto import RatiosCacheEntryDTO
 from domain.ports.ratios_cache_port import RatiosCachePort
+from infrastructure.adapters.engine_setup import EngineSetup
 from infrastructure.models.ratios_cache_model import (RatiosCacheBase, RatiosCacheEntryModel)
 
 
-class RatiosCacheAdapter(RatiosCachePort):
+class RatiosCacheAdapter(RatiosCachePort, EngineSetup):
     """SQLAlchemy-backed cache storing ratios as parquet files."""
 
     def __init__(self, *, config: ConfigPort, logger: LoggerPort | None) -> None:
         self._config = config
         self._logger = logger
 
-        self._engine = create_engine(
+        EngineSetup.__init__(
+            self,
             self._config.database.connection_cache_string,
-            connect_args={"check_same_thread": False, "timeout": 60},
-            pool_pre_ping=True,
-            future=True,
+            logger,
+            metadata=RatiosCacheBase.metadata,
         )
 
-        self._session_factory = sessionmaker(
-            bind=self._engine,
-            expire_on_commit=False,
-            future=True,
-        )
-
-    def initialize(self) -> None:
-        RatiosCacheBase.metadata.create_all(self._engine)
+    def initialize(self) -> None:  # pragma: no cover - retained for backwards compatibility
+        """Backwards compatible no-op initializer."""
+        # Tables are created during EngineSetup initialization.
+        return None
 
     def load(self, cache_key: str) -> tuple[pd.DataFrame, RatiosCacheEntryDTO] | None:
-        with self._session_factory() as session:
+        with self.Session() as session:
             entry = session.get(RatiosCacheEntryModel, cache_key)
             if entry is None:
                 return None
@@ -87,7 +84,7 @@ class RatiosCacheAdapter(RatiosCachePort):
         entry: RatiosCacheEntryModel | None = None
 
         try:
-            with self._session_factory.begin() as session:
+            with self.Session.begin() as session:
                 entry = session.get(RatiosCacheEntryModel, context.cache_key)
                 if entry is None:
                     entry = RatiosCacheEntryModel(
@@ -116,7 +113,7 @@ class RatiosCacheAdapter(RatiosCachePort):
             temp_path.replace(file_path)
         except Exception:
             temp_path.unlink(missing_ok=True)
-            with self._session_factory.begin() as session:
+            with self.Session.begin() as session:
                 stale_entry = session.get(RatiosCacheEntryModel, context.cache_key)
                 if stale_entry is not None:
                     session.delete(stale_entry)
@@ -140,7 +137,7 @@ class RatiosCacheAdapter(RatiosCachePort):
     def _invalidate_outdated(self, *, code_hash: str) -> None:
         cutoff = datetime.now() - self._config.cache.max_age
 
-        with self._session_factory.begin() as session:
+        with self.Session.begin() as session:
             entries = session.scalars(
                 select(RatiosCacheEntryModel).where(
                     (RatiosCacheEntryModel.code_hash != code_hash)
@@ -153,7 +150,7 @@ class RatiosCacheAdapter(RatiosCachePort):
                 session.delete(entry)
 
     def _evict_cache_if_needed(self) -> None:
-        with self._session_factory.begin() as session:
+        with self.Session.begin() as session:
             total_size = session.execute(
                 select(func.coalesce(func.sum(RatiosCacheEntryModel.size_bytes), 0))
             ).scalar_one()

--- a/infrastructure/factories/cli_factory.py
+++ b/infrastructure/factories/cli_factory.py
@@ -62,7 +62,6 @@ def cli_factory(config: ConfigPort, logger: LoggerPort) -> Cli:
     repository_stock_quote = RepositoryStockQuote(config=config, logger=logger)
     repository_indicators = RepositoryIndicators(config=config, logger=logger)
     ratios_cache = RatiosCacheAdapter(config=config, logger=logger)
-    ratios_cache.initialize()
 
     # Unit of Work
     uow_factory = UowFactory(session_factory=repository_nsd.Session)

--- a/infrastructure/models/company_eligible_model.py
+++ b/infrastructure/models/company_eligible_model.py
@@ -10,9 +10,9 @@ from .base_model import BaseModel
 
 
 class CompanyEligibleModel(BaseModel):
-    """ORM mapping for the ``proj_eligible_companies`` table."""
+    """ORM mapping for the ``tbl_company_eligible`` table."""
 
-    __tablename__ = "proj_eligible_companies"
+    __tablename__ = "tbl_company_eligible"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     company_name = Column(String, nullable=False, unique=True)
@@ -26,9 +26,9 @@ class CompanyEligibleModel(BaseModel):
     reason = Column(String, nullable=False)
 
     __table_args__ = (
-        Index("ix_proj_eligible_companies_company_name", "company_name"),
-        Index("ix_proj_eligible_companies_cvm_code", "cvm_code"),
-        Index("ix_proj_eligible_companies_segment", "company_segment"),
+        Index("ix_tbl_company_eligible_company_name", "company_name"),
+        Index("ix_tbl_company_eligible_cvm_code", "cvm_code"),
+        Index("ix_tbl_company_eligible_segment", "company_segment"),
     )
 
     @classmethod

--- a/infrastructure/repositories/repository_company_eligible.py
+++ b/infrastructure/repositories/repository_company_eligible.py
@@ -88,6 +88,6 @@ class RepositoryCompanyEligible(
             session.bulk_save_objects(objects)
 
         self._logger.log(
-            f"Projection proj_eligible_companies replaced with {len(items)} rows",
+            f"Projection tbl_company_eligible replaced with {len(items)} rows",
             level="debug",
         )


### PR DESCRIPTION
## Summary
- allow EngineSetup to work with configurable SQLAlchemy metadata
- reuse the shared engine setup inside RatiosCacheAdapter so cache tables are created automatically
- rename the eligible companies table to tbl_company_eligible and update related references

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_69078b8940c4832e9267cd63bb0a2845