### PR TITLE
Enhance company search query builder

### DIFF
--- a/application/dtos/company_search_dto.py
+++ b/application/dtos/company_search_dto.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class CompanySearchResultDTO:
+    company_name: str
+    trading_name: str | None
+    tickers: List[str] = field(default_factory=list)
+    sector: str | None = None
+    subsector: str | None = None
+    segment: str | None = None
+    market: str | None = None
+    institution_common: str | None = None
+    institution_preferred: str | None = None
+
+
+@dataclass(frozen=True)
+class CompanySearchResponseDTO:
+    items: List[CompanySearchResultDTO]
+    total: int
+    facets: Dict[str, List[str]] = field(default_factory=dict)

--- a/application/usecases/search_companies.py
+++ b/application/usecases/search_companies.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+from application.dtos.company_search_dto import (
+    CompanySearchResponseDTO,
+    CompanySearchResultDTO,
+)
+from application.ports.uow_port import UowFactoryPort
+from domain.dtos.company_data_dto import CompanyDataDTO
+from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from domain.value_objects.company_filters import CompanyFilterQuery, CompanyField
+
+
+DEFAULT_LIMIT = 200
+
+
+@dataclass
+class SearchCompaniesUseCase:
+    repository: RepositoryCompanyDataPort
+    uow_factory: UowFactoryPort
+
+    def __call__(
+        self,
+        query: CompanyFilterQuery | None = None,
+        *,
+        limit: int | None = None,
+    ) -> CompanySearchResponseDTO:
+        query = query or CompanyFilterQuery()
+        with self.uow_factory() as uow:
+            dtos: List[CompanyDataDTO] = self.repository.search(
+                query,
+                uow=uow,
+                limit=limit or DEFAULT_LIMIT,
+            )
+
+        items = [self._to_result(dto) for dto in dtos]
+        facets = self._build_facets(items)
+        return CompanySearchResponseDTO(items=items, total=len(items), facets=facets)
+
+    def _to_result(self, dto: CompanyDataDTO) -> CompanySearchResultDTO:
+        return CompanySearchResultDTO(
+            company_name=dto.company_name or "",
+            trading_name=dto.trading_name,
+            tickers=list(dto.ticker_codes or []),
+            sector=dto.industry_sector,
+            subsector=dto.industry_subsector,
+            segment=dto.industry_segment,
+            market=dto.market,
+            institution_common=dto.institution_common,
+            institution_preferred=dto.institution_preferred,
+        )
+
+    def _build_facets(
+        self,
+        items: Iterable[CompanySearchResultDTO],
+    ) -> Dict[str, List[str]]:
+        buckets: Dict[str, set[str]] = {
+            CompanyField.SECTOR.value: set(),
+            CompanyField.SUBSECTOR.value: set(),
+            CompanyField.SEGMENT.value: set(),
+            CompanyField.COMPANY_NAME.value: set(),
+            CompanyField.TRADING_NAME.value: set(),
+            CompanyField.TICKER.value: set(),
+            CompanyField.INSTITUTION_COMMON.value: set(),
+            CompanyField.INSTITUTION_PREFERRED.value: set(),
+            CompanyField.MARKET.value: set(),
+        }
+
+        for item in items:
+            if item.company_name:
+                buckets[CompanyField.COMPANY_NAME.value].add(item.company_name)
+            if item.trading_name:
+                buckets[CompanyField.TRADING_NAME.value].add(item.trading_name)
+            for ticker in item.tickers:
+                if ticker:
+                    buckets[CompanyField.TICKER.value].add(ticker)
+            if item.sector:
+                buckets[CompanyField.SECTOR.value].add(item.sector)
+            if item.subsector:
+                buckets[CompanyField.SUBSECTOR.value].add(item.subsector)
+            if item.segment:
+                buckets[CompanyField.SEGMENT.value].add(item.segment)
+            if item.market:
+                buckets[CompanyField.MARKET.value].add(item.market)
+            if item.institution_common:
+                buckets[CompanyField.INSTITUTION_COMMON.value].add(item.institution_common)
+            if item.institution_preferred:
+                buckets[CompanyField.INSTITUTION_PREFERRED.value].add(
+                    item.institution_preferred
+                )
+
+        return {
+            key: sorted({v for v in values if v})
+            for key, values in buckets.items()
+            if values
+        }

--- a/domain/ports/repository_company_data_port.py
+++ b/domain/ports/repository_company_data_port.py
@@ -5,6 +5,7 @@ from typing import Protocol, runtime_checkable
 from application.ports.uow_port import Uow
 from domain.dtos.company_data_dto import CompanyDataDTO
 from domain.ports.repository_base_port import RepositoryBasePort
+from domain.value_objects.company_filters import CompanyFilterQuery
 
 
 @runtime_checkable
@@ -39,3 +40,12 @@ class RepositoryCompanyDataPort(RepositoryBasePort[CompanyDataDTO, int], Protoco
         self, uow: Uow, company_names: list[str] | None = None
     ) -> dict[str, list[str]]:
         ...
+
+    def search(
+        self,
+        query: CompanyFilterQuery,
+        *,
+        uow: Uow,
+        limit: int | None = None,
+    ) -> list[CompanyDataDTO]:
+        """Return companies matching the structured filter query."""

--- a/domain/value_objects/__init__.py
+++ b/domain/value_objects/__init__.py
@@ -1,0 +1,19 @@
+"""Domain-level value objects shared across use cases."""
+
+from .company_filters import (
+    CompanyField,
+    ComparisonOperator,
+    LogicalOperator,
+    CompanyFilterCondition,
+    CompanyFilterClause,
+    CompanyFilterQuery,
+)
+
+__all__ = [
+    "CompanyField",
+    "ComparisonOperator",
+    "LogicalOperator",
+    "CompanyFilterCondition",
+    "CompanyFilterClause",
+    "CompanyFilterQuery",
+]

--- a/domain/value_objects/company_filters.py
+++ b/domain/value_objects/company_filters.py
@@ -1,0 +1,86 @@
+"""Structured filter model used by the company search use case."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List
+
+
+class CompanyField(str, Enum):
+    """Enumeration of filterable company attributes."""
+
+    SECTOR = "sector"
+    SUBSECTOR = "subsector"
+    SEGMENT = "segment"
+    COMPANY_NAME = "company_name"
+    TRADING_NAME = "trading_name"
+    TICKER = "ticker"
+    INSTITUTION_PREFERRED = "institution_preferred"
+    INSTITUTION_COMMON = "institution_common"
+    MARKET = "market"
+
+
+class ComparisonOperator(str, Enum):
+    """Supported comparison operators for company filters."""
+
+    EQUALS = "EQUALS"
+    IN = "IN"
+    CONTAINS = "CONTAINS"
+    STARTS_WITH = "STARTS_WITH"
+
+
+class LogicalOperator(str, Enum):
+    """Logical operators that combine filter clauses."""
+
+    AND = "AND"
+    OR = "OR"
+    NOT = "NOT"
+
+    def is_negative(self) -> bool:
+        """Return ``True`` when the clause is meant to be negated."""
+
+        return self is LogicalOperator.NOT
+
+
+@dataclass(frozen=True)
+class CompanyFilterCondition:
+    """A leaf condition applied to a specific field."""
+
+    field: CompanyField
+    operator: ComparisonOperator
+    values: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CompanyFilterClause:
+    """One clause in the structured filter query."""
+
+    logical: LogicalOperator
+    condition: CompanyFilterCondition | None = None
+    group: "CompanyFilterQuery" | None = None
+
+    def __post_init__(self) -> None:
+        has_condition = self.condition is not None
+        has_group = self.group is not None
+        if has_condition and has_group:
+            raise ValueError("A clause cannot have both condition and group")
+        if not has_condition and not has_group:
+            raise ValueError("A clause must define either a condition or a group")
+
+    def is_group(self) -> bool:
+        """Return ``True`` when this clause wraps a nested query."""
+
+        return self.group is not None
+
+
+@dataclass(frozen=True)
+class CompanyFilterQuery:
+    """Structured representation of the company search filters."""
+
+    clauses: List[CompanyFilterClause] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        """Return ``True`` when the query has no active clauses."""
+
+        return len(self.clauses) == 0

--- a/infrastructure/repositories/repository_company_data.py
+++ b/infrastructure/repositories/repository_company_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Tuple
 
+from sqlalchemy import and_, func, not_, or_, text
 from sqlalchemy.dialects.sqlite import insert
 
 from application.ports.config_port import ConfigPort
@@ -9,6 +10,14 @@ from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import Uow
 from domain.dtos.company_data_dto import CompanyDataDTO
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from domain.value_objects.company_filters import (
+    CompanyFilterClause,
+    CompanyFilterCondition,
+    CompanyFilterQuery,
+    CompanyField,
+    ComparisonOperator,
+    LogicalOperator,
+)
 from infrastructure.models.company_data_model import CompanyDataModel
 from infrastructure.repositories.repository_base import RepositoryBase
 
@@ -192,3 +201,183 @@ class RepositoryCompanyData(
             if tickers:
                 out[r["company_name"]] = tickers
         return out
+
+    # ------------------------------------------------------------------
+    # Query builder support
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        query: CompanyFilterQuery,
+        *,
+        uow: Uow,
+        limit: int | None = None,
+    ) -> list[CompanyDataDTO]:
+        """Run a structured search against the company catalog."""
+
+        model, _ = self.get_model_class()
+        session = uow.session
+
+        stmt = session.query(model)
+
+        boolean_expression = self._build_boolean_expression(query.clauses, model)
+        if boolean_expression is not None:
+            stmt = stmt.filter(boolean_expression)
+
+        stmt = stmt.order_by(model.company_name.asc())
+
+        if limit is None:
+            limit = 200
+        if limit:
+            stmt = stmt.limit(limit)
+
+        rows = stmt.all()
+        return [row.to_dto() for row in rows]
+
+    # Helpers -----------------------------------------------------------------
+    def _build_boolean_expression(
+        self, clauses: list[CompanyFilterClause], model
+    ) -> Optional[object]:
+        if not clauses:
+            return None
+
+        must_clauses: list[object] = []
+        should_clauses: list[object] = []
+        negative_clauses: list[object] = []
+
+        for clause in clauses:
+            if clause.is_group():
+                expression = self._build_boolean_expression(clause.group.clauses, model)
+            else:
+                expression = self._build_condition_expression(clause.condition, model)
+
+            if expression is None:
+                continue
+
+            if clause.logical == LogicalOperator.AND:
+                must_clauses.append(expression)
+            elif clause.logical == LogicalOperator.OR:
+                should_clauses.append(expression)
+            elif clause.logical == LogicalOperator.NOT:
+                negative_clauses.append(expression)
+
+        return self._combine_boolean_expressions(
+            must_clauses, should_clauses, negative_clauses
+        )
+
+    def _combine_boolean_expressions(
+        self,
+        must_clauses: list[object],
+        should_clauses: list[object],
+        negative_clauses: list[object],
+    ) -> Optional[object]:
+        expression: Optional[object] = None
+
+        if must_clauses:
+            expression = and_(*must_clauses)
+
+        if should_clauses:
+            should_expr = (
+                should_clauses[0]
+                if len(should_clauses) == 1
+                else or_(*should_clauses)
+            )
+            expression = (
+                should_expr
+                if expression is None
+                else and_(expression, should_expr)
+            )
+
+        if negative_clauses:
+            negatives = [not_(expr) for expr in negative_clauses]
+            negative_expr = (
+                negatives[0] if len(negatives) == 1 else and_(*negatives)
+            )
+            expression = (
+                negative_expr
+                if expression is None
+                else and_(expression, negative_expr)
+            )
+
+        return expression
+
+    def _build_condition_expression(
+        self, condition: CompanyFilterCondition, model
+    ) -> Optional[object]:
+        if condition is None:
+            return None
+
+        if not condition.values and condition.operator not in (
+            ComparisonOperator.CONTAINS,
+            ComparisonOperator.STARTS_WITH,
+        ):
+            return None
+
+        column = self._map_field(condition.field, model)
+        if column is None:
+            return None
+
+        values = [v for v in condition.values if v is not None]
+
+        if condition.field == CompanyField.TICKER:
+            return self._build_ticker_expression(condition, column)
+
+        if condition.operator == ComparisonOperator.CONTAINS:
+            return self._string_expression(column, values, mode="contains")
+
+        if condition.operator == ComparisonOperator.STARTS_WITH:
+            return self._string_expression(column, values, mode="starts_with")
+
+        if condition.operator == ComparisonOperator.EQUALS:
+            if len(values) == 1:
+                value = values[0]
+                return func.lower(column) == value.lower()
+            lowered = [v.lower() for v in values]
+            return func.lower(column).in_(lowered)
+
+        if condition.operator == ComparisonOperator.IN:
+            lowered = [v.lower() for v in values]
+            return func.lower(column).in_(lowered)
+
+        return None
+
+    def _string_expression(self, column, values: list[str], *, mode: str):
+        expressions = []
+        for value in values or [""]:
+            pattern = value.lower()
+            if mode == "contains":
+                like_pattern = f"%{pattern}%"
+            else:
+                like_pattern = f"{pattern}%"
+            expressions.append(func.lower(column).like(like_pattern))
+        return or_(*expressions) if expressions else None
+
+    def _build_ticker_expression(
+        self,
+        condition: CompanyFilterCondition,
+        column,
+    ) -> Optional[object]:
+        values = [v for v in condition.values if v]
+        if not values:
+            return None
+
+        normalized_column = func.replace(func.coalesce(column, ""), " ", "")
+        expressions = []
+        for value in values:
+            token = value.strip().upper()
+            like_pattern = f"%{token}%"
+            expressions.append(func.upper(normalized_column).like(like_pattern))
+        return or_(*expressions) if expressions else None
+
+    def _map_field(self, field: CompanyField, model):
+        mapping = {
+            CompanyField.SECTOR: model.industry_sector,
+            CompanyField.SUBSECTOR: model.industry_subsector,
+            CompanyField.SEGMENT: model.industry_segment,
+            CompanyField.COMPANY_NAME: model.company_name,
+            CompanyField.TRADING_NAME: model.trading_name,
+            CompanyField.TICKER: model.ticker_codes,
+            CompanyField.INSTITUTION_PREFERRED: model.institution_preferred,
+            CompanyField.INSTITUTION_COMMON: model.institution_common,
+            CompanyField.MARKET: model.market,
+        }
+        return mapping.get(field)

--- a/presentation/backend/api.py
+++ b/presentation/backend/api.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from presentation.backend.routers.charts import router as charts_router
+from presentation.backend.routers.companies import router as companies_router
 
 
 def create_app() -> FastAPI:
@@ -22,6 +23,7 @@ def create_app() -> FastAPI:
 
     # Camada de apresentação: apenas inclui routers finos
     app.include_router(charts_router)
+    app.include_router(companies_router)
 
     return app
 

--- a/presentation/backend/dependencies/company_search_dependencies.py
+++ b/presentation/backend/dependencies/company_search_dependencies.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from application.usecases.search_companies import SearchCompaniesUseCase
+from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from infrastructure.config.config_adapter import ConfigAdapter
+from infrastructure.logging.logger_adapter import Logger
+from infrastructure.repositories.repository_company_data import RepositoryCompanyData
+from infrastructure.uow.uow import UowFactory
+
+
+def get_company_search_usecase() -> SearchCompaniesUseCase:
+    config = ConfigAdapter()
+    logger = Logger(config)
+    repository: RepositoryCompanyDataPort = RepositoryCompanyData(
+        config=config,
+        logger=logger,
+    )
+    uow_factory = UowFactory(session_factory=repository.Session)
+    return SearchCompaniesUseCase(repository=repository, uow_factory=uow_factory)

--- a/presentation/backend/dto/company_search_dto.py
+++ b/presentation/backend/dto/company_search_dto.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field, root_validator
+
+
+class CompanyFilterConditionDTO(BaseModel):
+    field: str
+    operator: str = Field(default="IN")
+    values: List[str] = Field(default_factory=list)
+
+
+class CompanyFilterClauseDTO(BaseModel):
+    logical: str = Field(default="AND")
+    condition: Optional[CompanyFilterConditionDTO] = None
+    group: Optional["CompanyFilterQueryDTO"] = None
+
+    @root_validator
+    def check_structure(cls, values):  # noqa: D417
+        condition, group = values.get("condition"), values.get("group")
+        if condition is None and group is None:
+            raise ValueError(
+                "Each clause must provide either a condition or a nested group"
+            )
+        if condition is not None and group is not None:
+            raise ValueError(
+                "A clause cannot define both a condition and a nested group"
+            )
+        return values
+
+
+class CompanyFilterQueryDTO(BaseModel):
+    clauses: List[CompanyFilterClauseDTO] = Field(default_factory=list)
+
+
+CompanyFilterClauseDTO.update_forward_refs()
+
+
+class CompanySearchResultDTO(BaseModel):
+    company_name: str
+    trading_name: Optional[str] = None
+    tickers: List[str] = Field(default_factory=list)
+    sector: Optional[str] = None
+    subsector: Optional[str] = None
+    segment: Optional[str] = None
+    market: Optional[str] = None
+    institution_common: Optional[str] = None
+    institution_preferred: Optional[str] = None
+
+
+class CompanySearchResponseDTO(BaseModel):
+    items: List[CompanySearchResultDTO]
+    total: int
+    facets: Dict[str, List[str]] = Field(default_factory=dict)

--- a/presentation/backend/routers/companies.py
+++ b/presentation/backend/routers/companies.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from dataclasses import asdict
+from dataclasses import asdict
+
+from fastapi import APIRouter, Depends
+
+from application.usecases.search_companies import SearchCompaniesUseCase
+from domain.value_objects.company_filters import (
+    CompanyFilterClause,
+    CompanyFilterCondition,
+    CompanyFilterQuery,
+    CompanyField,
+    ComparisonOperator,
+    LogicalOperator,
+)
+from presentation.backend.dependencies.company_search_dependencies import (
+    get_company_search_usecase,
+)
+from presentation.backend.dto.company_search_dto import (
+    CompanyFilterConditionDTO,
+    CompanyFilterQueryDTO,
+    CompanySearchResponseDTO,
+)
+
+
+router = APIRouter(prefix="/companies", tags=["companies"])
+
+
+@router.post("/search", response_model=CompanySearchResponseDTO)
+async def search_companies(
+    filters: CompanyFilterQueryDTO | None = None,
+    use_case: SearchCompaniesUseCase = Depends(get_company_search_usecase),
+) -> CompanySearchResponseDTO:
+    query = _map_to_domain(filters)
+    result = use_case(query=query)
+    return CompanySearchResponseDTO(**asdict(result))
+
+
+def _map_to_domain(dto: CompanyFilterQueryDTO | None) -> CompanyFilterQuery:
+    if dto is None:
+        return CompanyFilterQuery()
+
+    clauses: list[CompanyFilterClause] = []
+    for clause in dto.clauses:
+        logical = _map_logical(clause.logical)
+        if logical is None:
+            continue
+        condition = _map_condition(clause.condition)
+        group = _map_to_domain(clause.group) if clause.group else None
+
+        if group is not None and not group.clauses:
+            group = None
+
+        if condition is None and group is None:
+            continue
+
+        try:
+            clauses.append(
+                CompanyFilterClause(
+                    logical=logical,
+                    condition=condition,
+                    group=group,
+                )
+            )
+        except ValueError:
+            continue
+    return CompanyFilterQuery(clauses=clauses)
+
+
+def _map_logical(value: str | None) -> LogicalOperator | None:
+    if not value:
+        return LogicalOperator.AND
+    try:
+        normalized = value.strip().upper()
+        aliases = {
+            "MUST": LogicalOperator.AND,
+            "SHOULD": LogicalOperator.OR,
+            "MUST_NOT": LogicalOperator.NOT,
+            "SHOULD_NOT": LogicalOperator.NOT,
+            "OR-NOT": LogicalOperator.NOT,
+            "OR_NOT": LogicalOperator.NOT,
+        }
+        if normalized in aliases:
+            return aliases[normalized]
+        return LogicalOperator(normalized)
+    except ValueError:
+        return None
+
+
+def _map_condition(
+    condition_dto: CompanyFilterConditionDTO | None,
+) -> CompanyFilterCondition | None:
+    if condition_dto is None:
+        return None
+    field_value = (condition_dto.field or "").strip()
+    if not field_value:
+        return None
+    try:
+        field = CompanyField(field_value)
+    except ValueError:
+        return None
+
+    operator_value = (condition_dto.operator or "IN").strip().upper()
+    if operator_value == "OR_NOT":  # guard legacy inputs
+        operator_value = "IN"
+    try:
+        operator = ComparisonOperator(operator_value)
+    except ValueError:
+        return None
+
+    values = [str(v) for v in (condition_dto.values or []) if str(v).strip()]
+    return CompanyFilterCondition(field=field, operator=operator, values=values)

--- a/presentation/frontend/src/App.vue
+++ b/presentation/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <!-- src/App.vue -->
 <template>
-  <div class=""component-box>
+  <div class="component-box">
     <a href="http://localhost:5173/">Home</a> |
     <a href="http://localhost:5173/charts">Chart</a>
   </div>
@@ -8,9 +8,10 @@
     <header>
       <h1>FLY Project</h1>
     </header>
-    <!-- aqui as views vão ser renderizadas conforme a rota -->
     <router-view />
-    <p>(c) Crafted in the Pampas and powered by yerba mate: an authentic gaucho tech.</p>
+    <p>
+      (c) Crafted in the Pampas and powered by yerba mate: an authentic gaucho tech.
+    </p>
   </div>
 </template>
 
@@ -19,20 +20,20 @@
 </script>
 
 <style>
-/* estilos simples, opcionais */
 body {
   margin: 0;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
+
 header {
   padding: 1rem;
   border-bottom: 1px solid #ccc;
 }
-<style>
+
 .page {
   display: flex;
-  flex-direction: column;     /* um box embaixo do outro */
-  gap: 20px;                  /* espaçamento entre boxes */
+  flex-direction: column;
+  gap: 20px;
   padding: 40px;
   background-color: rgba(45, 180, 169, 0.423);
 }
@@ -44,5 +45,4 @@ header {
   padding: 20px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
-
 </style>

--- a/presentation/frontend/src/components/CompanyFacet.vue
+++ b/presentation/frontend/src/components/CompanyFacet.vue
@@ -1,0 +1,160 @@
+<template>
+  <section class="company-facet">
+    <header class="company-facet__header">
+      <h3>{{ label }}</h3>
+      <select v-model="localLogical" @change="emitChange" aria-label="Operador lógico">
+        <option v-for="option in logicalOptions" :key="option" :value="option">
+          {{ option }}
+        </option>
+      </select>
+    </header>
+    <div v-if="!options.length" class="company-facet__empty">
+      Nenhuma opção disponível
+    </div>
+    <ul v-else class="company-facet__options">
+      <li v-for="option in options" :key="option">
+        <label>
+          <input
+            :type="multiple ? 'checkbox' : 'radio'"
+            :name="field"
+            :value="option"
+            :checked="isSelected(option)"
+            @change="toggle(option)"
+          />
+          <span>{{ option }}</span>
+        </label>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  field: { type: String, required: true },
+  label: { type: String, required: true },
+  options: { type: Array, default: () => [] },
+  logical: { type: String, default: 'AND' },
+  values: { type: Array, default: () => [] },
+  multiple: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['change'])
+
+const logicalOptions = ['AND', 'OR', 'NOT']
+const localLogical = ref(props.logical || 'AND')
+const selected = ref([...props.values])
+
+watch(
+  () => props.logical,
+  (value) => {
+    if (value && value !== localLogical.value) {
+      localLogical.value = value
+    }
+  }
+)
+
+watch(
+  () => props.values,
+  (value) => {
+    const incoming = Array.isArray(value) ? [...value] : []
+    if (JSON.stringify(incoming) !== JSON.stringify(selected.value)) {
+      selected.value = incoming
+    }
+  }
+)
+
+watch(
+  () => props.options,
+  (options) => {
+    const normalized = new Set(options)
+    const filtered = selected.value.filter((value) => normalized.has(value))
+    if (filtered.length !== selected.value.length) {
+      selected.value = filtered
+      emitChange()
+    }
+  }
+)
+
+function isSelected(option) {
+  return selected.value.includes(option)
+}
+
+function toggle(option) {
+  const exists = selected.value.includes(option)
+  if (props.multiple) {
+    if (exists) {
+      selected.value = selected.value.filter((value) => value !== option)
+    } else {
+      selected.value = [...selected.value, option]
+    }
+  } else {
+    selected.value = exists ? [] : [option]
+  }
+  emitChange()
+}
+
+function emitChange() {
+  emit('change', {
+    field: props.field,
+    logical: localLogical.value,
+    values: [...selected.value],
+  })
+}
+
+watch(localLogical, () => emitChange())
+</script>
+
+<style scoped>
+.company-facet {
+  border: 1px solid var(--vt-c-divider-light, #e2e8f0);
+  border-radius: 8px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background-color: var(--vt-c-bg-soft, #ffffff);
+}
+
+.company-facet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.company-facet__header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.company-facet__header select {
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
+
+.company-facet__options {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.25rem 0.75rem;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.company-facet__options label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.company-facet__empty {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+</style>

--- a/presentation/frontend/src/components/CompanyResultSelect.vue
+++ b/presentation/frontend/src/components/CompanyResultSelect.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="company-result-select">
+    <label :for="selectId">Seleção de companhias e tickers</label>
+    <select
+      :id="selectId"
+      multiple
+      :size="computedSize"
+      :disabled="disabled || !groupedOptions.length"
+      v-model="localValue"
+    >
+      <optgroup v-for="group in groupedOptions" :key="group.company" :label="group.label">
+        <option v-for="option in group.options" :key="option.value" :value="option.value">
+          {{ option.label }}
+        </option>
+      </optgroup>
+    </select>
+    <p v-if="!groupedOptions.length" class="company-result-select__hint">
+      Ajuste os filtros para listar companhias disponíveis.
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  companies: { type: Array, default: () => [] },
+  modelValue: { type: Array, default: () => [] },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+const selectId = `company-result-${Math.random().toString(36).slice(2, 8)}`
+
+const localValue = computed({
+  get: () => props.modelValue || [],
+  set: (value) => {
+    const normalized = Array.isArray(value) ? [...value] : []
+    emit('update:modelValue', normalized)
+  },
+})
+
+const groupedOptions = computed(() => {
+  return (props.companies || [])
+    .map((company) => {
+      const companyName = company.company_name || ''
+      const tradingName = company.trading_name || ''
+      const label = tradingName && tradingName !== companyName
+        ? `${companyName} — ${tradingName}`
+        : companyName || 'Companhia sem nome'
+      const options = (company.tickers || [])
+        .filter((ticker) => !!ticker)
+        .map((ticker) => ({
+          value: `${companyName}::${ticker}`,
+          label: `${ticker} · ${companyName}`,
+        }))
+      return { company: companyName || label, label, options }
+    })
+    .filter((group) => group.options.length > 0)
+})
+
+const computedSize = computed(() => {
+  const totalOptions = groupedOptions.value.reduce((sum, group) => sum + group.options.length, 0)
+  if (totalOptions === 0) return 4
+  return Math.min(Math.max(totalOptions, 4), 12)
+})
+</script>
+
+<style scoped>
+.company-result-select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.company-result-select label {
+  font-weight: 600;
+}
+
+.company-result-select select {
+  width: 100%;
+  min-height: 120px;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  padding: 0.5rem;
+  background-color: #fff;
+}
+
+.company-result-select__hint {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin: 0;
+}
+</style>

--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -1,0 +1,313 @@
+<template>
+  <section class="company-search">
+    <header class="company-search__header">
+      <h2>Construtor de filtros</h2>
+      <div class="company-search__actions">
+        <button type="button" class="ghost" @click="clearFilters">
+          Limpar filtros
+        </button>
+        <button type="button" @click="reload">Buscar</button>
+      </div>
+    </header>
+
+    <div class="company-search__query">
+      <label for="queryText">Consulta estruturada</label>
+      <textarea
+        id="queryText"
+        v-model="queryTextModel"
+        rows="2"
+        placeholder="AND sector IN (Energia, Financeiro)"
+      ></textarea>
+      <div class="company-search__query-actions">
+        <button type="button" @click="applyQuery">Aplicar consulta</button>
+        <span v-if="parseError" class="company-search__error">{{ parseError }}</span>
+      </div>
+    </div>
+
+    <div class="company-search__facets">
+      <CompanyFacet
+        v-for="facet in facetConfigs"
+        :key="facet.field"
+        :field="facet.field"
+        :label="facet.label"
+        :options="facetOptions(facet.field)"
+        :logical="clauseLogical(facet.field)"
+        :values="clauseValues(facet.field)"
+        :multiple="facet.multiple !== false"
+        @change="onFacetChange"
+      />
+    </div>
+
+    <div class="company-search__results">
+      <header>
+        <h3>Resultados ({{ total }})</h3>
+        <span v-if="isLoading" class="company-search__status">Carregando...</span>
+        <span v-else-if="error" class="company-search__error">{{ error }}</span>
+      </header>
+
+      <CompanyResultSelect
+        v-model="selectedItemsModel"
+        :companies="companies"
+        :disabled="isLoading || !companies.length"
+      />
+
+      <p v-if="!companies.length && !isLoading" class="muted">
+        Nenhuma companhia encontrada com os filtros atuais.
+      </p>
+      <p v-else-if="!selectedSummaries.length" class="muted">
+        Use o menu para escolher uma ou mais combinações de companhia e ticker.
+      </p>
+      <ul v-else class="company-search__selection">
+        <li v-for="item in selectedSummaries" :key="item.key">
+          <h4>{{ item.companyName }}</h4>
+          <div class="company-search__tags">
+            <span class="tag">{{ item.ticker }}</span>
+            <span v-if="item.market" class="tag tag--outline">{{ item.market }}</span>
+          </div>
+          <p v-if="item.tradingName" class="muted">{{ item.tradingName }}</p>
+          <p class="muted">
+            <span v-if="item.sector">Setor: {{ item.sector }} · </span>
+            <span v-if="item.subsector">Subsetor: {{ item.subsector }} · </span>
+            <span v-if="item.segment">Segmento: {{ item.segment }}</span>
+          </p>
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { COMPANY_FACETS } from '../config/companyFacets'
+import { useCompanyStore } from '../store/companyStore'
+import CompanyFacet from './CompanyFacet.vue'
+import CompanyResultSelect from './CompanyResultSelect.vue'
+
+const store = useCompanyStore()
+
+const facetConfigs = COMPANY_FACETS
+const parseError = ref('')
+
+const queryTextModel = computed({
+  get: () => store.queryText,
+  set: (value) => {
+    parseError.value = ''
+    store.setQueryText(value)
+  },
+})
+
+const companies = computed(() => store.companies)
+const total = computed(() => store.total)
+const facets = computed(() => store.facets || {})
+const isLoading = computed(() => store.isLoading)
+const error = computed(() => store.error)
+
+const selectedItemsModel = computed({
+  get: () => store.selectedItems,
+  set: (values) => store.setSelectedItems(values),
+})
+
+const selectedSummaries = computed(() => {
+  const index = new Map()
+  for (const company of store.companies || []) {
+    const companyName = company.company_name || ''
+    for (const ticker of company.tickers || []) {
+      if (!ticker) continue
+      const key = `${companyName}::${ticker}`
+      index.set(key, {
+        key,
+        companyName,
+        ticker,
+        tradingName: company.trading_name || '',
+        sector: company.sector || '',
+        subsector: company.subsector || '',
+        segment: company.segment || '',
+        market: company.market || '',
+      })
+    }
+  }
+  return (store.selectedItems || [])
+    .map((value) => index.get(value))
+    .filter(Boolean)
+})
+
+function facetOptions(field) {
+  return facets.value[field] || []
+}
+
+function clauseLogical(field) {
+  return store.clauseByField[field]?.logical || 'AND'
+}
+
+function clauseValues(field) {
+  return store.clauseByField[field]?.condition?.values || []
+}
+
+function onFacetChange({ field, logical, values }) {
+  store.setFacetSelection(field, logical, values)
+}
+
+function applyQuery() {
+  const result = store.applyQueryText()
+  if (!result.ok) {
+    parseError.value = result.message || 'Não foi possível interpretar a consulta.'
+    return
+  }
+  parseError.value = ''
+}
+
+function clearFilters() {
+  store.resetFilters()
+  parseError.value = ''
+}
+
+function reload() {
+  store.loadCompanies()
+}
+
+onMounted(() => {
+  if (!store.companies.length) {
+    reload()
+  }
+})
+</script>
+
+<style scoped>
+.company-search {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1rem;
+  border: 1px solid var(--vt-c-divider-light, #e2e8f0);
+  border-radius: 12px;
+  background-color: var(--vt-c-bg-mute, #f8fafc);
+}
+
+.company-search__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.company-search__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.company-search__actions button {
+  padding: 0.35rem 0.9rem;
+  border-radius: 6px;
+  border: none;
+  background: #0f172a;
+  color: #fff;
+  cursor: pointer;
+}
+
+.company-search__actions .ghost {
+  background: transparent;
+  border: 1px solid #0f172a;
+  color: #0f172a;
+}
+
+.company-search__query label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.company-search__query textarea {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  padding: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  resize: vertical;
+}
+
+.company-search__query-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.company-search__query-actions button {
+  padding: 0.35rem 0.9rem;
+  border-radius: 6px;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+}
+
+.company-search__facets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.company-search__results header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.company-search__selection {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.company-search__selection li {
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.company-search__selection h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.company-search__tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0.5rem 0;
+}
+
+.tag {
+  background: #0f172a;
+  color: #fff;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+
+.tag--outline {
+  background: transparent;
+  color: #0f172a;
+  border: 1px solid #0f172a;
+}
+
+.muted {
+  color: #64748b;
+  margin: 0.1rem 0 0;
+}
+
+.company-search__status {
+  color: #2563eb;
+  font-size: 0.9rem;
+}
+
+.company-search__error {
+  color: #dc2626;
+  font-size: 0.9rem;
+}
+</style>

--- a/presentation/frontend/src/config/companyFacets.js
+++ b/presentation/frontend/src/config/companyFacets.js
@@ -1,0 +1,11 @@
+export const COMPANY_FACETS = [
+  { field: 'sector', label: 'Setor', multiple: true },
+  { field: 'subsector', label: 'Subsetor', multiple: true },
+  { field: 'segment', label: 'Segmento', multiple: true },
+  { field: 'market', label: 'Mercado', multiple: true },
+  { field: 'company_name', label: 'Companhia', multiple: false },
+  { field: 'trading_name', label: 'Nome de pregão', multiple: false },
+  { field: 'ticker', label: 'Ticker', multiple: true },
+  { field: 'institution_common', label: 'Instituição Ordinária', multiple: false },
+  { field: 'institution_preferred', label: 'Instituição Preferencial', multiple: false },
+]

--- a/presentation/frontend/src/services/apiService.js
+++ b/presentation/frontend/src/services/apiService.js
@@ -8,3 +8,8 @@ export async function fetchChart(type) {
   const res = await api.get(`/charts/${encodeURIComponent(type)}`)
   return res.data
 }
+
+export async function searchCompanies(filterQuery) {
+  const res = await api.post('/companies/search', filterQuery || { clauses: [] })
+  return res.data
+}

--- a/presentation/frontend/src/store/companyStore.js
+++ b/presentation/frontend/src/store/companyStore.js
@@ -1,0 +1,635 @@
+import { defineStore } from 'pinia'
+import { searchCompanies } from '../services/apiService'
+
+const DEFAULT_OPERATOR = 'IN'
+const SELECTION_SEPARATOR = '::'
+
+const LOGICAL_ALIASES = {
+  AND: 'AND',
+  MUST: 'AND',
+  OR: 'OR',
+  SHOULD: 'OR',
+  NOT: 'NOT',
+  MUST_NOT: 'NOT',
+  SHOULD_NOT: 'NOT',
+  OR_NOT: 'NOT',
+  'OR-NOT': 'NOT',
+}
+
+const OPERATOR_ALIASES = {
+  IN: 'IN',
+  EQUALS: 'EQUALS',
+  EQ: 'EQUALS',
+  '=': 'EQUALS',
+  '==': 'EQUALS',
+  CONTAINS: 'CONTAINS',
+  HAS: 'CONTAINS',
+  STARTS_WITH: 'STARTS_WITH',
+  STARTSWITH: 'STARTS_WITH',
+  PREFIX: 'STARTS_WITH',
+}
+
+const FIELD_ALIASES = {
+  sector: 'sector',
+  setor: 'sector',
+  subsector: 'subsector',
+  subsetor: 'subsector',
+  segment: 'segment',
+  segmento: 'segment',
+  company_name: 'company_name',
+  companhia: 'company_name',
+  company: 'company_name',
+  trading_name: 'trading_name',
+  trading: 'trading_name',
+  nome_pregao: 'trading_name',
+  ticker: 'ticker',
+  codigo: 'ticker',
+  code: 'ticker',
+  institution_preferred: 'institution_preferred',
+  instituicao_preferencial: 'institution_preferred',
+  institution_common: 'institution_common',
+  instituicao_ordinaria: 'institution_common',
+  market: 'market',
+  mercado: 'market',
+}
+
+class ParseError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'ParseError'
+  }
+}
+
+function normalizeLogical(value) {
+  if (!value) return null
+  const key = String(value).toUpperCase()
+  return LOGICAL_ALIASES[key] || null
+}
+
+function normalizeOperator(value) {
+  if (!value) return DEFAULT_OPERATOR
+  const key = String(value).toUpperCase()
+  return OPERATOR_ALIASES[key] || null
+}
+
+function normalizeField(value) {
+  if (!value) return null
+  const key = String(value).toLowerCase()
+  return FIELD_ALIASES[key] || null
+}
+
+function normalizeValues(values) {
+  return (values || [])
+    .map((value) => String(value ?? '').trim())
+    .filter((value) => value.length)
+}
+
+function cloneClauses(clauses = []) {
+  return clauses.map((clause) => ({
+    logical: clause.logical,
+    condition: clause.condition
+      ? {
+          field: clause.condition.field,
+          operator: clause.condition.operator,
+          values: [...(clause.condition.values || [])],
+        }
+      : undefined,
+    group: clause.group
+      ? {
+          clauses: cloneClauses(clause.group.clauses || []),
+        }
+      : undefined,
+  }))
+}
+
+function formatValue(value) {
+  const raw = String(value ?? '').trim()
+  if (!raw) return ''
+  if (/[\s,]/.test(raw)) {
+    return `"${raw.replace(/"/g, '\\"')}"`
+  }
+  return raw
+}
+
+function serializeClauses(clauses = []) {
+  return clauses
+    .map((clause) => {
+      const logical = clause.logical || 'AND'
+      if (clause.group) {
+        const inner = serializeClauses(clause.group.clauses || [])
+        return `${logical} (${inner})`
+      }
+      const condition = clause.condition || {}
+      const operator = condition.operator || DEFAULT_OPERATOR
+      const values = (condition.values || []).map(formatValue).join(', ')
+      return `${logical} ${condition.field} ${operator} (${values})`
+    })
+    .join(' ; ')
+}
+
+function buildSelectionValue(company, ticker) {
+  return `${company}${SELECTION_SEPARATOR}${ticker}`
+}
+
+function splitSelectionValue(value) {
+  if (!value || typeof value !== 'string') {
+    return { company: '', ticker: '' }
+  }
+  const [company, ticker] = value.split(SELECTION_SEPARATOR)
+  return { company: company || '', ticker: ticker || '' }
+}
+
+function tokenize(input) {
+  const tokens = []
+  let index = 0
+  while (index < input.length) {
+    const char = input[index]
+    if (/\s/.test(char)) {
+      index += 1
+      continue
+    }
+    if (char === '(') {
+      tokens.push({ type: 'LPAREN', value: char })
+      index += 1
+      continue
+    }
+    if (char === ')') {
+      tokens.push({ type: 'RPAREN', value: char })
+      index += 1
+      continue
+    }
+    if (char === ',') {
+      tokens.push({ type: 'COMMA', value: char })
+      index += 1
+      continue
+    }
+    if (char === ';') {
+      tokens.push({ type: 'SEMICOLON', value: char })
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      const quote = char
+      index += 1
+      let buffer = ''
+      let closed = false
+      while (index < input.length) {
+        const current = input[index]
+        if (current === '\\' && index + 1 < input.length) {
+          buffer += input[index + 1]
+          index += 2
+          continue
+        }
+        if (current === quote) {
+          closed = true
+          index += 1
+          break
+        }
+        buffer += current
+        index += 1
+      }
+      if (!closed) {
+        throw new ParseError('Texto entre aspas não foi fechado.')
+      }
+      tokens.push({ type: 'STRING', value: buffer })
+      continue
+    }
+    let buffer = ''
+    while (index < input.length && !/[\s(),;]/.test(input[index])) {
+      buffer += input[index]
+      index += 1
+    }
+    tokens.push({ type: 'WORD', value: buffer })
+  }
+  return tokens
+}
+
+function flattenNode(node, kind) {
+  if (!node) return []
+  if (node.type === kind) {
+    return [...flattenNode(node.left, kind), ...flattenNode(node.right, kind)]
+  }
+  return [node]
+}
+
+function astToClauses(node, parentLogical) {
+  if (!node) {
+    return []
+  }
+  if (node.type === 'CLAUSE') {
+    return [
+      {
+        logical: parentLogical,
+        condition: {
+          field: node.field,
+          operator: node.operator,
+          values: node.values,
+        },
+      },
+    ]
+  }
+  if (node.type === 'NOT') {
+    const innerClauses = astToClauses(node.operand, 'AND')
+    return [
+      {
+        logical: 'NOT',
+        group: { clauses: innerClauses },
+      },
+    ]
+  }
+  if (node.type === 'AND' || node.type === 'OR') {
+    const nodeLogical = node.type === 'AND' ? 'AND' : 'OR'
+    const children = flattenNode(node, node.type)
+    const childClauses = children.flatMap((child) => astToClauses(child, nodeLogical))
+    if (parentLogical === nodeLogical) {
+      return childClauses
+    }
+    return [
+      {
+        logical: parentLogical,
+        group: { clauses: childClauses },
+      },
+    ]
+  }
+  throw new ParseError('Estrutura de consulta inválida.')
+}
+
+class QueryParser {
+  constructor(tokens) {
+    this.tokens = tokens
+    this.current = 0
+  }
+
+  parse() {
+    if (this.tokens.length === 0) {
+      return null
+    }
+    const expression = this.parseExpression()
+    if (!this.isAtEnd()) {
+      const token = this.peek()
+      const value = token?.value || token?.type || 'desconhecido'
+      throw new ParseError(`Símbolo inesperado: ${value}`)
+    }
+    return expression
+  }
+
+  parseExpression() {
+    let node = this.parseOr()
+    while (this.match('SEMICOLON')) {
+      if (this.isAtEnd()) {
+        break
+      }
+      const right = this.parseOr()
+      if (!right) {
+        break
+      }
+      node = node ? { type: 'AND', left: node, right } : right
+    }
+    return node
+  }
+
+  parseOr() {
+    let node = this.parseAnd()
+    while (this.matchLogical('OR')) {
+      const right = this.parseAnd()
+      if (!right) {
+        throw new ParseError('Expressão OR incompleta.')
+      }
+      node = node ? { type: 'OR', left: node, right } : right
+    }
+    return node
+  }
+
+  parseAnd() {
+    let node = this.parseUnary()
+    while (this.matchLogical('AND')) {
+      const right = this.parseUnary()
+      if (!right) {
+        throw new ParseError('Expressão AND incompleta.')
+      }
+      node = node ? { type: 'AND', left: node, right } : right
+    }
+    return node
+  }
+
+  parseUnary() {
+    if (this.matchLogical('NOT')) {
+      const operand = this.parseUnary()
+      if (!operand) {
+        throw new ParseError('Esperado expressão após NOT.')
+      }
+      return { type: 'NOT', operand }
+    }
+    if (this.match('LPAREN')) {
+      const expression = this.parseExpression()
+      this.consume('RPAREN', 'Esperado ) para fechar o grupo.')
+      return expression
+    }
+    return this.parseClause()
+  }
+
+  parseClause() {
+    while (true) {
+      const token = this.peek()
+      if (!token || token.type !== 'WORD') {
+        break
+      }
+      const logical = normalizeLogical(token.value)
+      if (logical && logical !== 'NOT') {
+        this.advance()
+        continue
+      }
+      break
+    }
+
+    const fieldToken = this.consumeWord('Informe o campo da companhia.')
+    const field = normalizeField(fieldToken.value)
+    if (!field) {
+      throw new ParseError(`Campo desconhecido: ${fieldToken.value}`)
+    }
+
+    const operatorToken = this.consumeWord('Informe o operador de comparação.')
+    const operator = normalizeOperator(operatorToken.value)
+    if (!operator) {
+      throw new ParseError(`Operador inválido: ${operatorToken.value}`)
+    }
+
+    this.consume('LPAREN', 'Esperado ( para iniciar a lista de valores.')
+    const values = []
+    if (this.check('RPAREN')) {
+      this.advance()
+    } else {
+      while (!this.isAtEnd()) {
+        if (this.check('RPAREN')) {
+          this.advance()
+          break
+        }
+        const value = this.consumeValue()
+        values.push(value)
+        if (this.check('RPAREN')) {
+          this.advance()
+          break
+        }
+        this.consume('COMMA', 'Separar valores com vírgula.')
+      }
+    }
+
+    const normalizedValues = normalizeValues(values)
+    if (!normalizedValues.length && !['CONTAINS', 'STARTS_WITH'].includes(operator)) {
+      throw new ParseError(`Informe pelo menos um valor para ${field}.`)
+    }
+
+    return {
+      type: 'CLAUSE',
+      field,
+      operator,
+      values: normalizedValues,
+    }
+  }
+
+  match(type) {
+    if (!this.check(type)) {
+      return false
+    }
+    this.advance()
+    return true
+  }
+
+  matchLogical(expected) {
+    const token = this.peek()
+    if (!token || token.type !== 'WORD') {
+      return false
+    }
+    const logical = normalizeLogical(token.value)
+    if (logical !== expected) {
+      return false
+    }
+    this.advance()
+    return true
+  }
+
+  consume(type, message) {
+    if (this.check(type)) {
+      return this.advance()
+    }
+    throw new ParseError(message)
+  }
+
+  consumeWord(message) {
+    const token = this.peek()
+    if (!token || token.type !== 'WORD') {
+      throw new ParseError(message)
+    }
+    this.advance()
+    return token
+  }
+
+  consumeValue() {
+    const token = this.peek()
+    if (!token) {
+      throw new ParseError('Valor ausente na lista.')
+    }
+    if (token.type === 'STRING') {
+      this.advance()
+      return token.value
+    }
+    if (token.type === 'WORD') {
+      const parts = [this.advance().value]
+      while (!this.isAtEnd()) {
+        const next = this.peek()
+        if (!next || next.type !== 'WORD') {
+          break
+        }
+        parts.push(this.advance().value)
+      }
+      return parts.join(' ')
+    }
+    throw new ParseError('Valor inválido na lista.')
+  }
+
+  check(type) {
+    if (this.isAtEnd()) {
+      return false
+    }
+    return this.peek().type === type
+  }
+
+  advance() {
+    if (!this.isAtEnd()) {
+      this.current += 1
+    }
+    return this.previous()
+  }
+
+  peek() {
+    return this.tokens[this.current]
+  }
+
+  previous() {
+    return this.tokens[this.current - 1]
+  }
+
+  isAtEnd() {
+    return this.current >= this.tokens.length
+  }
+}
+
+function parseTextToQuery(text) {
+  try {
+    const tokens = tokenize(text)
+    const parser = new QueryParser(tokens)
+    const ast = parser.parse()
+    if (!ast) {
+      return { clauses: [] }
+    }
+    const clauses = astToClauses(ast, 'AND')
+    return { clauses }
+  } catch (error) {
+    if (error instanceof ParseError) {
+      throw error
+    }
+    throw new ParseError('Não foi possível interpretar a consulta fornecida.')
+  }
+}
+
+export const useCompanyStore = defineStore('companyStore', {
+  state: () => ({
+    filterQuery: { clauses: [] },
+    queryText: '',
+    companies: [],
+    total: 0,
+    facets: {},
+    selectedItems: [],
+    isLoading: false,
+    error: null,
+  }),
+
+  getters: {
+    clauseByField(state) {
+      const map = {}
+      for (const clause of state.filterQuery.clauses || []) {
+        if (clause.condition && clause.condition.field) {
+          map[clause.condition.field] = clause
+        }
+      }
+      return map
+    },
+    selectedPairs(state) {
+      return (state.selectedItems || []).map(splitSelectionValue)
+    },
+  },
+
+  actions: {
+    setFacetSelection(field, logical, values, operator = DEFAULT_OPERATOR) {
+      const normalizedField = normalizeField(field) || field
+      const normalizedLogical = normalizeLogical(logical) || 'AND'
+      const normalizedValues = normalizeValues(values)
+      const normalizedOperator = normalizeOperator(operator) || DEFAULT_OPERATOR
+
+      const clauses = cloneClauses(this.filterQuery.clauses || [])
+      const filteredClauses = clauses.filter(
+        (clause) => !clause.condition || clause.condition.field !== normalizedField,
+      )
+
+      if (normalizedValues.length) {
+        filteredClauses.push({
+          logical: normalizedLogical,
+          condition: {
+            field: normalizedField,
+            operator: normalizedOperator,
+            values: normalizedValues,
+          },
+        })
+      }
+
+      this.filterQuery = { clauses: filteredClauses }
+      this.queryText = this.serializeQuery(this.filterQuery)
+      this.loadCompanies()
+    },
+
+    setQueryText(text) {
+      this.queryText = text
+    },
+
+    applyQueryText() {
+      try {
+        const parsed = this.parseQuery(this.queryText)
+        this.filterQuery = parsed
+        this.queryText = this.serializeQuery(parsed)
+        this.loadCompanies()
+        return { ok: true }
+      } catch (error) {
+        const message = error instanceof ParseError ? error.message : 'Consulta inválida.'
+        return { ok: false, message }
+      }
+    },
+
+    resetFilters() {
+      this.filterQuery = { clauses: [] }
+      this.queryText = ''
+      this.selectedItems = []
+      this.loadCompanies()
+    },
+
+    setSelectedItems(values) {
+      const normalized = Array.isArray(values)
+        ? values.map((value) => String(value)).filter((value) => value.length)
+        : []
+      this.selectedItems = normalized
+    },
+
+    async loadCompanies() {
+      this.isLoading = true
+      this.error = null
+      try {
+        const payload = await searchCompanies(this.filterQuery)
+        this.companies = payload.items || []
+        this.total = payload.total || 0
+        this.facets = payload.facets || {}
+        this._pruneSelection()
+        if (!this.queryText) {
+          this.queryText = this.serializeQuery(this.filterQuery)
+        }
+      } catch (err) {
+        console.error(err)
+        this.error = 'Falha ao carregar companhias'
+      } finally {
+        this.isLoading = false
+      }
+    },
+
+    serializeQuery(query) {
+      if (!query || !Array.isArray(query.clauses) || query.clauses.length === 0) {
+        return ''
+      }
+      return serializeClauses(query.clauses)
+    },
+
+    parseQuery(text) {
+      if (!text || !text.trim()) {
+        return { clauses: [] }
+      }
+      return parseTextToQuery(text)
+    },
+
+    _pruneSelection() {
+      if (!this.selectedItems || this.selectedItems.length === 0) {
+        return
+      }
+      const valid = new Set()
+      for (const company of this.companies || []) {
+        const companyName = company.company_name || ''
+        for (const ticker of company.tickers || []) {
+          if (!ticker) continue
+          valid.add(buildSelectionValue(companyName, ticker))
+        }
+      }
+      const filtered = this.selectedItems.filter((value) => valid.has(value))
+      if (filtered.length !== this.selectedItems.length) {
+        this.selectedItems = filtered
+      }
+    },
+  },
+})
+
+export { ParseError }

--- a/presentation/frontend/src/views/HomeView.vue
+++ b/presentation/frontend/src/views/HomeView.vue
@@ -1,11 +1,37 @@
 <template>
   <main class="home">
-    <h1>{{ title }}</h1>
-    <ChartSelector />
-    <PlotlyViewer />
+    <section class="home__charts">
+      <h1>{{ title }}</h1>
+      <ChartSelector />
+      <PlotlyViewer />
+    </section>
+    <CompanySearchBuilder class="home__search" />
   </main>
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import ChartSelector from '../components/ChartSelector.vue'
+import PlotlyViewer from '../components/PlotlyViewer.vue'
+import CompanySearchBuilder from '../components/CompanySearchBuilder.vue'
+
+const title = ref('Dashboard de Indicadores')
 </script>
+
+<style scoped>
+.home {
+  display: grid;
+  gap: 2rem;
+  padding: 1rem;
+}
+
+.home__charts {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.home__search {
+  max-width: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- update the company filter value objects and SQL builder to support nested logical groups and remove the OR_NOT operator
- extend the search API DTOs and router to map recursive clauses while returning refreshed facets alongside results
- redesign the frontend store and builder with an improved parser, live facet updates, and a ticker selection dropdown backed by shared facet configuration

## Testing
- `pytest` *(fails: pytest configuration passes unsupported coverage arguments in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e37207864832e8f7c27a939e3c551)