### PR TITLE
Refine industry cascade filtering

### DIFF
--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -81,6 +81,28 @@ let isSyncingSelection = false
 const facetConfigs = COMPANY_FACETS
 const parseError = ref('')
 const draftFacets = ref({})
+const DEFAULT_OPERATOR = 'IN'
+
+const CASCADE_CONFIG = {
+  industry_sector: {
+    level: 'sector',
+    parentField: null,
+  },
+  industry_subsector: {
+    level: 'subsector',
+    parentField: 'industry_sector',
+  },
+  industry_segment: {
+    level: 'segment',
+    parentField: 'industry_subsector',
+  },
+}
+
+const CASCADE_FIELDS = Object.keys(CASCADE_CONFIG)
+
+function isCascadeField(field) {
+  return CASCADE_FIELDS.includes(field)
+}
 
 const queryTextModel = computed({
   get: () => store.queryText,
@@ -184,11 +206,94 @@ function facetOptions(facet) {
     return facet.options || []
   }
 
-  if (dynamic.length) {
-    return dynamic
+  const baseOptions = dynamic.length ? dynamic : (facet.options || [])
+
+  if (!isCascadeField(field)) {
+    return baseOptions
   }
 
-  return facet.options || []
+  const cascade = store.industryCascade || {}
+  const { sectorToSubsectors = {}, sectorToSegments = {}, subsectorToSegments = {} } = cascade
+
+  const selectedSectors = currentCascadeValues('industry_sector')
+  const selectedSubsectors = currentCascadeValues('industry_subsector')
+
+  let allowedValues = null
+
+  if (field === 'industry_sector') {
+    const sectorsFromGraph = Object.keys(sectorToSubsectors).length
+      ? Object.keys(sectorToSubsectors)
+      : Object.keys(sectorToSegments)
+
+    if (sectorsFromGraph.length) {
+      allowedValues = sectorsFromGraph
+    }
+  } else if (field === 'industry_subsector') {
+    const sectors = selectedSectors.length
+      ? selectedSectors
+      : Object.keys(sectorToSubsectors)
+
+    const aggregated = new Set()
+    for (const sector of sectors) {
+      for (const subsector of sectorToSubsectors[sector] || []) {
+        aggregated.add(subsector)
+      }
+    }
+    if (aggregated.size) {
+      allowedValues = Array.from(aggregated)
+    }
+  } else if (field === 'industry_segment') {
+    const aggregated = new Set()
+
+    if (selectedSubsectors.length) {
+      for (const subsector of selectedSubsectors) {
+        for (const segment of subsectorToSegments[subsector] || []) {
+          aggregated.add(segment)
+        }
+      }
+    } else if (selectedSectors.length) {
+      for (const sector of selectedSectors) {
+        for (const segment of sectorToSegments[sector] || []) {
+          aggregated.add(segment)
+        }
+      }
+    } else {
+      for (const key of Object.keys(subsectorToSegments)) {
+        for (const segment of subsectorToSegments[key] || []) {
+          aggregated.add(segment)
+        }
+      }
+    }
+
+    if (aggregated.size) {
+      allowedValues = Array.from(aggregated)
+    }
+  }
+
+  if (!allowedValues || !allowedValues.length) {
+    // Sem restrição de cascata calculada: devolve a lista original
+    return baseOptions
+  }
+
+  // Aqui a cascata entra em ação de fato
+  const allowedSet = new Set(
+    allowedValues.map((value) => String(value || '').trim()),
+  )
+
+  // Garante que todas as opções sejam { value, label }
+  const normalized = baseOptions.map((option) => {
+    if (option && typeof option === 'object') {
+      const value = String(option.value ?? option.label ?? '').trim()
+      const label = option.label ?? value
+      return { value, label }
+    }
+    const value = String(option || '').trim()
+    return { value, label: value }
+  })
+
+  return normalized.filter((option) =>
+    allowedSet.has(String(option.value || '').trim()),
+  )
 }
 
 function facetLogical(field) {
@@ -213,6 +318,23 @@ function facetValues(field) {
     return draft.values
   }
   return store.clauseByField[field]?.condition?.values || []
+}
+
+function currentCascadeValues(field) {
+  const committed = store.clauseByField[field]?.condition?.values || []
+  const draft = draftFacets.value[field]?.values || []
+  const all = [...committed, ...draft]
+    .map((value) => String(value || '').trim())
+    .filter(Boolean)
+
+  const seen = new Set()
+  const result = []
+  for (const value of all) {
+    if (seen.has(value)) continue
+    seen.add(value)
+    result.push(value)
+  }
+  return result
 }
 
 function onFacetDraftChange({ field, logical, values, operator }) {

--- a/presentation/frontend/src/store/companyStore.js
+++ b/presentation/frontend/src/store/companyStore.js
@@ -563,6 +563,13 @@ export const useCompanyStore = defineStore('companyStore', {
     selectedItems: [],
     isLoading: false,
     error: null,
+
+    // Estrutura da cascata Setor → Subsetor → Segmento
+    industryCascade: {
+      sectorToSubsectors: {},
+      sectorToSegments: {},
+      subsectorToSegments: {},
+    },
   }),
 
   getters: {
@@ -645,6 +652,8 @@ export const useCompanyStore = defineStore('companyStore', {
         const payload = await searchCompanies(this.filterQuery)
         this.companies = payload.items || []
         this.total = payload.total || 0
+
+        this._rebuildIndustryCascade(this.companies)
         this._pruneSelection()
         if (!this.queryText) {
           this.queryText = this.serializeQuery(this.filterQuery)
@@ -678,6 +687,64 @@ export const useCompanyStore = defineStore('companyStore', {
         return { clauses: [] }
       }
       return parseTextToQuery(text)
+    },
+
+    _rebuildIndustryCascade(items = []) {
+      const sectorToSubsectors = new Map()
+      const sectorToSegments = new Map()
+      const subsectorToSegments = new Map()
+
+      for (const company of items || []) {
+        const sector = (company.sector || '').trim()
+        const subsector = (company.subsector || '').trim()
+        const segment = (company.segment || '').trim()
+
+        if (!sector && !subsector && !segment) continue
+
+        if (sector) {
+          if (!sectorToSubsectors.has(sector)) {
+            sectorToSubsectors.set(sector, new Set())
+          }
+          if (!sectorToSegments.has(sector)) {
+            sectorToSegments.set(sector, new Set())
+          }
+        }
+
+        if (subsector) {
+          if (!subsectorToSegments.has(subsector)) {
+            subsectorToSegments.set(subsector, new Set())
+          }
+        }
+
+        if (sector && subsector) {
+          sectorToSubsectors.get(sector).add(subsector)
+        }
+
+        if (sector && segment) {
+          sectorToSegments.get(sector).add(segment)
+        }
+
+        if (subsector && segment) {
+          subsectorToSegments.get(subsector).add(segment)
+        }
+      }
+
+      const normalizeMap = (map) => {
+        const result = {}
+        for (const [key, set] of map.entries()) {
+          const values = Array.from(set).filter((value) => value && value.length)
+          if (values.length) {
+            result[key] = values.sort((a, b) => a.localeCompare(b, 'pt-BR'))
+          }
+        }
+        return result
+      }
+
+      this.industryCascade = {
+        sectorToSubsectors: normalizeMap(sectorToSubsectors),
+        sectorToSegments: normalizeMap(sectorToSegments),
+        subsectorToSegments: normalizeMap(subsectorToSegments),
+      }
     },
 
     _pruneSelection() {


### PR DESCRIPTION
## Summary
- ensure facet options always derive from a shared baseOptions list
- apply cascade filtering over normalized options only when restrictions exist

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691141096a4c832e8687507964752871)