### PR TITLE
refactor: use absolute imports in application and infrastructure

### DIFF
--- a/application/ports/worker_pool_port.py
+++ b/application/ports/worker_pool_port.py
@@ -14,7 +14,7 @@ from typing import (
 
 from domain.dtos import WorkerTaskDTO
 
-from .logger_port import LoggerPort
+from application.ports.logger_port import LoggerPort
 
 # Generic type variable for processor return values
 R = TypeVar("R")

--- a/application/utils/__init__.py
+++ b/application/utils/__init__.py
@@ -1,3 +1,3 @@
-from .logger_facade import LoggerFacade
+from application.utils.logger_facade import LoggerFacade
 
 __all__ = ["LoggerFacade"]

--- a/infrastructure/http/__init__.py
+++ b/infrastructure/http/__init__.py
@@ -1,3 +1,3 @@
-from .affinity_http_client import RequestsAffinityHttpClient
+from infrastructure.http.affinity_http_client import RequestsAffinityHttpClient
 
 __all__ = ["RequestsAffinityHttpClient"]

--- a/infrastructure/logging/__init__.py
+++ b/infrastructure/logging/__init__.py
@@ -1,3 +1,3 @@
-from .logger_adapter import Logger
+from infrastructure.logging.logger_adapter import Logger
 
 __all__ = ["Logger"]

--- a/infrastructure/models/__init__.py
+++ b/infrastructure/models/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from .base_model import BaseModel
-from .company_eligible_model import CompanyEligibleModel
+from infrastructure.models.base_model import BaseModel
+from infrastructure.models.company_eligible_model import CompanyEligibleModel
 
 __all__ = [
     "BaseModel",

--- a/infrastructure/models/company_eligible_model.py
+++ b/infrastructure/models/company_eligible_model.py
@@ -6,7 +6,7 @@ from sqlalchemy import JSON, Column, Index, Integer, String
 
 from domain.dtos.company_eligible_dto import CompanyEligibleDTO
 
-from .base_model import BaseModel
+from infrastructure.models.base_model import BaseModel
 
 
 class CompanyEligibleModel(BaseModel):

--- a/infrastructure/scrapers/__init__.py
+++ b/infrastructure/scrapers/__init__.py
@@ -1,3 +1,3 @@
-from .scraper_company_data import CompanyDataScraper
+from infrastructure.scrapers.scraper_company_data import CompanyDataScraper
 
 __all__ = ["CompanyDataScraper"]

--- a/infrastructure/utils/__init__.py
+++ b/infrastructure/utils/__init__.py
@@ -1,5 +1,5 @@
-from .byte_formatter import ByteFormatter
-from .list_flatenner import ListFlattener
-from .version import get_version
+from infrastructure.utils.byte_formatter import ByteFormatter
+from infrastructure.utils.list_flatenner import ListFlattener
+from infrastructure.utils.version import get_version
 
 __all__ = ["ByteFormatter", "ListFlattener","get_version"]


### PR DESCRIPTION
## Summary
- replace package-relative imports with fully qualified module paths across the application and infrastructure packages to standardize import resolution

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_690794848f14832e901a2bd0fa0e09f5