### PR TITLE
Align chart ticker selection with company picker

### DIFF
--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -67,6 +67,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { COMPANY_FACETS } from '../config/companyFacets'
 import { useCompanyStore } from '../store/companyStore'
 import { useChartStore } from '../store/chartStore'
+import { extractTickers } from '../utils/tickers'
 import CompanyFacet from './CompanyFacet.vue'
 import CompanyResultSelect from './CompanyResultSelect.vue'
 
@@ -194,6 +195,27 @@ function reload() {
   store.loadCompanies()
 }
 
+async function syncChartWithSelection(selectionValues, { forceLoad = false } = {}) {
+  const tickers = extractTickers(selectionValues)
+  const [primaryTicker, ...comparisonTickers] = tickers
+  const currentType = chartStore.params.type || ''
+  const currentSelection = chartStore.params.selection || []
+
+  const typeChanged = primaryTicker !== currentType
+  const selectionChanged = !selectionsAreEqual(comparisonTickers, currentSelection)
+
+  if (typeChanged) {
+    chartStore.setType(primaryTicker)
+  }
+  if (selectionChanged) {
+    chartStore.setSelection(comparisonTickers)
+  }
+
+  if (forceLoad || typeChanged || selectionChanged) {
+    await chartStore.loadChart()
+  }
+}
+
 async function onSelectionChange(values) {
   if (isSyncingSelection) {
     return
@@ -205,8 +227,9 @@ async function onSelectionChange(values) {
     const normalized = normalizeSelection(values)
     const current = store.selectedItems || []
     const querySelection = parseSelectionParam(route.query.selection)
+    const selectionChanged = !selectionsAreEqual(normalized, current)
 
-    if (!selectionsAreEqual(normalized, current)) {
+    if (selectionChanged) {
       store.setSelectedItems(normalized)
     }
 
@@ -224,8 +247,7 @@ async function onSelectionChange(values) {
       }
     }
 
-    chartStore.setSelection(normalized)
-    await chartStore.loadChart()
+    await syncChartWithSelection(normalized, { forceLoad: selectionChanged })
   } finally {
     isSyncingSelection = false
   }
@@ -233,37 +255,39 @@ async function onSelectionChange(values) {
 
 onMounted(async () => {
   const initialSelection = parseSelectionParam(route.query.selection)
-  const current = store.selectedItems || []
-  const chartSelection = chartStore.params.selection || []
 
-  if (!selectionsAreEqual(initialSelection, current)) {
-    store.setSelectedItems(initialSelection)
+  isSyncingSelection = true
+  try {
+    const current = store.selectedItems || []
+    if (!selectionsAreEqual(initialSelection, current)) {
+      store.setSelectedItems(initialSelection)
+    }
+  } finally {
+    isSyncingSelection = false
   }
 
-  const selectionChanged = !selectionsAreEqual(initialSelection, chartSelection)
-  if (selectionChanged) {
-    chartStore.setSelection(initialSelection)
-    await chartStore.loadChart()
-  }
+  const normalizedSelection = store.selectedItems || initialSelection
+  await syncChartWithSelection(normalizedSelection, { forceLoad: true })
 })
 
 watch(
   () => store.selectedItems,
-  (values) => {
+  async (values) => {
     if (isSyncingSelection) {
       return
     }
 
     const normalized = normalizeSelection(values)
     const querySelection = parseSelectionParam(route.query.selection)
-    const chartSelection = chartStore.params.selection || []
 
     const needsQuerySync = !selectionsAreEqual(normalized, querySelection)
-    const needsChartSync = !selectionsAreEqual(normalized, chartSelection)
 
-    if (needsQuerySync || needsChartSync) {
-      onSelectionChange(normalized)
+    if (needsQuerySync) {
+      await onSelectionChange(normalized)
+      return
     }
+
+    await syncChartWithSelection(normalized)
   },
   { deep: true },
 )
@@ -275,17 +299,18 @@ watch(
       return
     }
 
-    const parsed = parseSelectionParam(value)
-    const companySelection = store.selectedItems || []
-    const chartSelection = chartStore.params.selection || []
+    isSyncingSelection = true
+    try {
+      const parsed = parseSelectionParam(value)
+      const companySelection = store.selectedItems || []
 
-    if (!selectionsAreEqual(parsed, companySelection)) {
-      store.setSelectedItems(parsed)
-    }
+      if (!selectionsAreEqual(parsed, companySelection)) {
+        store.setSelectedItems(parsed)
+      }
 
-    if (!selectionsAreEqual(parsed, chartSelection)) {
-      chartStore.setSelection(parsed)
-      await chartStore.loadChart()
+      await syncChartWithSelection(parsed)
+    } finally {
+      isSyncingSelection = false
     }
   },
 )

--- a/presentation/frontend/src/components/CompanySelectionSummary.vue
+++ b/presentation/frontend/src/components/CompanySelectionSummary.vue
@@ -39,6 +39,7 @@
 import { computed } from 'vue'
 import { useCompanyStore } from '../store/companyStore'
 import { useChartStore } from '../store/chartStore'
+import { extractTicker } from '../utils/tickers'
 
 const companyStore = useCompanyStore()
 const chartStore = useChartStore()
@@ -80,9 +81,11 @@ async function onTickerClick(item) {
   }
 
   const selection = [item.value]
+  const ticker = extractTicker(item.value)
 
   companyStore.setSelectedItems(selection)
-  chartStore.setSelection(selection)
+  chartStore.setType(ticker)
+  chartStore.setSelection([])
   await chartStore.loadChart()
 }
 </script>

--- a/presentation/frontend/src/components/PlotlyViewer.vue
+++ b/presentation/frontend/src/components/PlotlyViewer.vue
@@ -22,13 +22,13 @@
     </div>
 
     <p v-else>
-      Nenhum gráfico carregado.
+      Selecione uma companhia para visualizar o gráfico.
     </p>
   </section>
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed } from 'vue'
 import { useChartStore } from '../store/chartStore'
 
 const store = useChartStore()
@@ -36,10 +36,4 @@ const store = useChartStore()
 const chart = computed(() => store.chart)
 const isLoading = computed(() => store.isLoading)
 const error = computed(() => store.error)
-
-onMounted(() => {
-  if (!store.chart) {
-    store.loadChart()
-  }
-})
 </script>

--- a/presentation/frontend/src/services/apiService.js
+++ b/presentation/frontend/src/services/apiService.js
@@ -6,7 +6,10 @@ const api = axios.create({
 
 export async function fetchChart(params) {
   const payload = params || {}
-  const type = String(payload.type || '').trim() || 'PETR4'
+  const type = String(payload.type || '').trim()
+  if (!type) {
+    throw new Error('Ticker inválido para carregar o gráfico')
+  }
   const selection = Array.isArray(payload.selection) ? payload.selection : []
 
   const query = {}

--- a/presentation/frontend/src/store/chartStore.js
+++ b/presentation/frontend/src/store/chartStore.js
@@ -2,8 +2,7 @@ import { defineStore } from 'pinia'
 import { fetchChart } from '../services/apiService'
 
 function normalizeType(value) {
-  const normalized = String(value || '').trim()
-  return normalized || 'PETR4'
+  return String(value || '').trim()
 }
 
 function normalizeSelection(values) {
@@ -25,7 +24,7 @@ function areSelectionsEqual(a = [], b = []) {
 export const useChartStore = defineStore('chart', {
   state: () => ({
     params: {
-      type: 'PETR4',
+      type: '',
       selection: [],
     },
     chart: null,
@@ -50,10 +49,22 @@ export const useChartStore = defineStore('chart', {
     },
 
     async loadChart() {
+      const type = normalizeType(this.params.type)
+      if (!type) {
+        this.chart = null
+        this.error = null
+        this.isLoading = false
+        return
+      }
+
       this.isLoading = true
       this.error = null
       try {
-        this.chart = await fetchChart({ ...this.params })
+        const payload = {
+          ...this.params,
+          type,
+        }
+        this.chart = await fetchChart(payload)
       } catch (err) {
         console.error(err)
         this.error = err?.message || 'Falha ao carregar gráfico'

--- a/presentation/frontend/src/utils/tickers.js
+++ b/presentation/frontend/src/utils/tickers.js
@@ -1,0 +1,23 @@
+export function extractTicker(value) {
+  if (value == null) {
+    return ''
+  }
+  const raw = String(value).trim()
+  if (!raw) {
+    return ''
+  }
+  const parts = raw.split('::')
+  if (parts.length === 1) {
+    return parts[0]
+  }
+  return parts[1] || ''
+}
+
+export function extractTickers(values) {
+  if (!Array.isArray(values)) {
+    return []
+  }
+  return values
+    .map((value) => extractTicker(value))
+    .filter((ticker) => ticker.length)
+}

--- a/presentation/frontend/src/views/ChartView.vue
+++ b/presentation/frontend/src/views/ChartView.vue
@@ -1,10 +1,9 @@
 <!-- src/views/ChartView.vue -->
 <template>
   <section class="chart-view">
-    <!-- 1) Selector de tipo de gráfico / símbolo -->
+    <!-- 1) Cabeçalho -->
     <header class="chart-header">
       <h1>Gráfico</h1>
-      <ChartSelector />
     </header>
 
     <!-- 2) Estado de loading -->
@@ -17,12 +16,17 @@
       {{ error }}
     </div>
 
-    <!-- 4) Nenhum dado ainda -->
+    <!-- 4) Nenhum ticker selecionado -->
+    <div v-else-if="!hasTicker">
+      Escolha uma companhia para visualizar o gráfico.
+    </div>
+
+    <!-- 5) Nenhum dado ainda -->
     <div v-else-if="!chart">
       Nenhum gráfico carregado ainda.
     </div>
 
-    <!-- 5) Gráfico Plotly -->
+    <!-- 6) Gráfico Plotly -->
     <div v-else class="chart-container">
       <VuePlotly
         :data="chart.data"
@@ -42,7 +46,6 @@
 import { onMounted, computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useChartStore } from '../store/chartStore'
-import ChartSelector from '../components/ChartSelector.vue'
 
 const store = useChartStore()
 const { chart, isLoading, error, params } = storeToRefs(store)
@@ -54,10 +57,12 @@ const plotConfig = computed(() => ({
   // aqui você pode ajustar interações do Plotly se quiser
 }))
 
+const hasTicker = computed(() => !!(params.value?.type || '').trim())
+
 // Quando a view carregar pela primeira vez, garante um gráfico inicial
 onMounted(async () => {
-  // só carrega se ainda não tiver gráfico
-  if (!chart.value) {
+  // só carrega se houver um ticker definido e ainda não tiver gráfico
+  if (hasTicker.value && !chart.value) {
     await store.loadChart()
   }
 })


### PR DESCRIPTION
## Summary
- remove hidden PETR4 fallbacks so the chart only loads when a ticker is provided
- synchronize company selection with the chart store using ticker extraction helpers
- refresh chart UI messaging to prompt users to choose a company before loading data

## Testing
- not run (frontend changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0a0fa624832eb7ddbc94accfc29d)