### PR TITLE
feat: add query box submission for facets

### DIFF
--- a/presentation/frontend/src/components/CompanyFacet.vue
+++ b/presentation/frontend/src/components/CompanyFacet.vue
@@ -2,7 +2,7 @@
   <section class="company-facet">
     <header class="company-facet__header">
       <h3>{{ label }}</h3>
-      <select v-model="localLogical" @change="emitChange" aria-label="Operador lógico">
+      <select v-model="localLogical" aria-label="Operador lógico">
         <option v-for="option in logicalOptions" :key="option" :value="option">
           {{ option }}
         </option>
@@ -25,6 +25,11 @@
         </label>
       </li>
     </ul>
+    <div v-if="options.length" class="company-facet__footer">
+      <button type="button" class="company-facet__commit" @click="commit">
+        Enviar para consulta
+      </button>
+    </div>
   </section>
 </template>
 
@@ -40,7 +45,7 @@ const props = defineProps({
   multiple: { type: Boolean, default: true },
 })
 
-const emit = defineEmits(['change'])
+const emit = defineEmits(['change', 'commit'])
 
 const logicalOptions = ['AND', 'OR', 'NOT']
 const localLogical = ref(props.logical || 'AND')
@@ -65,18 +70,6 @@ watch(
   }
 )
 
-watch(
-  () => props.options,
-  (options) => {
-    const normalized = new Set(options)
-    const filtered = selected.value.filter((value) => normalized.has(value))
-    if (filtered.length !== selected.value.length) {
-      selected.value = filtered
-      emitChange()
-    }
-  }
-)
-
 function isSelected(option) {
   return selected.value.includes(option)
 }
@@ -92,10 +85,10 @@ function toggle(option) {
   } else {
     selected.value = exists ? [] : [option]
   }
-  emitChange()
+  emitDraftChange()
 }
 
-function emitChange() {
+function emitDraftChange() {
   emit('change', {
     field: props.field,
     logical: localLogical.value,
@@ -103,7 +96,27 @@ function emitChange() {
   })
 }
 
-watch(localLogical, () => emitChange())
+function commit() {
+  emit('commit', {
+    field: props.field,
+    logical: localLogical.value,
+    values: [...selected.value],
+  })
+}
+
+watch(localLogical, () => emitDraftChange())
+
+watch(
+  () => props.options,
+  (options) => {
+    const normalized = new Set(options)
+    const filtered = selected.value.filter((value) => normalized.has(value))
+    if (filtered.length !== selected.value.length) {
+      selected.value = filtered
+      emitDraftChange()
+    }
+  }
+)
 </script>
 
 <style scoped>
@@ -156,5 +169,27 @@ watch(localLogical, () => emitChange())
 .company-facet__empty {
   font-size: 0.85rem;
   color: #64748b;
+}
+
+.company-facet__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.company-facet__commit {
+  padding: 0.35rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--vt-c-primary, #2563eb);
+  background-color: var(--vt-c-primary, #2563eb);
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.company-facet__commit:hover {
+  background-color: #1d4ed8;
+  border-color: #1d4ed8;
 }
 </style>

--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -6,7 +6,6 @@
         <button type="button" class="ghost" @click="clearFilters">
           Limpar filtros
         </button>
-        <button type="button" @click="reload">Buscar</button>
       </div>
     </header>
 
@@ -19,7 +18,7 @@
         placeholder="AND sector IN (Energia, Financeiro)"
       ></textarea>
       <div class="company-search__query-actions">
-        <button type="button" @click="applyQuery">Aplicar consulta</button>
+        <button type="button" @click="applyQuery">Pesquisar</button>
         <span v-if="parseError" class="company-search__error">{{ parseError }}</span>
       </div>
     </div>
@@ -31,10 +30,11 @@
         :field="facet.field"
         :label="facet.label"
         :options="facetOptions(facet.field)"
-        :logical="clauseLogical(facet.field)"
-        :values="clauseValues(facet.field)"
+        :logical="facetLogical(facet.field)"
+        :values="facetValues(facet.field)"
         :multiple="facet.multiple !== false"
-        @change="onFacetChange"
+        @change="onFacetDraftChange"
+        @commit="onFacetCommit"
       />
     </div>
 
@@ -91,6 +91,7 @@ const store = useCompanyStore()
 
 const facetConfigs = COMPANY_FACETS
 const parseError = ref('')
+const draftFacets = ref({})
 
 const queryTextModel = computed({
   get: () => store.queryText,
@@ -139,16 +140,45 @@ function facetOptions(field) {
   return facets.value[field] || []
 }
 
-function clauseLogical(field) {
+function facetLogical(field) {
+  const draft = draftFacets.value[field]
+  if (draft && draft.logical) {
+    return draft.logical
+  }
   return store.clauseByField[field]?.logical || 'AND'
 }
 
-function clauseValues(field) {
+function facetValues(field) {
+  const draft = draftFacets.value[field]
+  if (draft && Array.isArray(draft.values)) {
+    return draft.values
+  }
   return store.clauseByField[field]?.condition?.values || []
 }
 
-function onFacetChange({ field, logical, values }) {
-  store.setFacetSelection(field, logical, values)
+function onFacetDraftChange({ field, logical, values }) {
+  draftFacets.value = {
+    ...draftFacets.value,
+    [field]: {
+      logical: logical || 'AND',
+      values: Array.isArray(values) ? [...values] : [],
+    },
+  }
+}
+
+function onFacetCommit({ field, logical, values }) {
+  const finalLogical = logical || 'AND'
+  const finalValues = Array.isArray(values) ? [...values] : []
+
+  store.setFacetSelection(field, finalLogical, finalValues)
+
+  draftFacets.value = {
+    ...draftFacets.value,
+    [field]: {
+      logical: finalLogical,
+      values: [],
+    },
+  }
 }
 
 function applyQuery() {
@@ -163,6 +193,7 @@ function applyQuery() {
 function clearFilters() {
   store.resetFilters()
   parseError.value = ''
+  draftFacets.value = {}
 }
 
 function reload() {

--- a/presentation/frontend/src/store/companyStore.js
+++ b/presentation/frontend/src/store/companyStore.js
@@ -544,7 +544,6 @@ export const useCompanyStore = defineStore('companyStore', {
 
       this.filterQuery = { clauses: filteredClauses }
       this.queryText = this.serializeQuery(this.filterQuery)
-      this.loadCompanies()
     },
 
     setQueryText(text) {


### PR DESCRIPTION
## Summary
- add commit buttons to each facet so selections can be sent to the structured query on demand
- keep facet changes as local drafts until submission and only load data when the query box search runs
- stop the store from triggering company reloads automatically when a facet value changes

## Testing
- npm run build *(fails: Could not resolve "../components/ChartSelector.vue" from "src/views/HomeView.vue")*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e76e4b97c832e80b70087e9e928ea)