### PR TITLE
Fix chart reload when company selection changes

### DIFF
--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -204,7 +204,6 @@ async function onSelectionChange(values) {
   try {
     const normalized = normalizeSelection(values)
     const current = store.selectedItems || []
-    const chartSelection = chartStore.params.selection || []
     const querySelection = parseSelectionParam(route.query.selection)
 
     if (!selectionsAreEqual(normalized, current)) {
@@ -225,12 +224,8 @@ async function onSelectionChange(values) {
       }
     }
 
-    const selectionChanged = !selectionsAreEqual(normalized, chartSelection)
     chartStore.setSelection(normalized)
-
-    if (selectionChanged || !chartStore.chart) {
-      await chartStore.loadChart()
-    }
+    await chartStore.loadChart()
   } finally {
     isSyncingSelection = false
   }

--- a/presentation/frontend/src/components/CompanySelectionSummary.vue
+++ b/presentation/frontend/src/components/CompanySelectionSummary.vue
@@ -7,7 +7,7 @@
     </p>
 
     <ul v-else class="company-search__selection">
-      <li v-for="item in selectedSummaries" :key="item.key">
+      <li v-for="item in selectedSummaries" :key="item.value">
         <h4>{{ item.companyName }}</h4>
 
         <div class="company-search__tags">
@@ -37,14 +37,11 @@
 
 <script setup>
 import { computed } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 import { useCompanyStore } from '../store/companyStore'
 import { useChartStore } from '../store/chartStore'
 
 const companyStore = useCompanyStore()
 const chartStore = useChartStore()
-const route = useRoute()
-const router = useRouter()
 
 const selectedSummaries = computed(() => {
   const index = new Map()
@@ -55,18 +52,20 @@ const selectedSummaries = computed(() => {
     for (const ticker of company.tickers || []) {
       if (!ticker) continue
 
-      const key = `${companyName}::${ticker}`
+      const value = `${companyName}::${ticker}`
 
-      index.set(key, {
-        key,
-        companyName,
-        ticker,
-        tradingName: company.trading_name || '',
-        sector: company.sector || '',
-        subsector: company.subsector || '',
-        segment: company.segment || '',
-        market: company.market || '',
-      })
+      if (!index.has(value)) {
+        index.set(value, {
+          value,
+          companyName,
+          ticker,
+          tradingName: company.trading_name || '',
+          sector: company.sector || '',
+          subsector: company.subsector || '',
+          segment: company.segment || '',
+          market: company.market || '',
+        })
+      }
     }
   }
 
@@ -76,41 +75,15 @@ const selectedSummaries = computed(() => {
 })
 
 async function onTickerClick(item) {
-  if (!item || !item.key) {
+  if (!item?.value) {
     return
   }
 
-  const selection = [item.key]
-  const currentSelection = companyStore.selectedItems || []
-  const alreadySelected =
-    currentSelection.length === 1 && currentSelection[0] === item.key
+  const selection = [item.value]
 
-  if (!alreadySelected) {
-    companyStore.setSelectedItems(selection)
-  }
-
-  const nextQuery = {
-    ...route.query,
-    selection: item.key,
-  }
-
-  try {
-    if (route.query.selection !== item.key) {
-      await router.replace({ query: nextQuery })
-    }
-  } catch (error) {
-    console.error(error)
-  }
-
-  const previousSelection = chartStore.params.selection || []
-  const chartNeedsUpdate =
-    previousSelection.length !== 1 || previousSelection[0] !== item.key
-
+  companyStore.setSelectedItems(selection)
   chartStore.setSelection(selection)
-
-  if (chartNeedsUpdate || !chartStore.chart) {
-    await chartStore.loadChart()
-  }
+  await chartStore.loadChart()
 }
 </script>
 

--- a/presentation/frontend/src/views/HomeView.vue
+++ b/presentation/frontend/src/views/HomeView.vue
@@ -14,7 +14,6 @@
         <h2 id="chart-results-heading">Resultados</h2>
         <h3>Preço</h3>
 
-        <ChartSelector />
         <PlotlyViewer />
       </section>
     </section>
@@ -23,7 +22,6 @@
 
 <script setup>
 import { ref } from 'vue'
-import ChartSelector from '../components/ChartSelector.vue'
 import PlotlyViewer from '../components/PlotlyViewer.vue'
 import CompanySearchBuilder from '../components/CompanySearchBuilder.vue'
 import CompanySelectionSummary from '../components/CompanySelectionSummary.vue'


### PR DESCRIPTION
## Summary
- remove the chart selector from the Home view to avoid duplicate controls
- reload the chart when a ticker tag is clicked in the company summary
- trigger chart reloads whenever the company select component changes

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0654c500832e8209964c03712e64)