### PR TITLE
Switch company search to eligible projection

### DIFF
--- a/application/usecases/search_companies.py
+++ b/application/usecases/search_companies.py
@@ -1,52 +1,110 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, List
+from typing import Dict, List
 
-from application.dtos.company_search_dto import (
-    CompanySearchResponseDTO,
-    CompanySearchResultDTO,
-)
+from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import UowFactoryPort
-from domain.dtos.company_data_dto import CompanyDataDTO
-from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from domain.dtos.company_eligible_dto import CompanyEligibleDTO
+from domain.ports.companies_eligible_port import CompaniesEligiblePort
 from domain.value_objects.company_filters import CompanyFilterQuery, CompanyField
 
 
-DEFAULT_LIMIT = 200
+@dataclass(frozen=True)
+class CompanySearchResultItem:
+    company_name: str
+    trading_name: str | None
+    tickers: list[str]
+    sector: str | None
+    subsector: str | None
+    segment: str | None
+    market: str | None
+    institution_common: str | None
+    institution_preferred: str | None
 
 
-@dataclass
+@dataclass(frozen=True)
+class CompanySearchResult:
+    items: list[CompanySearchResultItem]
+    total: int
+    facets: Dict[str, List[str]]
+
+
 class SearchCompaniesUseCase:
-    repository: RepositoryCompanyDataPort
-    uow_factory: UowFactoryPort
+    def __init__(
+        self,
+        *,
+        repository: CompaniesEligiblePort,
+        uow_factory: UowFactoryPort,
+        logger: LoggerPort | None = None,
+    ) -> None:
+        self._repository = repository
+        self._uow_factory = uow_factory
+        self._logger = logger
 
     def __call__(
         self,
         query: CompanyFilterQuery | None = None,
-        *,
-        limit: int | None = None,
-    ) -> CompanySearchResponseDTO:
+    ) -> CompanySearchResult:
         query = query or CompanyFilterQuery()
-        with self.uow_factory() as uow:
-            dtos: List[CompanyDataDTO] = self.repository.search(
-                query,
+        return self.run(query=query)
+
+    def run(self, *, query: CompanyFilterQuery) -> CompanySearchResult:
+        filters = self._extract_simple_filters(query)
+
+        with self._uow_factory() as uow:
+            dtos: list[CompanyEligibleDTO] = self._repository.list(
                 uow=uow,
-                limit=limit or DEFAULT_LIMIT,
+                cvm_code=filters.get("cvm_code"),
+                company_name=filters.get("company_name"),
+                segment=filters.get("segment"),
             )
 
-        items = [self._to_result(dto) for dto in dtos]
+        items = [self._to_item(dto) for dto in dtos]
         facets = self._build_facets(items)
-        return CompanySearchResponseDTO(items=items, total=len(items), facets=facets)
 
-    def _to_result(self, dto: CompanyDataDTO) -> CompanySearchResultDTO:
-        return CompanySearchResultDTO(
+        if self._logger is not None:
+            self._logger.log(
+                f"SearchCompaniesUseCase returned {len(items)} items",
+                level="debug",
+            )
+
+        return CompanySearchResult(
+            items=items,
+            total=len(items),
+            facets=facets,
+        )
+
+    def _extract_simple_filters(self, query: CompanyFilterQuery) -> dict[str, str]:
+        filters: dict[str, str] = {}
+
+        for clause in query.clauses:
+            condition = clause.condition
+            if condition is None or not condition.values:
+                continue
+            value = condition.values[0]
+            if not value:
+                continue
+            if condition.field == CompanyField.COMPANY_NAME:
+                filters.setdefault("company_name", value)
+            elif condition.field == CompanyField.SEGMENT:
+                filters.setdefault("segment", value)
+            elif condition.field == CompanyField.CVM_CODE:
+                filters.setdefault("cvm_code", value)
+
+        return filters
+
+    def _to_item(self, dto: CompanyEligibleDTO) -> CompanySearchResultItem:
+        return CompanySearchResultItem(
             company_name=dto.company_name or "",
             trading_name=dto.trading_name,
-            tickers=list(dto.ticker_codes or []),
-            sector=dto.industry_sector,
-            subsector=dto.industry_subsector,
-            segment=dto.industry_segment,
+            tickers=list(dto.ticker_codes),
+            sector=getattr(dto, "industry_sector", None)
+            or getattr(dto, "company_sector", None),
+            subsector=getattr(dto, "industry_subsector", None)
+            or getattr(dto, "company_subsector", None),
+            segment=getattr(dto, "industry_segment", None)
+            or getattr(dto, "company_segment", None),
             market=dto.market,
             institution_common=dto.institution_common,
             institution_preferred=dto.institution_preferred,
@@ -54,45 +112,23 @@ class SearchCompaniesUseCase:
 
     def _build_facets(
         self,
-        items: Iterable[CompanySearchResultDTO],
+        items: list[CompanySearchResultItem],
     ) -> Dict[str, List[str]]:
-        buckets: Dict[str, set[str]] = {
-            CompanyField.SECTOR.value: set(),
-            CompanyField.SUBSECTOR.value: set(),
-            CompanyField.SEGMENT.value: set(),
-            CompanyField.COMPANY_NAME.value: set(),
-            CompanyField.TRADING_NAME.value: set(),
-            CompanyField.TICKER.value: set(),
-            CompanyField.INSTITUTION_COMMON.value: set(),
-            CompanyField.INSTITUTION_PREFERRED.value: set(),
-            CompanyField.MARKET.value: set(),
+        facets: Dict[str, set[str]] = {
+            "sector": set(),
+            "subsector": set(),
+            "segment": set(),
+            "market": set(),
         }
 
         for item in items:
-            if item.company_name:
-                buckets[CompanyField.COMPANY_NAME.value].add(item.company_name)
-            if item.trading_name:
-                buckets[CompanyField.TRADING_NAME.value].add(item.trading_name)
-            for ticker in item.tickers:
-                if ticker:
-                    buckets[CompanyField.TICKER.value].add(ticker)
             if item.sector:
-                buckets[CompanyField.SECTOR.value].add(item.sector)
+                facets["sector"].add(item.sector)
             if item.subsector:
-                buckets[CompanyField.SUBSECTOR.value].add(item.subsector)
+                facets["subsector"].add(item.subsector)
             if item.segment:
-                buckets[CompanyField.SEGMENT.value].add(item.segment)
+                facets["segment"].add(item.segment)
             if item.market:
-                buckets[CompanyField.MARKET.value].add(item.market)
-            if item.institution_common:
-                buckets[CompanyField.INSTITUTION_COMMON.value].add(item.institution_common)
-            if item.institution_preferred:
-                buckets[CompanyField.INSTITUTION_PREFERRED.value].add(
-                    item.institution_preferred
-                )
+                facets["market"].add(item.market)
 
-        return {
-            key: sorted({v for v in values if v})
-            for key, values in buckets.items()
-            if values
-        }
+        return {key: sorted(values) for key, values in facets.items()}

--- a/presentation/backend/dependencies/company_search_dependencies.py
+++ b/presentation/backend/dependencies/company_search_dependencies.py
@@ -1,19 +1,25 @@
 from __future__ import annotations
 
 from application.usecases.search_companies import SearchCompaniesUseCase
-from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from domain.ports.companies_eligible_port import CompaniesEligiblePort
 from infrastructure.config.config_adapter import ConfigAdapter
 from infrastructure.logging.logger_adapter import Logger
-from infrastructure.repositories.repository_company_data import RepositoryCompanyData
+from infrastructure.repositories.repository_company_eligible import (
+    RepositoryCompanyEligible,
+)
 from infrastructure.uow.uow import UowFactory
 
 
 def get_company_search_usecase() -> SearchCompaniesUseCase:
     config = ConfigAdapter()
     logger = Logger(config)
-    repository: RepositoryCompanyDataPort = RepositoryCompanyData(
+    repository: CompaniesEligiblePort = RepositoryCompanyEligible(
         config=config,
         logger=logger,
     )
     uow_factory = UowFactory(session_factory=repository.Session)
-    return SearchCompaniesUseCase(repository=repository, uow_factory=uow_factory)
+    return SearchCompaniesUseCase(
+        repository=repository,
+        uow_factory=uow_factory,
+        logger=logger,
+    )


### PR DESCRIPTION
## Summary
- refactor `SearchCompaniesUseCase` to operate on `CompanyEligibleDTO`, expose lightweight result dataclasses, and build facets from the eligible projection
- update the FastAPI dependency wiring to provide the eligible repository and shared logger to the use case

## Testing
- pytest *(fails: NormalizeUseCase expects config.fly_settings in tests/application/usecases/test_normalize_ratios_flow.py)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f100c69a8832ea4758bb44a621d8b)