### PR TITLE
Reorganize dashboard layout and headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ data/
 
 .coverage
 
+
+presentation/frontend/node_modules/

--- a/presentation/frontend/src/App.vue
+++ b/presentation/frontend/src/App.vue
@@ -1,0 +1,25 @@
+<template>
+  <div id="app">
+    <header class="app-header">
+      <h1>FLY Project</h1>
+    </header>
+    <HomeView />
+  </div>
+</template>
+
+<script setup>
+import HomeView from './views/HomeView.vue'
+</script>
+
+<style scoped>
+#app {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+  color: #111;
+}
+
+.app-header {
+  margin-bottom: 2rem;
+}
+</style>

--- a/presentation/frontend/src/components/ChartSelector.vue
+++ b/presentation/frontend/src/components/ChartSelector.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="chart-selector">
+    <label>
+      Tipo de gráfico
+      <select v-model="selected">
+        <option value="price">Preço</option>
+        <option value="volume">Volume</option>
+      </select>
+    </label>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const selected = ref('price')
+</script>
+
+<style scoped>
+.chart-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+</style>

--- a/presentation/frontend/src/components/CompanyFacet.vue
+++ b/presentation/frontend/src/components/CompanyFacet.vue
@@ -1,0 +1,60 @@
+<template>
+  <fieldset class="company-facet">
+    <legend>{{ label }}</legend>
+    <div class="company-facet__options">
+      <label
+        v-for="option in options"
+        :key="option.value || option"
+        class="company-facet__option"
+      >
+        <input
+          type="checkbox"
+          :value="option.value || option"
+          :checked="values.includes(option.value || option)"
+          @change="onToggle(option.value || option)"
+        />
+        <span>{{ option.label || option }}</span>
+      </label>
+    </div>
+  </fieldset>
+</template>
+
+<script setup>
+const props = defineProps({
+  field: { type: String, required: true },
+  label: { type: String, required: true },
+  options: { type: Array, default: () => [] },
+  values: { type: Array, default: () => [] },
+  logical: { type: String, default: 'AND' },
+  multiple: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['change'])
+
+const onToggle = (value) => {
+  emit('change', {
+    field: props.field,
+    value,
+  })
+}
+</script>
+
+<style scoped>
+.company-facet {
+  border: 1px solid #e0e0e0;
+  padding: 1rem;
+  border-radius: 0.5rem;
+}
+
+.company-facet__options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.company-facet__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+</style>

--- a/presentation/frontend/src/components/CompanyResultSelect.vue
+++ b/presentation/frontend/src/components/CompanyResultSelect.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="company-result-select">
+    <label class="company-result-select__label">
+      Resultados de companhias
+      <select
+        multiple
+        :disabled="disabled"
+        :value="modelValue"
+        @change="onSelect"
+      >
+        <option
+          v-for="company in companies"
+          :key="companyKey(company)"
+          :value="companyKey(company)"
+        >
+          {{ company.company_name }} - {{ company.tickers?.[0] || '—' }}
+        </option>
+      </select>
+    </label>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  companies: { type: Array, default: () => [] },
+  modelValue: { type: Array, default: () => [] },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const companyKey = (company) => {
+  const name = company.company_name || ''
+  const ticker = company.tickers?.[0] || ''
+  return `${name}::${ticker}`
+}
+
+const onSelect = (event) => {
+  const options = Array.from(event.target.selectedOptions || [])
+  emit(
+    'update:modelValue',
+    options.map((option) => option.value),
+  )
+}
+</script>
+
+<style scoped>
+.company-result-select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.company-result-select select {
+  width: 100%;
+  min-height: 8rem;
+}
+</style>

--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -1,0 +1,171 @@
+<template>
+  <section class="company-search">
+    <header class="company-search__header">
+      <h2>Construtor de filtros</h2>
+      <div class="company-search__actions">
+        <button type="button" class="ghost" @click="clearFilters">
+          Limpar filtros
+        </button>
+        <button type="button" @click="reload">Buscar</button>
+      </div>
+    </header>
+
+    <section class="company-search__facets" aria-labelledby="filters-heading">
+      <h2 id="filters-heading">Filtros</h2>
+
+      <CompanyFacet
+        v-for="facet in facetConfigs"
+        :key="facet.field"
+        :field="facet.field"
+        :label="facet.label"
+        :options="facetOptions(facet.field)"
+        :logical="clauseLogical(facet.field)"
+        :values="clauseValues(facet.field)"
+        :multiple="facet.multiple !== false"
+        @change="onFacetChange"
+      />
+    </section>
+
+    <div class="company-search__query">
+      <label for="queryText">Consulta estruturada</label>
+      <textarea
+        id="queryText"
+        v-model="queryTextModel"
+        rows="2"
+        placeholder="AND sector IN (Energia, Financeiro)"
+      ></textarea>
+      <div class="company-search__query-actions">
+        <button type="button" @click="applyQuery">Aplicar consulta</button>
+        <span v-if="parseError" class="company-search__error">
+          {{ parseError }}
+        </span>
+      </div>
+    </div>
+
+    <div class="company-search__results">
+      <header>
+        <h3>Resultados ({{ total }})</h3>
+        <span v-if="isLoading" class="company-search__status">Carregando...</span>
+        <span v-else-if="error" class="company-search__error">{{ error }}</span>
+      </header>
+
+      <CompanyResultSelect
+        v-model="selectedItemsModel"
+        :companies="companies"
+        :disabled="isLoading || !companies.length"
+      />
+
+      <p v-if="!companies.length && !isLoading" class="muted">
+        Nenhuma companhia encontrada com os filtros atuais.
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import CompanyFacet from './CompanyFacet.vue'
+import CompanyResultSelect from './CompanyResultSelect.vue'
+import { useCompanyStore } from '../store/companyStore'
+
+const store = useCompanyStore()
+
+const facetConfigs = computed(() => store.facetConfigs || [])
+const companies = computed(() => store.companies || [])
+const total = computed(() => store.total ?? companies.value.length)
+const error = computed(() => store.error)
+const isLoading = computed(() => store.isLoading)
+const parseError = computed(() => store.parseError)
+
+const queryTextModel = computed({
+  get: () => store.queryText,
+  set: (value) => store.updateQueryText(value),
+})
+
+const selectedItemsModel = computed({
+  get: () => store.selectedItems,
+  set: (value) => store.updateSelectedItems(value),
+})
+
+const facetOptions = (field) => store.facetOptions(field)
+const clauseValues = (field) => store.clauseValues(field)
+const clauseLogical = (field) => store.clauseLogical(field)
+
+const reload = () => store.reload()
+const clearFilters = () => store.clearFilters()
+const applyQuery = () => store.applyQuery()
+
+const onFacetChange = (payload) => {
+  store.updateFacet(payload)
+}
+</script>
+
+<style scoped>
+.company-search {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.company-search__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.company-search__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.company-search__facets {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.company-search__query {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.company-search__query textarea {
+  width: 100%;
+  resize: vertical;
+}
+
+.company-search__query-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.company-search__results {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.company-search__error {
+  color: #d93025;
+}
+
+.company-search__status {
+  color: #666;
+}
+
+.muted {
+  color: #666;
+}
+
+button {
+  padding: 0.5rem 1rem;
+}
+
+button.ghost {
+  background: transparent;
+  border: 1px solid currentColor;
+}
+</style>

--- a/presentation/frontend/src/components/CompanySelectionSummary.vue
+++ b/presentation/frontend/src/components/CompanySelectionSummary.vue
@@ -1,0 +1,95 @@
+<template>
+  <section aria-labelledby="company-heading">
+    <h3 id="company-heading">Companhia</h3>
+
+    <p v-if="!selectedSummaries.length" class="muted">
+      Use o menu de resultados para escolher uma ou mais combinações de companhia e ticker.
+    </p>
+
+    <ul v-else class="company-search__selection">
+      <li v-for="item in selectedSummaries" :key="item.key">
+        <h4>{{ item.companyName }}</h4>
+        <div class="company-search__tags">
+          <span class="tag">{{ item.ticker }}</span>
+          <span v-if="item.market" class="tag tag--outline">
+            {{ item.market }}
+          </span>
+        </div>
+        <p v-if="item.tradingName" class="muted">
+          {{ item.tradingName }}
+        </p>
+        <p class="muted">
+          <span v-if="item.sector">Setor: {{ item.sector }} · </span>
+          <span v-if="item.subsector">Subsetor: {{ item.subsector }} · </span>
+          <span v-if="item.segment">Segmento: {{ item.segment }}</span>
+        </p>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useCompanyStore } from '../store/companyStore'
+
+const store = useCompanyStore()
+
+const selectedSummaries = computed(() => {
+  const index = new Map()
+  for (const company of store.companies || []) {
+    const companyName = company.company_name || ''
+    for (const ticker of company.tickers || []) {
+      if (!ticker) continue
+      const key = `${companyName}::${ticker}`
+      index.set(key, {
+        key,
+        companyName,
+        ticker,
+        tradingName: company.trading_name || '',
+        sector: company.sector || '',
+        subsector: company.subsector || '',
+        segment: company.segment || '',
+        market: company.market || '',
+      })
+    }
+  }
+
+  return (store.selectedItems || [])
+    .map((value) => index.get(value))
+    .filter(Boolean)
+})
+</script>
+
+<style scoped>
+.company-search__selection {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.company-search__tags {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  background: #f0f0f0;
+  font-size: 0.875rem;
+}
+
+.tag--outline {
+  border: 1px solid currentColor;
+  background: transparent;
+}
+
+.muted {
+  color: #666;
+}
+</style>

--- a/presentation/frontend/src/components/PlotlyViewer.vue
+++ b/presentation/frontend/src/components/PlotlyViewer.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="plotly-viewer">
+    <div class="plotly-viewer__placeholder">Gráfico será exibido aqui.</div>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.plotly-viewer {
+  border: 1px solid #e0e0e0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.plotly-viewer__placeholder {
+  color: #888;
+}
+</style>

--- a/presentation/frontend/src/main.js
+++ b/presentation/frontend/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/presentation/frontend/src/store/companyStore.js
+++ b/presentation/frontend/src/store/companyStore.js
@@ -1,0 +1,178 @@
+import { reactive, computed } from 'vue'
+
+const state = reactive({
+  facetConfigs: [
+    {
+      field: 'sector',
+      label: 'Setor',
+      multiple: true,
+    },
+    {
+      field: 'segment',
+      label: 'Segmento',
+      multiple: true,
+    },
+  ],
+  facets: new Map(),
+  facetOptions: new Map([
+    [
+      'sector',
+      [
+        { value: 'Energia', label: 'Energia' },
+        { value: 'Financeiro', label: 'Financeiro' },
+        { value: 'Tecnologia', label: 'Tecnologia' },
+      ],
+    ],
+    [
+      'segment',
+      [
+        { value: 'Distribuição', label: 'Distribuição' },
+        { value: 'Serviços', label: 'Serviços' },
+      ],
+    ],
+  ]),
+  clauseLogical: new Map(),
+  clauseValues: new Map(),
+  queryText: '',
+  parseError: '',
+  companies: [],
+  selectedItems: [],
+  total: 0,
+  error: '',
+  isLoading: false,
+})
+
+function companyKey(company) {
+  const name = company.company_name || ''
+  const ticker = company.tickers?.[0] || ''
+  return `${name}::${ticker}`
+}
+
+export function useCompanyStore() {
+  const computedFacetOptions = (field) => state.facetOptions.get(field) || []
+  const computedClauseValues = (field) => state.clauseValues.get(field) || []
+  const computedClauseLogical = (field) => state.clauseLogical.get(field) || 'AND'
+
+  const reload = () => {
+    state.isLoading = true
+    setTimeout(() => {
+      const companies = [
+        {
+          company_name: 'Fly Energia',
+          trading_name: 'Fly Energia Participações',
+          sector: 'Energia',
+          subsector: 'Energia Elétrica',
+          segment: 'Distribuição',
+          tickers: ['FLY3'],
+          market: 'B3',
+        },
+        {
+          company_name: 'Banco Fly',
+          trading_name: 'Banco Fly S.A.',
+          sector: 'Financeiro',
+          subsector: 'Bancos',
+          segment: 'Serviços Financeiros',
+          tickers: ['FLYB11'],
+          market: 'B3',
+        },
+      ]
+      state.companies = companies
+      state.total = companies.length
+      state.error = ''
+      state.isLoading = false
+    }, 300)
+  }
+
+  const clearFilters = () => {
+    state.facets.clear()
+    state.clauseValues.clear()
+    state.clauseLogical.clear()
+    state.queryText = ''
+    state.parseError = ''
+    state.selectedItems = []
+    state.companies = []
+    state.total = 0
+  }
+
+  const applyQuery = () => {
+    if (state.queryText && !state.queryText.trim().startsWith('AND')) {
+      state.parseError = 'Consulta deve iniciar com AND'
+      return
+    }
+    state.parseError = ''
+  }
+
+  const updateQueryText = (value) => {
+    state.queryText = value
+  }
+
+  const updateSelectedItems = (value) => {
+    state.selectedItems = Array.isArray(value) ? value : []
+  }
+
+  const updateFacet = ({ field, value }) => {
+    const current = new Set(state.clauseValues.get(field) || [])
+    if (current.has(value)) {
+      current.delete(value)
+    } else {
+      current.add(value)
+    }
+    state.clauseValues.set(field, Array.from(current))
+  }
+
+  const selectedItems = computed(() => state.selectedItems)
+
+  const companies = computed(() => state.companies)
+
+  return {
+    get facetConfigs() {
+      return state.facetConfigs
+    },
+    get companies() {
+      return companies.value
+    },
+    get total() {
+      return state.total
+    },
+    get error() {
+      return state.error
+    },
+    get isLoading() {
+      return state.isLoading
+    },
+    get parseError() {
+      return state.parseError
+    },
+    get queryText() {
+      return state.queryText
+    },
+    get selectedItems() {
+      return selectedItems.value
+    },
+    facetOptions: computedFacetOptions,
+    clauseValues: computedClauseValues,
+    clauseLogical: computedClauseLogical,
+    reload,
+    clearFilters,
+    applyQuery,
+    updateQueryText,
+    updateSelectedItems,
+    updateFacet,
+  }
+}
+
+export function seedCompanies() {
+  state.companies = [
+    {
+      company_name: 'Fly Energia',
+      trading_name: 'Fly Energia Participações',
+      sector: 'Energia',
+      subsector: 'Energia Elétrica',
+      segment: 'Distribuição',
+      tickers: ['FLY3'],
+      market: 'B3',
+    },
+  ]
+  state.selectedItems = state.companies.map((company) => companyKey(company))
+  state.total = state.companies.length
+}

--- a/presentation/frontend/src/views/HomeView.vue
+++ b/presentation/frontend/src/views/HomeView.vue
@@ -1,0 +1,55 @@
+<template>
+  <main class="home">
+    <CompanySearchBuilder class="home__search" />
+
+    <section class="home__charts">
+      <h2>{{ title }}</h2>
+
+      <CompanySelectionSummary />
+
+      <section class="home__charts-results" aria-labelledby="chart-results-heading">
+        <h2 id="chart-results-heading">Resultados</h2>
+        <h3>Preço</h3>
+
+        <ChartSelector />
+        <PlotlyViewer />
+      </section>
+    </section>
+  </main>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import ChartSelector from '../components/ChartSelector.vue'
+import PlotlyViewer from '../components/PlotlyViewer.vue'
+import CompanySearchBuilder from '../components/CompanySearchBuilder.vue'
+import CompanySelectionSummary from '../components/CompanySelectionSummary.vue'
+
+const title = ref('Dashboard de indicadores')
+</script>
+
+<style scoped>
+.home {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 1rem;
+}
+
+.home__charts {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.home__charts-results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.home__search {
+  max-width: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- reorder the company search builder so filters appear before the structured query and update the section headings
- extract the selected company summary into its own component for reuse in the dashboard
- restructure the home view to present the filter builder ahead of the dashboard results with updated headings for charts

## Testing
- not run (frontend changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea3b35834832eb2e0b7a7498a1673)