### PR TITLE
Expand company eligible filters and search integration

### DIFF
--- a/application/usecases/search_companies.py
+++ b/application/usecases/search_companies.py
@@ -8,8 +8,8 @@ from application.dtos.company_search_dto import (
     CompanySearchResultDTO,
 )
 from application.ports.uow_port import UowFactoryPort
-from domain.dtos.company_data_dto import CompanyDataDTO
-from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from domain.dtos.company_eligible_dto import CompanyEligibleDTO
+from domain.ports.repository_company_eligible_port import RepositoryCompanyEligiblePort
 from domain.value_objects.company_filters import CompanyFilterQuery, CompanyField
 
 
@@ -18,7 +18,7 @@ DEFAULT_LIMIT = 200
 
 @dataclass
 class SearchCompaniesUseCase:
-    repository: RepositoryCompanyDataPort
+    repository: RepositoryCompanyEligiblePort
     uow_factory: UowFactoryPort
 
     def __call__(
@@ -29,17 +29,17 @@ class SearchCompaniesUseCase:
     ) -> CompanySearchResponseDTO:
         query = query or CompanyFilterQuery()
         with self.uow_factory() as uow:
-            dtos: List[CompanyDataDTO] = self.repository.search(
+            dtos: List[CompanyEligibleDTO] = self.repository.search(
                 query,
                 uow=uow,
                 limit=limit or DEFAULT_LIMIT,
             )
 
         items = [self._to_result(dto) for dto in dtos]
-        facets = self._build_facets(items)
+        facets = self._build_facets(dtos)
         return CompanySearchResponseDTO(items=items, total=len(items), facets=facets)
 
-    def _to_result(self, dto: CompanyDataDTO) -> CompanySearchResultDTO:
+    def _to_result(self, dto: CompanyEligibleDTO) -> CompanySearchResultDTO:
         return CompanySearchResultDTO(
             company_name=dto.company_name or "",
             trading_name=dto.trading_name,
@@ -54,42 +54,57 @@ class SearchCompaniesUseCase:
 
     def _build_facets(
         self,
-        items: Iterable[CompanySearchResultDTO],
+        items: Iterable[CompanyEligibleDTO],
     ) -> Dict[str, List[str]]:
+        string_fields = [
+            CompanyField.ISSUING_COMPANY,
+            CompanyField.TRADING_NAME,
+            CompanyField.COMPANY_NAME,
+            CompanyField.CNPJ,
+            CompanyField.MARKET,
+            CompanyField.INDUSTRY_SECTOR,
+            CompanyField.INDUSTRY_SUBSECTOR,
+            CompanyField.INDUSTRY_SEGMENT,
+            CompanyField.INDUSTRY_CLASSIFICATION,
+            CompanyField.INDUSTRY_CLASSIFICATION_ENG,
+            CompanyField.ACTIVITY,
+            CompanyField.COMPANY_SEGMENT,
+            CompanyField.COMPANY_SEGMENT_ENG,
+            CompanyField.COMPANY_CATEGORY,
+            CompanyField.COMPANY_TYPE,
+            CompanyField.LISTING_SEGMENT,
+            CompanyField.REGISTRAR,
+            CompanyField.WEBSITE,
+            CompanyField.INSTITUTION_COMMON,
+            CompanyField.INSTITUTION_PREFERRED,
+            CompanyField.STATUS,
+            CompanyField.MARKET_INDICATOR,
+            CompanyField.CODE,
+            CompanyField.TYPE_BDR,
+            CompanyField.REASON,
+        ]
+
+        boolean_fields = [
+            CompanyField.HAS_BDR,
+            CompanyField.HAS_QUOTATION,
+            CompanyField.HAS_EMISSIONS,
+        ]
+
         buckets: Dict[str, set[str]] = {
-            CompanyField.SECTOR.value: set(),
-            CompanyField.SUBSECTOR.value: set(),
-            CompanyField.SEGMENT.value: set(),
-            CompanyField.COMPANY_NAME.value: set(),
-            CompanyField.TRADING_NAME.value: set(),
-            CompanyField.TICKER.value: set(),
-            CompanyField.INSTITUTION_COMMON.value: set(),
-            CompanyField.INSTITUTION_PREFERRED.value: set(),
-            CompanyField.MARKET.value: set(),
+            field.value: set() for field in string_fields + boolean_fields
         }
 
         for item in items:
-            if item.company_name:
-                buckets[CompanyField.COMPANY_NAME.value].add(item.company_name)
-            if item.trading_name:
-                buckets[CompanyField.TRADING_NAME.value].add(item.trading_name)
-            for ticker in item.tickers:
-                if ticker:
-                    buckets[CompanyField.TICKER.value].add(ticker)
-            if item.sector:
-                buckets[CompanyField.SECTOR.value].add(item.sector)
-            if item.subsector:
-                buckets[CompanyField.SUBSECTOR.value].add(item.subsector)
-            if item.segment:
-                buckets[CompanyField.SEGMENT.value].add(item.segment)
-            if item.market:
-                buckets[CompanyField.MARKET.value].add(item.market)
-            if item.institution_common:
-                buckets[CompanyField.INSTITUTION_COMMON.value].add(item.institution_common)
-            if item.institution_preferred:
-                buckets[CompanyField.INSTITUTION_PREFERRED.value].add(
-                    item.institution_preferred
-                )
+            for field in string_fields:
+                value = getattr(item, field.value, None)
+                if value:
+                    buckets[field.value].add(value)
+
+            for field in boolean_fields:
+                value = getattr(item, field.value, None)
+                if value is None:
+                    continue
+                buckets[field.value].add("true" if value else "false")
 
         return {
             key: sorted({v for v in values if v})

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -9,6 +9,7 @@ from application.ports.worker_pool_port import WorkerPoolPort
 from domain.ports.datacleaner_port import DataCleanerPort
 from domain.ports.repository_base_port import RepositoryBasePort
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from domain.ports.repository_company_eligible_port import RepositoryCompanyEligiblePort
 from domain.ports.repository_nsd_port import RepositoryNsdPort
 from domain.ports.repository_statements_fetched_port import (
            RepositoryStatementFetchedPort,
@@ -18,9 +19,21 @@ from domain.ports.scraper_base_port import ScraperBasePort
 from domain.ports.scraper_company_data_port import ScraperCompanyDataPort
 from domain.ports.scraper_statements_raw_port import ScraperStatementRawPort
 
-__all__ = ["CliPort","RepositoryCompanyDataPort", "ConfigPort", "DataCleanerPort",
-           "AffinityHttpClientPort", "LoggerPort",
-           "RepositoryBasePort", "RepositoryNsdPort",
-           "RepositoryStatementsRawPort", "RepositoryStatementFetchedPort",
-           "ScraperBasePort", "ScraperCompanyDataPort",
-           "ScraperStatementRawPort", "MetricsCollectorPort", "WorkerPoolPort"]
+__all__ = [
+    "CliPort",
+    "RepositoryCompanyDataPort",
+    "RepositoryCompanyEligiblePort",
+    "ConfigPort",
+    "DataCleanerPort",
+    "AffinityHttpClientPort",
+    "LoggerPort",
+    "RepositoryBasePort",
+    "RepositoryNsdPort",
+    "RepositoryStatementsRawPort",
+    "RepositoryStatementFetchedPort",
+    "ScraperBasePort",
+    "ScraperCompanyDataPort",
+    "ScraperStatementRawPort",
+    "MetricsCollectorPort",
+    "WorkerPoolPort",
+]

--- a/domain/ports/repository_company_eligible_port.py
+++ b/domain/ports/repository_company_eligible_port.py
@@ -1,0 +1,27 @@
+"""Port definition for the eligible companies repository with search support."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from application.ports.uow_port import Uow
+from domain.dtos.company_eligible_dto import CompanyEligibleDTO
+from domain.ports.repository_base_port import RepositoryBasePort
+from domain.value_objects.company_filters import CompanyFilterQuery
+
+
+@runtime_checkable
+class RepositoryCompanyEligiblePort(
+    RepositoryBasePort[CompanyEligibleDTO, str], Protocol
+):
+    """Port abstraction for querying the eligible companies projection."""
+
+    def search(
+        self,
+        query: CompanyFilterQuery,
+        *,
+        uow: Uow,
+        limit: int | None = None,
+    ) -> list[CompanyEligibleDTO]:
+        """Return companies matching the structured filter query."""
+        ...

--- a/domain/value_objects/company_filters.py
+++ b/domain/value_objects/company_filters.py
@@ -10,15 +10,43 @@ from typing import List
 class CompanyField(str, Enum):
     """Enumeration of filterable company attributes."""
 
-    SECTOR = "sector"
-    SUBSECTOR = "subsector"
-    SEGMENT = "segment"
-    COMPANY_NAME = "company_name"
+    ISSUING_COMPANY = "issuing_company"
     TRADING_NAME = "trading_name"
-    TICKER = "ticker"
-    INSTITUTION_PREFERRED = "institution_preferred"
-    INSTITUTION_COMMON = "institution_common"
+    COMPANY_NAME = "company_name"
+    CNPJ = "cnpj"
     MARKET = "market"
+    INDUSTRY_SECTOR = "industry_sector"
+    INDUSTRY_SUBSECTOR = "industry_subsector"
+    INDUSTRY_SEGMENT = "industry_segment"
+    INDUSTRY_CLASSIFICATION = "industry_classification"
+    INDUSTRY_CLASSIFICATION_ENG = "industry_classification_eng"
+    ACTIVITY = "activity"
+    COMPANY_SEGMENT = "company_segment"
+    COMPANY_SEGMENT_ENG = "company_segment_eng"
+    COMPANY_CATEGORY = "company_category"
+    COMPANY_TYPE = "company_type"
+    LISTING_SEGMENT = "listing_segment"
+    REGISTRAR = "registrar"
+    WEBSITE = "website"
+    INSTITUTION_COMMON = "institution_common"
+    INSTITUTION_PREFERRED = "institution_preferred"
+    STATUS = "status"
+    MARKET_INDICATOR = "market_indicator"
+    CODE = "code"
+    TYPE_BDR = "type_bdr"
+    REASON = "reason"
+    HAS_BDR = "has_bdr"
+    HAS_QUOTATION = "has_quotation"
+    HAS_EMISSIONS = "has_emissions"
+    DATE_QUOTATION = "date_quotation"
+    LAST_DATE = "last_date"
+    LISTING_DATE = "listing_date"
+
+    # Backwards compatibility aliases
+    SECTOR = INDUSTRY_SECTOR
+    SUBSECTOR = INDUSTRY_SUBSECTOR
+    SEGMENT = INDUSTRY_SEGMENT
+    TICKER = CODE
 
 
 class ComparisonOperator(str, Enum):
@@ -28,6 +56,7 @@ class ComparisonOperator(str, Enum):
     IN = "IN"
     CONTAINS = "CONTAINS"
     STARTS_WITH = "STARTS_WITH"
+    BETWEEN = "BETWEEN"
 
 
 class LogicalOperator(str, Enum):

--- a/infrastructure/repositories/repository_company_eligible.py
+++ b/infrastructure/repositories/repository_company_eligible.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Sequence, Tuple
+from datetime import datetime
+from typing import Optional, Sequence, Tuple
 
-from sqlalchemy import delete
+from sqlalchemy import and_, delete, func, not_, or_
 from sqlalchemy.orm import Session
 
 from application.ports.config_port import ConfigPort
@@ -12,13 +13,64 @@ from application.ports.logger_port import LoggerPort
 from application.ports.uow_port import Uow
 from domain.dtos.company_eligible_dto import CompanyEligibleDTO
 from domain.ports.companies_eligible_port import CompaniesEligiblePort
-from infrastructure.repositories.repository_base import RepositoryBase
+from domain.ports.repository_company_eligible_port import RepositoryCompanyEligiblePort
+from domain.value_objects.company_filters import (
+    CompanyFilterClause,
+    CompanyFilterCondition,
+    CompanyFilterQuery,
+    CompanyField,
+    ComparisonOperator,
+    LogicalOperator,
+)
 from infrastructure.models.company_eligible_model import CompanyEligibleModel
+from infrastructure.repositories.repository_base import RepositoryBase
+
+
+STRING_FIELDS: set[CompanyField] = {
+    CompanyField.ISSUING_COMPANY,
+    CompanyField.TRADING_NAME,
+    CompanyField.COMPANY_NAME,
+    CompanyField.CNPJ,
+    CompanyField.MARKET,
+    CompanyField.INDUSTRY_SECTOR,
+    CompanyField.INDUSTRY_SUBSECTOR,
+    CompanyField.INDUSTRY_SEGMENT,
+    CompanyField.INDUSTRY_CLASSIFICATION,
+    CompanyField.INDUSTRY_CLASSIFICATION_ENG,
+    CompanyField.ACTIVITY,
+    CompanyField.COMPANY_SEGMENT,
+    CompanyField.COMPANY_SEGMENT_ENG,
+    CompanyField.COMPANY_CATEGORY,
+    CompanyField.COMPANY_TYPE,
+    CompanyField.LISTING_SEGMENT,
+    CompanyField.REGISTRAR,
+    CompanyField.WEBSITE,
+    CompanyField.INSTITUTION_COMMON,
+    CompanyField.INSTITUTION_PREFERRED,
+    CompanyField.STATUS,
+    CompanyField.MARKET_INDICATOR,
+    CompanyField.CODE,
+    CompanyField.TYPE_BDR,
+    CompanyField.REASON,
+}
+
+BOOLEAN_FIELDS: set[CompanyField] = {
+    CompanyField.HAS_BDR,
+    CompanyField.HAS_QUOTATION,
+    CompanyField.HAS_EMISSIONS,
+}
+
+DATE_FIELDS: set[CompanyField] = {
+    CompanyField.DATE_QUOTATION,
+    CompanyField.LAST_DATE,
+    CompanyField.LISTING_DATE,
+}
 
 
 class RepositoryCompanyEligible(
     RepositoryBase[CompanyEligibleDTO, str],
     CompaniesEligiblePort,
+    RepositoryCompanyEligiblePort,
 ):
     """SQLite-backed repository for the eligible companies projection."""
 
@@ -73,6 +125,35 @@ class RepositoryCompanyEligible(
 
         return [row.to_dto() for row in rows]
 
+    # ------------------------------------------------------------------
+    # Query builder support
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        query: CompanyFilterQuery,
+        *,
+        uow: Uow,
+        limit: int | None = None,
+    ) -> list[CompanyEligibleDTO]:
+        session: Session = uow.session
+        model, _ = self.get_model_class()
+
+        stmt = session.query(model)
+
+        expression = self._build_boolean_expression(query.clauses, model)
+        if expression is not None:
+            stmt = stmt.filter(expression)
+
+        stmt = stmt.order_by(model.company_name.asc())
+
+        if limit is None:
+            limit = 200
+        if limit:
+            stmt = stmt.limit(limit)
+
+        rows = stmt.all()
+        return [row.to_dto() for row in rows]
+
     def replace_all(
         self,
         items: Sequence[CompanyEligibleDTO],
@@ -91,3 +172,223 @@ class RepositoryCompanyEligible(
         #     f"Projection tbl_company_eligible replaced with {len(items)} rows",
         #     level="debug",
         # )
+
+    # Helpers -----------------------------------------------------------------
+    def _build_boolean_expression(
+        self, clauses: list[CompanyFilterClause], model
+    ) -> Optional[object]:
+        if not clauses:
+            return None
+
+        must_clauses: list[object] = []
+        should_clauses: list[object] = []
+        negative_clauses: list[object] = []
+
+        for clause in clauses:
+            if clause.is_group():
+                expression = self._build_boolean_expression(clause.group.clauses, model)
+            else:
+                expression = self._build_condition_expression(clause.condition, model)
+
+            if expression is None:
+                continue
+
+            if clause.logical == LogicalOperator.AND:
+                must_clauses.append(expression)
+            elif clause.logical == LogicalOperator.OR:
+                should_clauses.append(expression)
+            elif clause.logical == LogicalOperator.NOT:
+                negative_clauses.append(expression)
+
+        return self._combine_boolean_expressions(
+            must_clauses, should_clauses, negative_clauses
+        )
+
+    def _combine_boolean_expressions(
+        self,
+        must_clauses: list[object],
+        should_clauses: list[object],
+        negative_clauses: list[object],
+    ) -> Optional[object]:
+        expression: Optional[object] = None
+
+        if must_clauses:
+            expression = and_(*must_clauses)
+
+        if should_clauses:
+            should_expr = (
+                should_clauses[0]
+                if len(should_clauses) == 1
+                else or_(*should_clauses)
+            )
+            expression = (
+                should_expr
+                if expression is None
+                else and_(expression, should_expr)
+            )
+
+        if negative_clauses:
+            negatives = [not_(expr) for expr in negative_clauses]
+            negative_expr = (
+                negatives[0] if len(negatives) == 1 else and_(*negatives)
+            )
+            expression = (
+                negative_expr
+                if expression is None
+                else and_(expression, negative_expr)
+            )
+
+        return expression
+
+    def _build_condition_expression(
+        self, condition: CompanyFilterCondition | None, model
+    ) -> Optional[object]:
+        if condition is None:
+            return None
+
+        column = self._map_field(condition.field, model)
+        if column is None:
+            return None
+
+        if condition.field in DATE_FIELDS:
+            return self._date_expression(condition, column)
+
+        if condition.field in BOOLEAN_FIELDS:
+            return self._boolean_expression(condition, column)
+
+        return self._string_expression(condition, column)
+
+    def _string_expression(self, condition: CompanyFilterCondition, column):
+        values = [v for v in condition.values if v is not None]
+        operator = condition.operator
+
+        if not values and operator not in (
+            ComparisonOperator.CONTAINS,
+            ComparisonOperator.STARTS_WITH,
+        ):
+            return None
+
+        if operator == ComparisonOperator.CONTAINS:
+            return self._string_like(column, values, mode="contains")
+
+        if operator == ComparisonOperator.STARTS_WITH:
+            return self._string_like(column, values, mode="starts_with")
+
+        lowered = [str(value).lower() for value in values]
+
+        if operator == ComparisonOperator.EQUALS and len(lowered) == 1:
+            value = lowered[0]
+            return func.lower(column) == value
+
+        if operator in (ComparisonOperator.EQUALS, ComparisonOperator.IN):
+            return func.lower(column).in_(lowered)
+
+        if not values:
+            return None
+
+        return func.lower(column).in_(lowered)
+
+    def _string_like(self, column, values: list[str], *, mode: str):
+        expressions = []
+        targets = values or [""]
+        for value in targets:
+            pattern = str(value).lower()
+            if mode == "contains":
+                like_pattern = f"%{pattern}%"
+            else:
+                like_pattern = f"{pattern}%"
+            expressions.append(func.lower(column).like(like_pattern))
+        return or_(*expressions) if expressions else None
+
+    def _boolean_expression(
+        self, condition: CompanyFilterCondition, column
+    ) -> Optional[object]:
+        raw_values = condition.values or []
+        normalized: list[bool] = []
+        for value in raw_values:
+            parsed = self._coerce_boolean(value)
+            if parsed is not None:
+                normalized.append(parsed)
+
+        if not normalized:
+            return None
+
+        unique_values = list(dict.fromkeys(normalized))
+
+        if condition.operator in (ComparisonOperator.IN, ComparisonOperator.EQUALS):
+            if len(unique_values) == 1:
+                return column.is_(unique_values[0])
+            return column.in_(unique_values)
+
+        return column.is_(unique_values[0])
+
+    def _date_expression(
+        self, condition: CompanyFilterCondition, column
+    ) -> Optional[object]:
+        values = condition.values or []
+        if condition.operator != ComparisonOperator.BETWEEN or len(values) < 2:
+            return None
+
+        start = self._parse_date(values[0])
+        end = self._parse_date(values[1])
+        if not start or not end:
+            return None
+        if end < start:
+            start, end = end, start
+        return and_(column >= start, column <= end)
+
+    @staticmethod
+    def _parse_date(value: str | None):
+        if not value:
+            return None
+        try:
+            return datetime.strptime(str(value), "%Y-%m-%d").date()
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _coerce_boolean(value: object) -> Optional[bool]:
+        if isinstance(value, bool):
+            return value
+        text = str(value).strip().lower()
+        if text in {"true", "1", "yes", "sim"}:
+            return True
+        if text in {"false", "0", "no", "nao", "não"}:
+            return False
+        return None
+
+    def _map_field(self, field: CompanyField, model):
+        mapping = {
+            CompanyField.ISSUING_COMPANY: model.issuing_company,
+            CompanyField.TRADING_NAME: model.trading_name,
+            CompanyField.COMPANY_NAME: model.company_name,
+            CompanyField.CNPJ: model.cnpj,
+            CompanyField.MARKET: model.market,
+            CompanyField.INDUSTRY_SECTOR: model.industry_sector,
+            CompanyField.INDUSTRY_SUBSECTOR: model.industry_subsector,
+            CompanyField.INDUSTRY_SEGMENT: model.industry_segment,
+            CompanyField.INDUSTRY_CLASSIFICATION: model.industry_classification,
+            CompanyField.INDUSTRY_CLASSIFICATION_ENG: model.industry_classification_eng,
+            CompanyField.ACTIVITY: model.activity,
+            CompanyField.COMPANY_SEGMENT: model.company_segment,
+            CompanyField.COMPANY_SEGMENT_ENG: model.company_segment_eng,
+            CompanyField.COMPANY_CATEGORY: model.company_category,
+            CompanyField.COMPANY_TYPE: model.company_type,
+            CompanyField.LISTING_SEGMENT: model.listing_segment,
+            CompanyField.REGISTRAR: model.registrar,
+            CompanyField.WEBSITE: model.website,
+            CompanyField.INSTITUTION_COMMON: model.institution_common,
+            CompanyField.INSTITUTION_PREFERRED: model.institution_preferred,
+            CompanyField.STATUS: model.status,
+            CompanyField.MARKET_INDICATOR: model.market_indicator,
+            CompanyField.CODE: model.code,
+            CompanyField.TYPE_BDR: model.type_bdr,
+            CompanyField.REASON: model.reason,
+            CompanyField.HAS_BDR: model.has_bdr,
+            CompanyField.HAS_QUOTATION: model.has_quotation,
+            CompanyField.HAS_EMISSIONS: model.has_emissions,
+            CompanyField.DATE_QUOTATION: model.date_quotation,
+            CompanyField.LAST_DATE: model.last_date,
+            CompanyField.LISTING_DATE: model.listing_date,
+        }
+        return mapping.get(field)

--- a/presentation/backend/dependencies/company_search_dependencies.py
+++ b/presentation/backend/dependencies/company_search_dependencies.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
 from application.usecases.search_companies import SearchCompaniesUseCase
-from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
+from domain.ports.repository_company_eligible_port import (
+    RepositoryCompanyEligiblePort,
+)
 from infrastructure.config.config_adapter import ConfigAdapter
 from infrastructure.logging.logger_adapter import Logger
-from infrastructure.repositories.repository_company_data import RepositoryCompanyData
+from infrastructure.repositories.repository_company_eligible import (
+    RepositoryCompanyEligible,
+)
 from infrastructure.uow.uow import UowFactory
 
 
 def get_company_search_usecase() -> SearchCompaniesUseCase:
     config = ConfigAdapter()
     logger = Logger(config)
-    repository: RepositoryCompanyDataPort = RepositoryCompanyData(
+    repository: RepositoryCompanyEligiblePort = RepositoryCompanyEligible(
         config=config,
         logger=logger,
     )

--- a/presentation/frontend/src/components/CompanyFacet.vue
+++ b/presentation/frontend/src/components/CompanyFacet.vue
@@ -8,24 +8,64 @@
         </option>
       </select>
     </header>
-    <div v-if="!options.length" class="company-facet__empty">
-      Nenhuma opção disponível
-    </div>
-    <ul v-else class="company-facet__options">
-      <li v-for="option in options" :key="option">
-        <label>
+
+    <div class="company-facet__body">
+      <template v-if="isDateRange">
+        <div class="company-facet__dates">
+          <label>
+            Início
+            <input type="date" v-model="startDate" @change="onDateChange" />
+          </label>
+          <label>
+            Fim
+            <input type="date" v-model="endDate" @change="onDateChange" />
+          </label>
+        </div>
+      </template>
+
+      <template v-else-if="isBoolean">
+        <select v-model="localBoolean" @change="emitDraftChange">
+          <option value="">Selecione…</option>
+          <option
+            v-for="option in normalizedOptions"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+      </template>
+
+      <template v-else>
+        <div v-if="normalizedOptions.length" class="company-facet__select-wrapper">
           <input
-            :type="multiple ? 'checkbox' : 'radio'"
-            :name="field"
-            :value="option"
-            :checked="isSelected(option)"
-            @change="toggle(option)"
+            v-if="searchable"
+            v-model="searchText"
+            type="search"
+            class="company-facet__search"
+            placeholder="Filtrar opções…"
+            @input="onSearch"
           />
-          <span>{{ option }}</span>
-        </label>
-      </li>
-    </ul>
-    <div v-if="options.length" class="company-facet__footer">
+          <select
+            v-model="localSelection"
+            :multiple="multiple"
+            class="company-facet__select"
+            :size="computedSize"
+          >
+            <option
+              v-for="option in filteredOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+        </div>
+        <p v-else class="company-facet__empty">Nenhuma opção disponível</p>
+      </template>
+    </div>
+
+    <div class="company-facet__footer">
       <button type="button" class="company-facet__commit" @click="commit">
         Enviar para consulta
       </button>
@@ -34,22 +74,135 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 const props = defineProps({
   field: { type: String, required: true },
   label: { type: String, required: true },
   options: { type: Array, default: () => [] },
   logical: { type: String, default: 'AND' },
+  operator: { type: String, default: '' },
   values: { type: Array, default: () => [] },
   multiple: { type: Boolean, default: true },
+  type: { type: String, default: 'text' },
+  searchable: { type: Boolean, default: false },
 })
 
 const emit = defineEmits(['change', 'commit'])
 
 const logicalOptions = ['AND', 'OR', 'NOT']
 const localLogical = ref(props.logical || 'AND')
-const selected = ref([...props.values])
+const localSelection = ref([])
+const localBoolean = ref('')
+const startDate = ref('')
+const endDate = ref('')
+const searchText = ref('')
+const isSyncing = ref(false)
+
+const isBoolean = computed(() => props.type === 'boolean')
+const isDateRange = computed(() => props.type === 'date-range')
+const isTextual = computed(() => !isBoolean.value && !isDateRange.value)
+
+const defaultOperator = computed(() => {
+  if (isDateRange.value) return 'BETWEEN'
+  if (isBoolean.value) return 'EQUALS'
+  return 'IN'
+})
+
+const activeOperator = computed(() => props.operator || defaultOperator.value)
+
+const normalizedOptions = computed(() => {
+  const raw = Array.isArray(props.options) ? props.options : []
+  const seen = new Set()
+  const entries = []
+  for (const option of raw) {
+    let value
+    let label
+    if (option && typeof option === 'object') {
+      value = option.value ?? option.label ?? ''
+      label = option.label ?? String(option.value ?? '')
+    } else {
+      value = option
+      label = option
+    }
+    if (value === undefined || value === null || value === '') {
+      continue
+    }
+    const key = String(value)
+    if (seen.has(key)) continue
+    seen.add(key)
+    entries.push({ value: key, label: String(label ?? value) })
+  }
+  return entries
+})
+
+const filteredOptions = computed(() => {
+  if (!props.searchable || !searchText.value.trim()) {
+    return normalizedOptions.value
+  }
+  const needle = searchText.value.toLowerCase()
+  return normalizedOptions.value.filter((option) =>
+    option.label.toLowerCase().includes(needle)
+  )
+})
+
+const computedSize = computed(() => {
+  if (!isTextual.value) return 1
+  const total = filteredOptions.value.length
+  if (!total) return 4
+  return Math.min(Math.max(total, 4), 12)
+})
+
+function currentValues() {
+  if (isBoolean.value) {
+    return localBoolean.value ? [localBoolean.value] : []
+  }
+  if (isDateRange.value) {
+    const values = [startDate.value, endDate.value].filter((value) => !!value)
+    if (values.length === 2) {
+      return [startDate.value, endDate.value]
+    }
+    return []
+  }
+  return Array.isArray(localSelection.value)
+    ? localSelection.value.map((value) => String(value))
+    : []
+}
+
+function emitDraftChange() {
+  if (isSyncing.value) return
+  emit('change', {
+    field: props.field,
+    logical: localLogical.value,
+    operator: activeOperator.value,
+    values: currentValues(),
+  })
+}
+
+function commit() {
+  emit('commit', {
+    field: props.field,
+    logical: localLogical.value,
+    operator: activeOperator.value,
+    values: currentValues(),
+  })
+}
+
+function onDateChange() {
+  emitDraftChange()
+}
+
+function onSearch() {
+  if (!searchText.value) {
+    searchText.value = ''
+  }
+}
+
+watch(localSelection, emitDraftChange, { deep: true })
+watch(localBoolean, emitDraftChange)
+watch(startDate, emitDraftChange)
+watch(endDate, emitDraftChange)
+watch(localLogical, emitDraftChange)
 
 watch(
   () => props.logical,
@@ -63,57 +216,47 @@ watch(
 watch(
   () => props.values,
   (value) => {
-    const incoming = Array.isArray(value) ? [...value] : []
-    if (JSON.stringify(incoming) !== JSON.stringify(selected.value)) {
-      selected.value = incoming
+    isSyncing.value = true
+    const incoming = Array.isArray(value) ? value.map((entry) => String(entry)) : []
+    if (isBoolean.value) {
+      localBoolean.value = incoming[0] ?? ''
+    } else if (isDateRange.value) {
+      startDate.value = incoming[0] ?? ''
+      endDate.value = incoming[1] ?? ''
+    } else {
+      localSelection.value = [...incoming]
     }
-  }
+    nextTick(() => {
+      isSyncing.value = false
+    })
+  },
+  { immediate: true }
 )
 
-function isSelected(option) {
-  return selected.value.includes(option)
-}
-
-function toggle(option) {
-  const exists = selected.value.includes(option)
-  if (props.multiple) {
-    if (exists) {
-      selected.value = selected.value.filter((value) => value !== option)
-    } else {
-      selected.value = [...selected.value, option]
-    }
-  } else {
-    selected.value = exists ? [] : [option]
+watch(
+  () => props.operator,
+  () => {
+    emitDraftChange()
   }
-  emitDraftChange()
-}
-
-function emitDraftChange() {
-  emit('change', {
-    field: props.field,
-    logical: localLogical.value,
-    values: [...selected.value],
-  })
-}
-
-function commit() {
-  emit('commit', {
-    field: props.field,
-    logical: localLogical.value,
-    values: [...selected.value],
-  })
-}
-
-watch(localLogical, () => emitDraftChange())
+)
 
 watch(
   () => props.options,
   (options) => {
-    const normalized = new Set(options)
-    const filtered = selected.value.filter((value) => normalized.has(value))
-    if (filtered.length !== selected.value.length) {
-      selected.value = filtered
-      emitDraftChange()
+    if (!isTextual.value) {
+      return
+    }
+    const available = new Set(
+      (options || []).map((option) => {
+        if (option && typeof option === 'object') {
+          return String(option.value ?? option.label ?? '')
+        }
+        return String(option ?? '')
+      })
+    )
+    const filtered = (localSelection.value || []).filter((value) => available.has(value))
+    if (filtered.length !== (localSelection.value || []).length) {
+      localSelection.value = filtered
     }
   }
 )
@@ -126,7 +269,7 @@ watch(
   padding: 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   background-color: var(--vt-c-bg-soft, #ffffff);
 }
 
@@ -148,22 +291,54 @@ watch(
   border-radius: 4px;
 }
 
-.company-facet__options {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 0.25rem 0.75rem;
-  max-height: 200px;
-  overflow-y: auto;
+.company-facet__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.company-facet__options label {
+.company-facet__body select {
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+}
+
+.company-facet__select-wrapper {
   display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.9rem;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.company-facet__search {
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+}
+
+.company-facet__select {
+  min-height: 120px;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+  padding: 0.4rem;
+}
+
+.company-facet__dates {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.company-facet__dates label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  gap: 0.25rem;
+}
+
+.company-facet__dates input[type='date'] {
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
 }
 
 .company-facet__empty {

--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -14,10 +14,13 @@
         :key="facet.field"
         :field="facet.field"
         :label="facet.label"
-        :options="facetOptions(facet.field)"
+        :options="facetOptions(facet)"
         :logical="facetLogical(facet.field)"
+        :operator="facetOperator(facet.field)"
         :values="facetValues(facet.field)"
         :multiple="facet.multiple !== false"
+        :type="facet.type || 'text'"
+        :searchable="Boolean(facet.searchable)"
         @change="onFacetDraftChange"
         @commit="onFacetCommit"
       />
@@ -129,8 +132,63 @@ function selectionsAreEqual(a = [], b = []) {
   return a.every((value, index) => value === b[index])
 }
 
-function facetOptions(field) {
-  return facets.value[field] || []
+function booleanLabel(value) {
+  if (value === 'true') return 'Sim'
+  if (value === 'false') return 'Não'
+  return value
+}
+
+function facetOptions(facet) {
+  const field = facet.field
+  const dynamic = facets.value[field] || []
+
+  if (facet.type === 'boolean') {
+    const base = Array.isArray(facet.options) ? facet.options : []
+    const normalized = []
+    const seen = new Set()
+
+    const pushOption = (rawValue, rawLabel) => {
+      if (rawValue === null || rawValue === undefined || rawValue === '') {
+        return
+      }
+      const stringValue = String(rawValue).toLowerCase()
+      if (!stringValue) return
+      if (seen.has(stringValue)) return
+      seen.add(stringValue)
+      const label = rawLabel ?? booleanLabel(stringValue)
+      normalized.push({ value: stringValue, label })
+    }
+
+    for (const option of base) {
+      if (option && typeof option === 'object') {
+        pushOption(option.value ?? option.label ?? '', option.label)
+      } else {
+        pushOption(option, undefined)
+      }
+    }
+
+    for (const option of dynamic) {
+      if (option && typeof option === 'object') {
+        pushOption(option.value ?? option.label ?? '', option.label)
+      } else if (typeof option === 'boolean') {
+        pushOption(option ? 'true' : 'false', undefined)
+      } else {
+        pushOption(option, undefined)
+      }
+    }
+
+    return normalized
+  }
+
+  if (facet.type === 'date-range') {
+    return facet.options || []
+  }
+
+  if (dynamic.length) {
+    return dynamic
+  }
+
+  return facet.options || []
 }
 
 function facetLogical(field) {
@@ -141,6 +199,14 @@ function facetLogical(field) {
   return store.clauseByField[field]?.logical || 'AND'
 }
 
+function facetOperator(field) {
+  const draft = draftFacets.value[field]
+  if (draft && draft.operator) {
+    return draft.operator
+  }
+  return store.clauseByField[field]?.condition?.operator || ''
+}
+
 function facetValues(field) {
   const draft = draftFacets.value[field]
   if (draft && Array.isArray(draft.values)) {
@@ -149,26 +215,29 @@ function facetValues(field) {
   return store.clauseByField[field]?.condition?.values || []
 }
 
-function onFacetDraftChange({ field, logical, values }) {
+function onFacetDraftChange({ field, logical, values, operator }) {
   draftFacets.value = {
     ...draftFacets.value,
     [field]: {
       logical: logical || 'AND',
+      operator: operator || '',
       values: Array.isArray(values) ? [...values] : [],
     },
   }
 }
 
-function onFacetCommit({ field, logical, values }) {
+function onFacetCommit({ field, logical, values, operator }) {
   const finalLogical = logical || 'AND'
   const finalValues = Array.isArray(values) ? [...values] : []
+  const finalOperator = operator || DEFAULT_OPERATOR
 
-  store.setFacetSelection(field, finalLogical, finalValues)
+  store.setFacetSelection(field, finalLogical, finalValues, finalOperator)
 
   draftFacets.value = {
     ...draftFacets.value,
     [field]: {
       logical: finalLogical,
+      operator: finalOperator,
       values: [],
     },
   }

--- a/presentation/frontend/src/config/companyFacets.js
+++ b/presentation/frontend/src/config/companyFacets.js
@@ -1,11 +1,65 @@
 export const COMPANY_FACETS = [
-  { field: 'sector', label: 'Setor', multiple: true },
-  { field: 'subsector', label: 'Subsetor', multiple: true },
-  { field: 'segment', label: 'Segmento', multiple: true },
-  { field: 'market', label: 'Mercado', multiple: true },
-  { field: 'company_name', label: 'Companhia', multiple: false }, // false to radio
-  { field: 'trading_name', label: 'Nome de pregão', multiple: true },
-  { field: 'ticker', label: 'Ticker', multiple: true },
-  { field: 'institution_common', label: 'Instituição Ordinária', multiple: true },
-  { field: 'institution_preferred', label: 'Instituição Preferencial', multiple: true },
+  // --- Campos textuais -----------------------------------------------------
+  { field: 'issuing_company', label: 'Emissora', type: 'text', multiple: true, searchable: true },
+  { field: 'trading_name', label: 'Nome de Pregão', type: 'text', multiple: true, searchable: true },
+  { field: 'company_name', label: 'Companhia', type: 'text', multiple: true, searchable: true },
+  { field: 'cnpj', label: 'CNPJ', type: 'text', multiple: true, searchable: true },
+  { field: 'market', label: 'Mercado', type: 'text', multiple: true, searchable: true },
+  { field: 'industry_sector', label: 'Setor', type: 'text', multiple: true, searchable: true },
+  { field: 'industry_subsector', label: 'Subsetor', type: 'text', multiple: true, searchable: true },
+  { field: 'industry_segment', label: 'Segmento', type: 'text', multiple: true, searchable: true },
+  { field: 'industry_classification', label: 'Classificação', type: 'text', multiple: true, searchable: true },
+  { field: 'industry_classification_eng', label: 'Classificação (EN)', type: 'text', multiple: true, searchable: true },
+  { field: 'activity', label: 'Atividade', type: 'text', multiple: true, searchable: true },
+  { field: 'company_segment', label: 'Segmento da Companhia', type: 'text', multiple: true, searchable: true },
+  { field: 'company_segment_eng', label: 'Segmento da Companhia (EN)', type: 'text', multiple: true, searchable: true },
+  { field: 'company_category', label: 'Categoria', type: 'text', multiple: true, searchable: true },
+  { field: 'company_type', label: 'Tipo', type: 'text', multiple: true, searchable: true },
+  { field: 'listing_segment', label: 'Segmento de Listagem', type: 'text', multiple: true, searchable: true },
+  { field: 'registrar', label: 'Escriturador', type: 'text', multiple: true, searchable: true },
+  { field: 'website', label: 'Website', type: 'text', multiple: true, searchable: true },
+  { field: 'institution_common', label: 'Instituição Ordinária', type: 'text', multiple: true, searchable: true },
+  { field: 'institution_preferred', label: 'Instituição Preferencial', type: 'text', multiple: true, searchable: true },
+  { field: 'status', label: 'Status', type: 'text', multiple: true, searchable: true },
+  { field: 'market_indicator', label: 'Indicador de Mercado', type: 'text', multiple: true, searchable: true },
+  { field: 'code', label: 'Código', type: 'text', multiple: true, searchable: true },
+  { field: 'type_bdr', label: 'Tipo de BDR', type: 'text', multiple: true, searchable: true },
+  { field: 'reason', label: 'Motivo', type: 'text', multiple: true, searchable: true },
+
+  // --- Booleanos -----------------------------------------------------------
+  {
+    field: 'has_bdr',
+    label: 'Tem BDR',
+    type: 'boolean',
+    multiple: false,
+    options: [
+      { value: 'true', label: 'Sim' },
+      { value: 'false', label: 'Não' },
+    ],
+  },
+  {
+    field: 'has_quotation',
+    label: 'Tem Cotação',
+    type: 'boolean',
+    multiple: false,
+    options: [
+      { value: 'true', label: 'Sim' },
+      { value: 'false', label: 'Não' },
+    ],
+  },
+  {
+    field: 'has_emissions',
+    label: 'Tem Emissões',
+    type: 'boolean',
+    multiple: false,
+    options: [
+      { value: 'true', label: 'Sim' },
+      { value: 'false', label: 'Não' },
+    ],
+  },
+
+  // --- Datas ---------------------------------------------------------------
+  { field: 'date_quotation', label: 'Data de Cotação', type: 'date-range', multiple: false },
+  { field: 'last_date', label: 'Última Data', type: 'date-range', multiple: false },
+  { field: 'listing_date', label: 'Data de Listagem', type: 'date-range', multiple: false },
 ]

--- a/presentation/frontend/src/store/companyStore.js
+++ b/presentation/frontend/src/store/companyStore.js
@@ -27,30 +27,74 @@ const OPERATOR_ALIASES = {
   STARTS_WITH: 'STARTS_WITH',
   STARTSWITH: 'STARTS_WITH',
   PREFIX: 'STARTS_WITH',
+  BETWEEN: 'BETWEEN',
 }
 
 const FIELD_ALIASES = {
-  sector: 'sector',
-  setor: 'sector',
-  subsector: 'subsector',
-  subsetor: 'subsector',
-  segment: 'segment',
-  segmento: 'segment',
+  sector: 'industry_sector',
+  setor: 'industry_sector',
+  industry_sector: 'industry_sector',
+  subsector: 'industry_subsector',
+  subsetor: 'industry_subsector',
+  industry_subsector: 'industry_subsector',
+  segment: 'industry_segment',
+  segmento: 'industry_segment',
+  industry_segment: 'industry_segment',
+  industry_classification: 'industry_classification',
+  classificacao: 'industry_classification',
+  industry_classification_eng: 'industry_classification_eng',
+  classification_en: 'industry_classification_eng',
+  activity: 'activity',
+  atividade: 'activity',
+  company_segment: 'company_segment',
+  segmento_companhia: 'company_segment',
+  company_segment_eng: 'company_segment_eng',
+  company_category: 'company_category',
+  categoria: 'company_category',
+  company_type: 'company_type',
+  tipo_companhia: 'company_type',
+  listing_segment: 'listing_segment',
+  segmento_listagem: 'listing_segment',
+  registrar: 'registrar',
+  escriturador: 'registrar',
+  website: 'website',
+  site: 'website',
+  institution_common: 'institution_common',
+  instituicao_ordinaria: 'institution_common',
+  institution_preferred: 'institution_preferred',
+  instituicao_preferencial: 'institution_preferred',
+  market: 'market',
+  mercado: 'market',
+  market_indicator: 'market_indicator',
+  indicador_mercado: 'market_indicator',
+  code: 'code',
+  codigo: 'code',
+  ticker: 'code',
+  type_bdr: 'type_bdr',
+  tipo_bdr: 'type_bdr',
+  reason: 'reason',
+  motivo: 'reason',
   company_name: 'company_name',
   companhia: 'company_name',
   company: 'company_name',
   trading_name: 'trading_name',
   trading: 'trading_name',
   nome_pregao: 'trading_name',
-  ticker: 'ticker',
-  codigo: 'ticker',
-  code: 'ticker',
-  institution_preferred: 'institution_preferred',
-  instituicao_preferencial: 'institution_preferred',
-  institution_common: 'institution_common',
-  instituicao_ordinaria: 'institution_common',
-  market: 'market',
-  mercado: 'market',
+  issuing_company: 'issuing_company',
+  emissora: 'issuing_company',
+  cnpj: 'cnpj',
+  has_bdr: 'has_bdr',
+  tem_bdr: 'has_bdr',
+  has_quotation: 'has_quotation',
+  tem_cotacao: 'has_quotation',
+  has_emissions: 'has_emissions',
+  tem_emissoes: 'has_emissions',
+  date_quotation: 'date_quotation',
+  data_cotacao: 'date_quotation',
+  last_date: 'last_date',
+  ultima_data: 'last_date',
+  listing_date: 'listing_date',
+  data_listagem: 'listing_date',
 }
 
 class ParseError extends Error {
@@ -80,7 +124,20 @@ function normalizeField(value) {
 
 function normalizeValues(values) {
   return (values || [])
-    .map((value) => String(value ?? '').trim())
+    .map((value) => {
+      const raw = String(value ?? '').trim()
+      const upper = raw.toUpperCase()
+      if (upper === 'TRUE' || upper === 'FALSE') {
+        return upper.toLowerCase()
+      }
+      if (upper === 'SIM') {
+        return 'true'
+      }
+      if (upper === 'NAO' || upper === 'NÃO') {
+        return 'false'
+      }
+      return raw
+    })
     .filter((value) => value.length)
 }
 
@@ -377,6 +434,10 @@ class QueryParser {
     const normalizedValues = normalizeValues(values)
     if (!normalizedValues.length && !['CONTAINS', 'STARTS_WITH'].includes(operator)) {
       throw new ParseError(`Informe pelo menos um valor para ${field}.`)
+    }
+
+    if (operator === 'BETWEEN' && normalizedValues.length !== 2) {
+      throw new ParseError(`O operador BETWEEN exige dois valores para ${field}.`)
     }
 
     return {


### PR DESCRIPTION
## Summary
- expose every eligible-company attribute in the front-end facets with searchable multi-selects, boolean pickers, and date ranges
- update the Pinia store and filter parser to understand BETWEEN, boolean aliases, and the expanded field list
- route company search through the eligible-company repository, adding a search port plus SQLAlchemy filtering for strings, booleans, and date ranges

## Testing
- `pytest -o addopts=` *(fails: missing optional dependencies sqlalchemy and pandas)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc579feb8832eac5a53618ef94ef5)