### PR TITLE
Adjust dashboard headings for chart section

### DIFF
--- a/presentation/frontend/src/components/PlotlyViewer.vue
+++ b/presentation/frontend/src/components/PlotlyViewer.vue
@@ -1,10 +1,19 @@
 <template>
-  <div class="plotly-viewer">
-    <div class="plotly-viewer__placeholder">Gráfico será exibido aqui.</div>
-  </div>
+  <section class="plotly-viewer" aria-labelledby="plotly-viewer-heading">
+    <h3 id="plotly-viewer-heading">{{ props.title }}</h3>
+    <div class="plotly-viewer__content">
+      <div class="plotly-viewer__placeholder">Gráfico será exibido aqui.</div>
+    </div>
+  </section>
 </template>
 
 <script setup>
+const props = defineProps({
+  title: {
+    type: String,
+    default: 'Preço',
+  },
+})
 </script>
 
 <style scoped>
@@ -12,6 +21,12 @@
   border: 1px solid #e0e0e0;
   border-radius: 0.5rem;
   padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.plotly-viewer__content {
   min-height: 200px;
   display: flex;
   align-items: center;

--- a/presentation/frontend/src/views/HomeView.vue
+++ b/presentation/frontend/src/views/HomeView.vue
@@ -9,10 +9,9 @@
 
       <section class="home__charts-results" aria-labelledby="chart-results-heading">
         <h2 id="chart-results-heading">Resultados</h2>
-        <h3>Preço</h3>
 
         <ChartSelector />
-        <PlotlyViewer />
+        <PlotlyViewer title="Preço" />
       </section>
     </section>
   </main>
@@ -45,7 +44,7 @@ const title = ref('Dashboard de indicadores')
 .home__charts-results {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   margin-top: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- ensure the Plotly viewer component renders an internal heading and exposes a configurable title
- update the home view layout to delegate the chart heading to the viewer and keep spacing consistent with the new hierarchy

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea54bbb8c832eb0d1cc089c7524f3)