### PR TITLE
Sync charts with company selection

### DIFF
--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -62,13 +62,19 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { COMPANY_FACETS } from '../config/companyFacets'
 import { useCompanyStore } from '../store/companyStore'
+import { useChartStore } from '../store/chartStore'
 import CompanyFacet from './CompanyFacet.vue'
 import CompanyResultSelect from './CompanyResultSelect.vue'
 
 const store = useCompanyStore()
+const chartStore = useChartStore()
+const route = useRoute()
+const router = useRouter()
+let isSyncingSelection = false
 
 const facetConfigs = COMPANY_FACETS
 const parseError = ref('')
@@ -90,8 +96,39 @@ const error = computed(() => store.error)
 
 const selectedItemsModel = computed({
   get: () => store.selectedItems,
-  set: (values) => store.setSelectedItems(values),
+  set: (values) => {
+    onSelectionChange(values)
+  },
 })
+
+function normalizeSelection(values) {
+  if (!Array.isArray(values)) {
+    return []
+  }
+  return values
+    .map((value) => String(value || '').trim())
+    .filter((value) => value.length)
+}
+
+function parseSelectionParam(rawValue) {
+  if (!rawValue) {
+    return []
+  }
+
+  const values = Array.isArray(rawValue) ? rawValue : [rawValue]
+
+  return values
+    .flatMap((entry) => String(entry || '').split(','))
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length)
+}
+
+function selectionsAreEqual(a = [], b = []) {
+  if (a.length !== b.length) {
+    return false
+  }
+  return a.every((value, index) => value === b[index])
+}
 
 function facetOptions(field) {
   return facets.value[field] || []
@@ -156,6 +193,107 @@ function clearFilters() {
 function reload() {
   store.loadCompanies()
 }
+
+async function onSelectionChange(values) {
+  if (isSyncingSelection) {
+    return
+  }
+
+  isSyncingSelection = true
+
+  try {
+    const normalized = normalizeSelection(values)
+    const current = store.selectedItems || []
+    const chartSelection = chartStore.params.selection || []
+    const querySelection = parseSelectionParam(route.query.selection)
+
+    if (!selectionsAreEqual(normalized, current)) {
+      store.setSelectedItems(normalized)
+    }
+
+    const selectionParam = normalized.join(',')
+    const nextQuery = {
+      ...route.query,
+      selection: selectionParam || undefined,
+    }
+
+    if (!selectionsAreEqual(normalized, querySelection)) {
+      try {
+        await router.replace({ query: nextQuery })
+      } catch (error) {
+        console.error(error)
+      }
+    }
+
+    const selectionChanged = !selectionsAreEqual(normalized, chartSelection)
+    chartStore.setSelection(normalized)
+
+    if (selectionChanged || !chartStore.chart) {
+      await chartStore.loadChart()
+    }
+  } finally {
+    isSyncingSelection = false
+  }
+}
+
+onMounted(async () => {
+  const initialSelection = parseSelectionParam(route.query.selection)
+  const current = store.selectedItems || []
+  const chartSelection = chartStore.params.selection || []
+
+  if (!selectionsAreEqual(initialSelection, current)) {
+    store.setSelectedItems(initialSelection)
+  }
+
+  const selectionChanged = !selectionsAreEqual(initialSelection, chartSelection)
+  if (selectionChanged) {
+    chartStore.setSelection(initialSelection)
+    await chartStore.loadChart()
+  }
+})
+
+watch(
+  () => store.selectedItems,
+  (values) => {
+    if (isSyncingSelection) {
+      return
+    }
+
+    const normalized = normalizeSelection(values)
+    const querySelection = parseSelectionParam(route.query.selection)
+    const chartSelection = chartStore.params.selection || []
+
+    const needsQuerySync = !selectionsAreEqual(normalized, querySelection)
+    const needsChartSync = !selectionsAreEqual(normalized, chartSelection)
+
+    if (needsQuerySync || needsChartSync) {
+      onSelectionChange(normalized)
+    }
+  },
+  { deep: true },
+)
+
+watch(
+  () => route.query.selection,
+  async (value) => {
+    if (isSyncingSelection) {
+      return
+    }
+
+    const parsed = parseSelectionParam(value)
+    const companySelection = store.selectedItems || []
+    const chartSelection = chartStore.params.selection || []
+
+    if (!selectionsAreEqual(parsed, companySelection)) {
+      store.setSelectedItems(parsed)
+    }
+
+    if (!selectionsAreEqual(parsed, chartSelection)) {
+      chartStore.setSelection(parsed)
+      await chartStore.loadChart()
+    }
+  },
+)
 
 onMounted(() => {
   if (!store.companies.length) {

--- a/presentation/frontend/src/components/CompanySelectionSummary.vue
+++ b/presentation/frontend/src/components/CompanySelectionSummary.vue
@@ -11,7 +11,13 @@
         <h4>{{ item.companyName }}</h4>
 
         <div class="company-search__tags">
-          <span class="tag">{{ item.ticker }}</span>
+          <button
+            type="button"
+            class="tag tag--clickable"
+            @click="onTickerClick(item)"
+          >
+            {{ item.ticker }}
+          </button>
           <span v-if="item.market" class="tag tag--outline">{{ item.market }}</span>
         </div>
 
@@ -31,14 +37,19 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useCompanyStore } from '../store/companyStore'
+import { useChartStore } from '../store/chartStore'
 
-const store = useCompanyStore()
+const companyStore = useCompanyStore()
+const chartStore = useChartStore()
+const route = useRoute()
+const router = useRouter()
 
 const selectedSummaries = computed(() => {
   const index = new Map()
 
-  for (const company of store.companies || []) {
+  for (const company of companyStore.companies || []) {
     const companyName = company.company_name || ''
 
     for (const ticker of company.tickers || []) {
@@ -59,10 +70,48 @@ const selectedSummaries = computed(() => {
     }
   }
 
-  return (store.selectedItems || [])
+  return (companyStore.selectedItems || [])
     .map((value) => index.get(value))
     .filter(Boolean)
 })
+
+async function onTickerClick(item) {
+  if (!item || !item.key) {
+    return
+  }
+
+  const selection = [item.key]
+  const currentSelection = companyStore.selectedItems || []
+  const alreadySelected =
+    currentSelection.length === 1 && currentSelection[0] === item.key
+
+  if (!alreadySelected) {
+    companyStore.setSelectedItems(selection)
+  }
+
+  const nextQuery = {
+    ...route.query,
+    selection: item.key,
+  }
+
+  try {
+    if (route.query.selection !== item.key) {
+      await router.replace({ query: nextQuery })
+    }
+  } catch (error) {
+    console.error(error)
+  }
+
+  const previousSelection = chartStore.params.selection || []
+  const chartNeedsUpdate =
+    previousSelection.length !== 1 || previousSelection[0] !== item.key
+
+  chartStore.setSelection(selection)
+
+  if (chartNeedsUpdate || !chartStore.chart) {
+    await chartStore.loadChart()
+  }
+}
 </script>
 
 <style scoped>
@@ -106,6 +155,16 @@ const selectedSummaries = computed(() => {
   background: transparent;
   color: #0f172a;
   border: 1px solid #0f172a;
+}
+
+.tag--clickable {
+  cursor: pointer;
+  border: none;
+}
+
+.tag--clickable:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 2px;
 }
 
 .muted {

--- a/presentation/frontend/src/services/apiService.js
+++ b/presentation/frontend/src/services/apiService.js
@@ -4,8 +4,19 @@ const api = axios.create({
   baseURL: 'http://localhost:8000',
 })
 
-export async function fetchChart(type) {
-  const res = await api.get(`/charts/${encodeURIComponent(type)}`)
+export async function fetchChart(params) {
+  const payload = params || {}
+  const type = String(payload.type || '').trim() || 'PETR4'
+  const selection = Array.isArray(payload.selection) ? payload.selection : []
+
+  const query = {}
+  if (selection.length) {
+    query.selection = selection.join(',')
+  }
+
+  const res = await api.get(`/charts/${encodeURIComponent(type)}`, {
+    params: query,
+  })
   return res.data
 }
 

--- a/presentation/frontend/src/store/chartStore.js
+++ b/presentation/frontend/src/store/chartStore.js
@@ -1,10 +1,32 @@
 import { defineStore } from 'pinia'
 import { fetchChart } from '../services/apiService'
 
+function normalizeType(value) {
+  const normalized = String(value || '').trim()
+  return normalized || 'PETR4'
+}
+
+function normalizeSelection(values) {
+  if (!Array.isArray(values)) {
+    return []
+  }
+  return values
+    .map((item) => String(item || '').trim())
+    .filter((item) => item.length)
+}
+
+function areSelectionsEqual(a = [], b = []) {
+  if (a.length !== b.length) {
+    return false
+  }
+  return a.every((value, index) => value === b[index])
+}
+
 export const useChartStore = defineStore('chart', {
   state: () => ({
     params: {
       type: 'PETR4',
+      selection: [],
     },
     chart: null,
     isLoading: false,
@@ -13,17 +35,28 @@ export const useChartStore = defineStore('chart', {
 
   actions: {
     setType(type) {
-      this.params.type = type || 'PETR4'
+      this.params.type = normalizeType(type)
+    },
+
+    setSelection(selection) {
+      const normalized = normalizeSelection(selection)
+      if (areSelectionsEqual(normalized, this.params.selection)) {
+        return
+      }
+      this.params = {
+        ...this.params,
+        selection: normalized,
+      }
     },
 
     async loadChart() {
       this.isLoading = true
       this.error = null
       try {
-        this.chart = await fetchChart(this.params.type)
+        this.chart = await fetchChart({ ...this.params })
       } catch (err) {
         console.error(err)
-        this.error = 'Falha ao carregar gráfico'
+        this.error = err?.message || 'Falha ao carregar gráfico'
       } finally {
         this.isLoading = false
       }


### PR DESCRIPTION
## Summary
- extend the chart store to track the selected company/ticker pairs and forward them to the chart API
- synchronize company selection changes with the URL and chart reloads from the company search builder
- make the selected ticker chips clickable so they update the selection and refresh the chart

## Testing
- not run (frontend only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0074bf80832e9c08b8d412d234fb)