### PR TITLE
feat: refresh chart when selecting tickers

### DIFF
--- a/presentation/frontend/src/App.vue
+++ b/presentation/frontend/src/App.vue
@@ -3,18 +3,17 @@
     <header class="app-header">
       <h1>FLY Project</h1>
     </header>
-    <HomeView />
+    <RouterView />
   </div>
 </template>
 
 <script setup>
-import HomeView from './views/HomeView.vue'
+import { RouterView } from 'vue-router'
 </script>
 
 <style scoped>
 #app {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   color: #111;
 }

--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -3,9 +3,7 @@
     <header class="company-search__header">
       <h2>Construtor de filtros</h2>
       <div class="company-search__actions">
-        <button type="button" class="ghost" @click="clearFilters">
-          Limpar filtros
-        </button>
+        <button type="button" class="ghost" @click="clearFilters">Limpar filtros</button>
         <button type="button" @click="reload">Buscar</button>
       </div>
     </header>
@@ -58,17 +56,47 @@
       <p v-if="!companies.length && !isLoading" class="muted">
         Nenhuma companhia encontrada com os filtros atuais.
       </p>
+      <p v-else-if="!selectedSummaries.length" class="muted">
+        Use o menu para escolher uma ou mais combinações de companhia e ticker.
+      </p>
+      <ul v-else class="company-search__selection">
+        <li v-for="item in selectedSummaries" :key="item.key">
+          <h4>{{ item.companyName }}</h4>
+          <div class="company-search__tags">
+            <button
+              type="button"
+              class="tag"
+              :class="{ 'tag--active': isActiveTicker(item.ticker) }"
+              @click="selectTicker(item.ticker)"
+            >
+              {{ item.ticker }}
+            </button>
+            <span v-if="item.market" class="tag tag--outline">{{ item.market }}</span>
+          </div>
+          <p v-if="item.tradingName" class="muted">{{ item.tradingName }}</p>
+          <p class="muted">
+            <span v-if="item.sector">Setor: {{ item.sector }} · </span>
+            <span v-if="item.subsector">Subsetor: {{ item.subsector }} · </span>
+            <span v-if="item.segment">Segmento: {{ item.segment }}</span>
+          </p>
+        </li>
+      </ul>
     </div>
   </section>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useCompanyStore } from '../store/companyStore'
+import { useChartStore } from '../store/chartStore'
 import CompanyFacet from './CompanyFacet.vue'
 import CompanyResultSelect from './CompanyResultSelect.vue'
-import { useCompanyStore } from '../store/companyStore'
 
 const store = useCompanyStore()
+const chartStore = useChartStore()
+const route = useRoute()
+const router = useRouter()
 
 const facetConfigs = computed(() => store.facetConfigs || [])
 const companies = computed(() => store.companies || [])
@@ -76,6 +104,7 @@ const total = computed(() => store.total ?? companies.value.length)
 const error = computed(() => store.error)
 const isLoading = computed(() => store.isLoading)
 const parseError = computed(() => store.parseError)
+const selectedTicker = computed(() => store.selectedTicker)
 
 const queryTextModel = computed({
   get: () => store.queryText,
@@ -86,6 +115,8 @@ const selectedItemsModel = computed({
   get: () => store.selectedItems,
   set: (value) => store.updateSelectedItems(value),
 })
+
+const selectedSummaries = computed(() => store.selectedSummaries || [])
 
 const facetOptions = (field) => store.facetOptions(field)
 const clauseValues = (field) => store.clauseValues(field)
@@ -98,6 +129,32 @@ const applyQuery = () => store.applyQuery()
 const onFacetChange = (payload) => {
   store.updateFacet(payload)
 }
+
+function selectTicker(ticker) {
+  if (!ticker) {
+    return
+  }
+  const value = String(ticker)
+  if (store.selectedTicker !== value) {
+    store.setSelectedTicker(value)
+  }
+  chartStore.loadChartByTicker(value)
+
+  const currentType = typeof route.query.type === 'string' ? route.query.type : undefined
+  if (currentType !== value) {
+    router.replace({ query: { ...route.query, type: value } })
+  }
+}
+
+function isActiveTicker(ticker) {
+  return selectedTicker.value === ticker
+}
+
+onMounted(() => {
+  if (!store.companies.length) {
+    store.loadCompanies()
+  }
+})
 </script>
 
 <style scoped>
@@ -153,7 +210,65 @@ const onFacetChange = (payload) => {
 }
 
 .company-search__status {
-  color: #666;
+  color: #2563eb;
+}
+
+.company-search__selection {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.company-search__selection li {
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.company-search__selection h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.company-search__tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0.5rem 0;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  background: #0f172a;
+  color: #fff;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  gap: 0.25rem;
+  border: none;
+  cursor: pointer;
+}
+
+.tag:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
+}
+
+.tag--outline {
+  background: transparent;
+  color: #0f172a;
+  border: 1px solid #0f172a;
+  cursor: default;
+}
+
+.tag--active {
+  background: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
 }
 
 .muted {

--- a/presentation/frontend/src/components/CompanySelectionSummary.vue
+++ b/presentation/frontend/src/components/CompanySelectionSummary.vue
@@ -34,30 +34,7 @@ import { useCompanyStore } from '../store/companyStore'
 
 const store = useCompanyStore()
 
-const selectedSummaries = computed(() => {
-  const index = new Map()
-  for (const company of store.companies || []) {
-    const companyName = company.company_name || ''
-    for (const ticker of company.tickers || []) {
-      if (!ticker) continue
-      const key = `${companyName}::${ticker}`
-      index.set(key, {
-        key,
-        companyName,
-        ticker,
-        tradingName: company.trading_name || '',
-        sector: company.sector || '',
-        subsector: company.subsector || '',
-        segment: company.segment || '',
-        market: company.market || '',
-      })
-    }
-  }
-
-  return (store.selectedItems || [])
-    .map((value) => index.get(value))
-    .filter(Boolean)
-})
+const selectedSummaries = computed(() => store.selectedSummaries || [])
 </script>
 
 <style scoped>

--- a/presentation/frontend/src/components/PlotlyViewer.vue
+++ b/presentation/frontend/src/components/PlotlyViewer.vue
@@ -1,18 +1,111 @@
 <template>
   <section class="plotly-viewer" aria-labelledby="plotly-viewer-heading">
     <h3 id="plotly-viewer-heading">{{ props.title }}</h3>
-    <div class="plotly-viewer__content">
-      <div class="plotly-viewer__placeholder">Gráfico será exibido aqui.</div>
+
+    <div v-if="isLoading" class="plotly-viewer__status" role="status">
+      Carregando gráfico...
     </div>
+
+    <div v-else-if="error" class="plotly-viewer__status plotly-viewer__status--error" role="alert">
+      {{ error }}
+    </div>
+
+    <div v-else-if="chart" class="plotly-viewer__chart" role="img" :aria-label="chart.title">
+      <header class="plotly-viewer__chart-header">
+        <h4>{{ chart.title }}</h4>
+        <span class="plotly-viewer__badge">{{ activeTicker }}</span>
+      </header>
+      <ul>
+        <li v-for="point in chart.series" :key="point.date">
+          <span class="plotly-viewer__date">{{ point.date }}</span>
+          <span class="plotly-viewer__value">{{ point.close.toFixed(2) }}</span>
+        </li>
+      </ul>
+    </div>
+
+    <p v-else class="plotly-viewer__status">Nenhum gráfico carregado.</p>
   </section>
 </template>
 
 <script setup>
+import { computed, onMounted, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useChartStore } from '../store/chartStore'
+import { useCompanyStore } from '../store/companyStore'
+
 const props = defineProps({
   title: {
     type: String,
     default: 'Preço',
   },
+})
+
+const chartStore = useChartStore()
+const companyStore = useCompanyStore()
+const route = useRoute()
+const router = useRouter()
+
+const chart = computed(() => chartStore.chart)
+const isLoading = computed(() => chartStore.isLoading)
+const error = computed(() => chartStore.error)
+const activeTicker = computed(() => companyStore.selectedTicker || chartStore.params.type)
+
+function ensureTickerQuery(ticker) {
+  if (!ticker) return
+  const currentType = typeof route.query.type === 'string' ? route.query.type : undefined
+  if (currentType === ticker) {
+    return
+  }
+  router.replace({ query: { ...route.query, type: ticker } })
+}
+
+watch(
+  () => companyStore.selectedTicker,
+  (ticker) => {
+    if (!ticker) {
+      return
+    }
+    ensureTickerQuery(ticker)
+    chartStore.loadChartByTicker(ticker)
+  },
+)
+
+watch(
+  () => route.query.type,
+  (value) => {
+    const ticker = typeof value === 'string' ? value : ''
+    if (ticker && ticker !== companyStore.selectedTicker) {
+      companyStore.setSelectedTicker(ticker)
+    }
+  },
+  { immediate: true },
+)
+
+onMounted(() => {
+  const queryTicker = typeof route.query.type === 'string' ? route.query.type : ''
+  if (queryTicker) {
+    if (queryTicker !== companyStore.selectedTicker) {
+      companyStore.setSelectedTicker(queryTicker)
+    } else {
+      chartStore.loadChartByTicker(queryTicker)
+    }
+    return
+  }
+
+  const fallbackTicker =
+    companyStore.selectedTicker || chartStore.params.type || 'PETR4'
+
+  if (!fallbackTicker) {
+    return
+  }
+
+  if (fallbackTicker !== companyStore.selectedTicker) {
+    companyStore.setSelectedTicker(fallbackTicker)
+  } else {
+    chartStore.loadChartByTicker(fallbackTicker)
+  }
+
+  ensureTickerQuery(fallbackTicker)
 })
 </script>
 
@@ -26,14 +119,57 @@ const props = defineProps({
   gap: 0.75rem;
 }
 
-.plotly-viewer__content {
-  min-height: 200px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.plotly-viewer__status {
+  color: #475569;
 }
 
-.plotly-viewer__placeholder {
-  color: #888;
+.plotly-viewer__status--error {
+  color: #dc2626;
+}
+
+.plotly-viewer__chart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.plotly-viewer__chart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.plotly-viewer__badge {
+  background: #0f172a;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+}
+
+.plotly-viewer__chart ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.plotly-viewer__chart li {
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  color: #0f172a;
+}
+
+.plotly-viewer__date {
+  opacity: 0.7;
+}
+
+.plotly-viewer__value {
+  font-weight: 600;
 }
 </style>

--- a/presentation/frontend/src/main.js
+++ b/presentation/frontend/src/main.js
@@ -1,4 +1,13 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+
+const pinia = createPinia()
+
+app.use(pinia)
+app.use(router)
+
+app.mount('#app')

--- a/presentation/frontend/src/router/index.js
+++ b/presentation/frontend/src/router/index.js
@@ -1,0 +1,17 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import HomeView from '../views/HomeView.vue'
+
+const routes = [
+  {
+    path: '/',
+    name: 'home',
+    component: HomeView,
+  },
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+
+export default router

--- a/presentation/frontend/src/store/chartStore.js
+++ b/presentation/frontend/src/store/chartStore.js
@@ -1,0 +1,110 @@
+import { defineStore } from 'pinia'
+
+const DEFAULT_TICKER = 'PETR4'
+
+const MOCK_CHART_DATA = {
+  PETR4: {
+    title: 'PETR4 · Histórico de preços',
+    series: [
+      { date: '2024-05-06', close: 38.21 },
+      { date: '2024-05-07', close: 37.94 },
+      { date: '2024-05-08', close: 38.7 },
+      { date: '2024-05-09', close: 39.12 },
+      { date: '2024-05-10', close: 39.56 },
+    ],
+  },
+  FLY3: {
+    title: 'FLY3 · Histórico de preços',
+    series: [
+      { date: '2024-05-06', close: 12.35 },
+      { date: '2024-05-07', close: 12.5 },
+      { date: '2024-05-08', close: 12.82 },
+      { date: '2024-05-09', close: 12.3 },
+      { date: '2024-05-10', close: 12.55 },
+    ],
+  },
+  FLYB11: {
+    title: 'FLYB11 · Histórico de preços',
+    series: [
+      { date: '2024-05-06', close: 24.12 },
+      { date: '2024-05-07', close: 24.4 },
+      { date: '2024-05-08', close: 24.78 },
+      { date: '2024-05-09', close: 24.33 },
+      { date: '2024-05-10', close: 24.61 },
+    ],
+  },
+}
+
+function buildChartPayload(ticker) {
+  const normalized = ticker && MOCK_CHART_DATA[ticker]
+  if (normalized) {
+    return normalized
+  }
+
+  return {
+    title: `${ticker || DEFAULT_TICKER} · Histórico de preços`,
+    series: [
+      { date: '2024-05-06', close: 20.0 },
+      { date: '2024-05-07', close: 20.1 },
+      { date: '2024-05-08', close: 20.4 },
+      { date: '2024-05-09', close: 20.25 },
+      { date: '2024-05-10', close: 20.45 },
+    ],
+  }
+}
+
+export const useChartStore = defineStore('chartStore', {
+  state: () => ({
+    params: {
+      type: DEFAULT_TICKER,
+    },
+    chart: null,
+    isLoading: false,
+    error: '',
+    lastLoadedTicker: '',
+  }),
+
+  actions: {
+    setType(type) {
+      this.params.type = type || DEFAULT_TICKER
+    },
+
+    async loadChartByTicker(ticker) {
+      const normalized = ticker ? String(ticker).toUpperCase() : ''
+      const target = normalized || this.params.type || DEFAULT_TICKER
+      if (target !== this.params.type) {
+        this.setType(target)
+      }
+
+      if (this.isLoading && this.params.type === target) {
+        return
+      }
+
+      if (this.lastLoadedTicker === target && this.chart && !this.error) {
+        return
+      }
+
+      await this.loadChart()
+    },
+
+    async loadChart() {
+      const ticker = this.params.type || DEFAULT_TICKER
+      this.isLoading = true
+      this.error = ''
+
+      await new Promise((resolve) => setTimeout(resolve, 150))
+
+      try {
+        this.chart = buildChartPayload(ticker)
+        this.lastLoadedTicker = ticker
+      } catch (error) {
+        console.error(error)
+        this.chart = null
+        this.error = 'Falha ao carregar gráfico'
+        this.lastLoadedTicker = ''
+      } finally {
+        this.isLoading = false
+      }
+    },
+  },
+})

--- a/presentation/frontend/src/store/companyStore.js
+++ b/presentation/frontend/src/store/companyStore.js
@@ -1,168 +1,32 @@
-import { reactive, computed } from 'vue'
+import { defineStore } from 'pinia'
 
-const state = reactive({
-  facetConfigs: [
-    {
-      field: 'sector',
-      label: 'Setor',
-      multiple: true,
-    },
-    {
-      field: 'segment',
-      label: 'Segmento',
-      multiple: true,
-    },
+const DEFAULT_FACET_CONFIGS = [
+  {
+    field: 'sector',
+    label: 'Setor',
+    multiple: true,
+  },
+  {
+    field: 'segment',
+    label: 'Segmento',
+    multiple: true,
+  },
+]
+
+const DEFAULT_FACET_OPTIONS = {
+  sector: [
+    { value: 'Energia', label: 'Energia' },
+    { value: 'Financeiro', label: 'Financeiro' },
+    { value: 'Tecnologia', label: 'Tecnologia' },
   ],
-  facets: new Map(),
-  facetOptions: new Map([
-    [
-      'sector',
-      [
-        { value: 'Energia', label: 'Energia' },
-        { value: 'Financeiro', label: 'Financeiro' },
-        { value: 'Tecnologia', label: 'Tecnologia' },
-      ],
-    ],
-    [
-      'segment',
-      [
-        { value: 'Distribuição', label: 'Distribuição' },
-        { value: 'Serviços', label: 'Serviços' },
-      ],
-    ],
-  ]),
-  clauseLogical: new Map(),
-  clauseValues: new Map(),
-  queryText: '',
-  parseError: '',
-  companies: [],
-  selectedItems: [],
-  total: 0,
-  error: '',
-  isLoading: false,
-})
-
-function companyKey(company) {
-  const name = company.company_name || ''
-  const ticker = company.tickers?.[0] || ''
-  return `${name}::${ticker}`
+  segment: [
+    { value: 'Distribuição', label: 'Distribuição' },
+    { value: 'Serviços', label: 'Serviços' },
+  ],
 }
 
-export function useCompanyStore() {
-  const computedFacetOptions = (field) => state.facetOptions.get(field) || []
-  const computedClauseValues = (field) => state.clauseValues.get(field) || []
-  const computedClauseLogical = (field) => state.clauseLogical.get(field) || 'AND'
-
-  const reload = () => {
-    state.isLoading = true
-    setTimeout(() => {
-      const companies = [
-        {
-          company_name: 'Fly Energia',
-          trading_name: 'Fly Energia Participações',
-          sector: 'Energia',
-          subsector: 'Energia Elétrica',
-          segment: 'Distribuição',
-          tickers: ['FLY3'],
-          market: 'B3',
-        },
-        {
-          company_name: 'Banco Fly',
-          trading_name: 'Banco Fly S.A.',
-          sector: 'Financeiro',
-          subsector: 'Bancos',
-          segment: 'Serviços Financeiros',
-          tickers: ['FLYB11'],
-          market: 'B3',
-        },
-      ]
-      state.companies = companies
-      state.total = companies.length
-      state.error = ''
-      state.isLoading = false
-    }, 300)
-  }
-
-  const clearFilters = () => {
-    state.facets.clear()
-    state.clauseValues.clear()
-    state.clauseLogical.clear()
-    state.queryText = ''
-    state.parseError = ''
-    state.selectedItems = []
-    state.companies = []
-    state.total = 0
-  }
-
-  const applyQuery = () => {
-    if (state.queryText && !state.queryText.trim().startsWith('AND')) {
-      state.parseError = 'Consulta deve iniciar com AND'
-      return
-    }
-    state.parseError = ''
-  }
-
-  const updateQueryText = (value) => {
-    state.queryText = value
-  }
-
-  const updateSelectedItems = (value) => {
-    state.selectedItems = Array.isArray(value) ? value : []
-  }
-
-  const updateFacet = ({ field, value }) => {
-    const current = new Set(state.clauseValues.get(field) || [])
-    if (current.has(value)) {
-      current.delete(value)
-    } else {
-      current.add(value)
-    }
-    state.clauseValues.set(field, Array.from(current))
-  }
-
-  const selectedItems = computed(() => state.selectedItems)
-
-  const companies = computed(() => state.companies)
-
-  return {
-    get facetConfigs() {
-      return state.facetConfigs
-    },
-    get companies() {
-      return companies.value
-    },
-    get total() {
-      return state.total
-    },
-    get error() {
-      return state.error
-    },
-    get isLoading() {
-      return state.isLoading
-    },
-    get parseError() {
-      return state.parseError
-    },
-    get queryText() {
-      return state.queryText
-    },
-    get selectedItems() {
-      return selectedItems.value
-    },
-    facetOptions: computedFacetOptions,
-    clauseValues: computedClauseValues,
-    clauseLogical: computedClauseLogical,
-    reload,
-    clearFilters,
-    applyQuery,
-    updateQueryText,
-    updateSelectedItems,
-    updateFacet,
-  }
-}
-
-export function seedCompanies() {
-  state.companies = [
+function createCompanyDataset() {
+  return [
     {
       company_name: 'Fly Energia',
       trading_name: 'Fly Energia Participações',
@@ -172,7 +36,203 @@ export function seedCompanies() {
       tickers: ['FLY3'],
       market: 'B3',
     },
+    {
+      company_name: 'Banco Fly',
+      trading_name: 'Banco Fly S.A.',
+      sector: 'Financeiro',
+      subsector: 'Bancos',
+      segment: 'Serviços Financeiros',
+      tickers: ['FLYB11'],
+      market: 'B3',
+    },
+    {
+      company_name: 'Petróleo do Brasil',
+      trading_name: 'Petrobras',
+      sector: 'Energia',
+      subsector: 'Petróleo, Gás e Biocombustíveis',
+      segment: 'Exploração e Produção',
+      tickers: ['PETR4'],
+      market: 'B3',
+    },
   ]
-  state.selectedItems = state.companies.map((company) => companyKey(company))
-  state.total = state.companies.length
+}
+
+function parseSelectionValue(value) {
+  if (!value) return { companyName: '', ticker: '' }
+  const [companyName = '', ticker = ''] = String(value).split('::')
+  return { companyName, ticker }
+}
+
+export const useCompanyStore = defineStore('companyStore', {
+  state: () => ({
+    facetConfigs: DEFAULT_FACET_CONFIGS,
+    facetOptionsIndex: DEFAULT_FACET_OPTIONS,
+    clauseLogicalIndex: {},
+    clauseValuesIndex: {},
+    queryText: '',
+    parseError: '',
+    companies: [],
+    selectedItems: [],
+    selectedTicker: '',
+    total: 0,
+    error: '',
+    isLoading: false,
+  }),
+
+  getters: {
+    facets(state) {
+      return state.facetConfigs
+    },
+    facetOptions: (state) => (field) => state.facetOptionsIndex[field] || [],
+    clauseValues: (state) => (field) => state.clauseValuesIndex[field] || [],
+    clauseLogical: (state) => (field) => state.clauseLogicalIndex[field] || 'AND',
+    selectedSummaries(state) {
+      const index = new Map()
+      for (const company of state.companies) {
+        const companyName = company.company_name || ''
+        for (const ticker of company.tickers || []) {
+          if (!ticker) continue
+          const key = `${companyName}::${ticker}`
+          index.set(key, {
+            key,
+            companyName,
+            ticker,
+            tradingName: company.trading_name || '',
+            sector: company.sector || '',
+            subsector: company.subsector || '',
+            segment: company.segment || '',
+            market: company.market || '',
+          })
+        }
+      }
+
+      return state.selectedItems
+        .map((value) => index.get(value))
+        .filter(Boolean)
+    },
+  },
+
+  actions: {
+    loadCompanies() {
+      this.isLoading = true
+      this.error = ''
+
+      setTimeout(() => {
+        const companies = createCompanyDataset()
+        this.companies = companies
+        this.total = companies.length
+        this.isLoading = false
+
+        if (this.selectedTicker) {
+          this.setSelectedTicker(this.selectedTicker)
+        }
+      }, 200)
+    },
+
+    reload() {
+      this.loadCompanies()
+    },
+
+    clearFilters() {
+      this.clauseLogicalIndex = {}
+      this.clauseValuesIndex = {}
+      this.queryText = ''
+      this.parseError = ''
+      this.selectedItems = []
+      this.selectedTicker = ''
+      this.companies = []
+      this.total = 0
+    },
+
+    applyQuery() {
+      if (this.queryText && !this.queryText.trim().toUpperCase().startsWith('AND')) {
+        this.parseError = 'Consulta deve iniciar com AND'
+        return
+      }
+      this.parseError = ''
+    },
+
+    updateQueryText(value) {
+      this.queryText = value
+    },
+
+    updateSelectedItems(values) {
+      this.selectedItems = Array.isArray(values)
+        ? values.map((value) => String(value)).filter((value) => value.length)
+        : []
+
+      if (!this.selectedTicker) {
+        this.syncSelectedTickerFromSelection()
+      }
+    },
+
+    updateFacet({ field, value }) {
+      if (!field) return
+      const normalizedField = String(field)
+      const current = new Set(this.clauseValuesIndex[normalizedField] || [])
+      if (current.has(value)) {
+        current.delete(value)
+      } else {
+        current.add(value)
+      }
+      this.clauseValuesIndex = {
+        ...this.clauseValuesIndex,
+        [normalizedField]: Array.from(current),
+      }
+    },
+
+    setSelectedTicker(ticker) {
+      const normalized = ticker ? String(ticker) : ''
+      if (this.selectedTicker !== normalized) {
+        this.selectedTicker = normalized
+      }
+
+      if (!normalized) {
+        return
+      }
+
+      const existsInSelection = this.selectedSummaries.some(
+        (summary) => summary.ticker === normalized,
+      )
+      if (existsInSelection) {
+        return
+      }
+
+      // ensure ticker is represented in selection when available
+      const matches = this.companies
+        .flatMap((company) =>
+          (company.tickers || []).map((tickerValue) => ({ company, tickerValue })),
+        )
+        .filter((entry) => entry.tickerValue === normalized)
+        .map(({ company, tickerValue }) => `${company.company_name || ''}::${tickerValue}`)
+
+      if (matches.length) {
+        const values = new Set(this.selectedItems)
+        matches.forEach((match) => values.add(match))
+        this.selectedItems = Array.from(values)
+      }
+    },
+
+    syncSelectedTickerFromSelection() {
+      if (this.selectedTicker) {
+        return
+      }
+      const [first] = this.selectedItems
+      if (!first) {
+        return
+      }
+      const { ticker } = parseSelectionValue(first)
+      this.selectedTicker = ticker
+    },
+  },
+})
+
+export function seedCompanies(store) {
+  const companies = createCompanyDataset()
+  if (store) {
+    store.companies = companies
+    store.total = companies.length
+    store.selectedItems = companies
+      .flatMap((company) => (company.tickers || []).map((ticker) => `${company.company_name}::${ticker}`))
+  }
 }


### PR DESCRIPTION
## Summary
- bootstrap Pinia and Vue Router so the frontend can share ticker state via stores and query params
- extend the company store with selected ticker handling and add a chart store that loads mocked datasets per ticker
- update the search builder and Plotly viewer components to trigger chart reloads, highlight the active ticker, and keep the ?type query in sync

## Testing
- npm --prefix presentation/frontend run build *(fails: package.json missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eaad21e58832e9ebb544b2d7ff827)