### PR TITLE
Ensure company search response matches frontend contract

### DIFF
--- a/application/usecases/search_companies.py
+++ b/application/usecases/search_companies.py
@@ -95,10 +95,12 @@ class SearchCompaniesUseCase:
         return filters
 
     def _to_item(self, dto: CompanyEligibleDTO) -> CompanySearchResultItem:
+        tickers = [ticker for ticker in (dto.ticker_codes or ()) if ticker]
+
         return CompanySearchResultItem(
             company_name=dto.company_name or "",
             trading_name=dto.trading_name,
-            tickers=list(dto.ticker_codes),
+            tickers=tickers,
             sector=getattr(dto, "industry_sector", None)
             or getattr(dto, "company_sector", None),
             subsector=getattr(dto, "industry_subsector", None)

--- a/presentation/backend/routers/companies.py
+++ b/presentation/backend/routers/companies.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
-from dataclasses import asdict
-from dataclasses import asdict
-
 from fastapi import APIRouter, Depends, Body
 
 from application.usecases.search_companies import SearchCompaniesUseCase


### PR DESCRIPTION
## Summary
- guard company search mapping against missing ticker codes so the response always includes the expected fields
- clean up the companies router import so the response model is built from a single dataclass export

## Testing
- not run (SQLAlchemy is not installed in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f228444b8832e8c65590e698708c2)