### PR TITLE
Refine Plotly viewer prop resolution

### DIFF
--- a/application/dtos/account_series_dto.py
+++ b/application/dtos/account_series_dto.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import List
+
+
+@dataclass
+class AccountSeriesPointDTO:
+    date: date
+    value: float
+
+
+@dataclass
+class AccountSeriesDTO:
+    ticker: str
+    account_code: str
+    label: str
+    points: List[AccountSeriesPointDTO]

--- a/application/usecases/get_account_series.py
+++ b/application/usecases/get_account_series.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import List
+
+from application.dtos.account_series_dto import (
+    AccountSeriesDTO,
+    AccountSeriesPointDTO,
+)
+from application.ports.uow_port import UowFactoryPort
+from domain.ports.repository_account_series_port import RepositoryAccountSeriesPort
+from domain.value_objects.account_code import AccountCode
+
+
+@dataclass
+class GetAccountSeriesUseCase:
+    repository: RepositoryAccountSeriesPort
+    uow_factory: UowFactoryPort
+
+    def __call__(
+        self,
+        *,
+        ticker: str,
+        account_code: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> AccountSeriesDTO:
+        account = AccountCode(account_code)
+
+        with self.uow_factory() as uow:
+            points = self.repository.get_account_series(
+                ticker=ticker,
+                account=account,
+                uow=uow,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            uow.commit()
+
+        dto_points: List[AccountSeriesPointDTO] = [
+            AccountSeriesPointDTO(date=p.date, value=float(p.value)) for p in points
+        ]
+        dto_points.sort(key=lambda p: p.date)
+
+        label = f"Conta {account.value}"
+
+        return AccountSeriesDTO(
+            ticker=ticker,
+            account_code=account.value,
+            label=label,
+            points=dto_points,
+        )

--- a/domain/entities/__init__.py
+++ b/domain/entities/__init__.py
@@ -1,5 +1,6 @@
 """Domain entities package."""
 
 from .eligible_company import EligibleCompany
+from .account_series import AccountPoint
 
-__all__ = ["EligibleCompany"]
+__all__ = ["EligibleCompany", "AccountPoint"]

--- a/domain/entities/account_series.py
+++ b/domain/entities/account_series.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass
+class AccountPoint:
+    """Representa um ponto da série temporal de uma conta contábil."""
+
+    date: date
+    value: float

--- a/domain/ports/__init__.py
+++ b/domain/ports/__init__.py
@@ -11,6 +11,7 @@ from domain.ports.repository_base_port import RepositoryBasePort
 from domain.ports.repository_company_data_port import RepositoryCompanyDataPort
 from domain.ports.repository_company_eligible_port import RepositoryCompanyEligiblePort
 from domain.ports.repository_nsd_port import RepositoryNsdPort
+from domain.ports.repository_account_series_port import RepositoryAccountSeriesPort
 from domain.ports.repository_statements_fetched_port import (
            RepositoryStatementFetchedPort,
 )
@@ -36,4 +37,5 @@ __all__ = [
     "ScraperStatementRawPort",
     "MetricsCollectorPort",
     "WorkerPoolPort",
+    "RepositoryAccountSeriesPort",
 ]

--- a/domain/ports/repository_account_series_port.py
+++ b/domain/ports/repository_account_series_port.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import date
+from typing import List
+
+from application.ports.uow_port import Uow
+from domain.entities.account_series import AccountPoint
+from domain.value_objects.account_code import AccountCode
+
+
+class RepositoryAccountSeriesPort(ABC):
+    """Porta de repositório para séries temporais de contas contábeis."""
+
+    @abstractmethod
+    def get_account_series(
+        self,
+        *,
+        ticker: str,
+        account: AccountCode,
+        uow: Uow,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> List[AccountPoint]:
+        """Retorna série temporal de uma conta para um ticker."""
+
+*** End of File

--- a/domain/value_objects/__init__.py
+++ b/domain/value_objects/__init__.py
@@ -8,6 +8,7 @@ from .company_filters import (
     CompanyFilterClause,
     CompanyFilterQuery,
 )
+from .account_code import AccountCode
 
 __all__ = [
     "CompanyField",
@@ -16,4 +17,5 @@ __all__ = [
     "CompanyFilterCondition",
     "CompanyFilterClause",
     "CompanyFilterQuery",
+    "AccountCode",
 ]

--- a/domain/value_objects/account_code.py
+++ b/domain/value_objects/account_code.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AccountCode:
+    """Value object que representa um código de conta contábil."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        v = self.value.strip()
+        if not v:
+            raise ValueError("AccountCode vazio")
+
+        parts = v.split(".")
+        if any(not part.isdigit() for part in parts):
+            raise ValueError(f"AccountCode inválido: {v}")
+
+        object.__setattr__(self, "value", v)
+
+    def __str__(self) -> str:
+        return self.value

--- a/infrastructure/models/__init__.py
+++ b/infrastructure/models/__init__.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from infrastructure.models.base_model import BaseModel
 from infrastructure.models.company_eligible_model import CompanyEligibleModel
+from infrastructure.models.account_series_model import FinancialStatementModel
 
 __all__ = [
     "BaseModel",
     "CompanyEligibleModel",
+    "FinancialStatementModel",
 ]

--- a/infrastructure/models/account_series_model.py
+++ b/infrastructure/models/account_series_model.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Float, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from infrastructure.models.base_model import BaseModel, _YMDDate
+
+
+class FinancialStatementModel(BaseModel):
+    """Modelo ORM simplificado para séries temporais de contas."""
+
+    __tablename__ = "financial_statements"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    ticker: Mapped[str] = mapped_column(String(32), index=True, nullable=False)
+    account_code: Mapped[str] = mapped_column(String(16), index=True, nullable=False)
+    reference_date: Mapped[datetime] = mapped_column(
+        _YMDDate(), index=True, nullable=False
+    )
+    value: Mapped[float] = mapped_column(Float, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "ticker",
+            "account_code",
+            "reference_date",
+            name="uq_financial_statement",
+        ),
+    )

--- a/infrastructure/repositories/repository_account_series.py
+++ b/infrastructure/repositories/repository_account_series.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from application.ports.config_port import ConfigPort
+from application.ports.logger_port import LoggerPort
+from application.ports.uow_port import Uow
+from domain.entities.account_series import AccountPoint
+from domain.ports.repository_account_series_port import RepositoryAccountSeriesPort
+from domain.value_objects.account_code import AccountCode
+from infrastructure.adapters.engine_setup import EngineSetup
+from infrastructure.models.account_series_model import FinancialStatementModel
+
+
+class RepositoryAccountSeries(EngineSetup, RepositoryAccountSeriesPort):
+    """Repositório SQLAlchemy para séries temporais de contas contábeis."""
+
+    def __init__(self, *, config: ConfigPort, logger: LoggerPort) -> None:
+        super().__init__(config.database.connection_string, logger)
+
+    def get_account_series(
+        self,
+        *,
+        ticker: str,
+        account: AccountCode,
+        uow: Uow,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> List[AccountPoint]:
+        session: Session = uow.session
+
+        query = (
+            session.query(FinancialStatementModel)
+            .filter(FinancialStatementModel.ticker == ticker)
+            .filter(FinancialStatementModel.account_code == account.value)
+            .order_by(FinancialStatementModel.reference_date.asc())
+        )
+
+        if start_date is not None:
+            query = query.filter(
+                FinancialStatementModel.reference_date
+                >= datetime.combine(start_date, time.min)
+            )
+        if end_date is not None:
+            query = query.filter(
+                FinancialStatementModel.reference_date
+                <= datetime.combine(end_date, time.max)
+            )
+
+        rows = query.all()
+
+        return [
+            AccountPoint(
+                date=row.reference_date.date()
+                if isinstance(row.reference_date, datetime)
+                else row.reference_date,
+                value=float(row.value) if row.value is not None else 0.0,
+            )
+            for row in rows
+        ]

--- a/presentation/backend/api.py
+++ b/presentation/backend/api.py
@@ -4,6 +4,9 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from presentation.backend.routers.charts import router as charts_router
 from presentation.backend.routers.companies import router as companies_router
+from presentation.backend.routers.account_charts import (
+    router as account_charts_router,
+)
 
 
 def create_app() -> FastAPI:
@@ -23,6 +26,7 @@ def create_app() -> FastAPI:
 
     # Camada de apresentação: apenas inclui routers finos
     app.include_router(charts_router)
+    app.include_router(account_charts_router)
     app.include_router(companies_router)
 
     return app

--- a/presentation/backend/dependencies/account_chart_dependencies.py
+++ b/presentation/backend/dependencies/account_chart_dependencies.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from application.usecases.get_account_series import GetAccountSeriesUseCase
+from domain.ports.repository_account_series_port import RepositoryAccountSeriesPort
+from infrastructure.config.config_adapter import ConfigAdapter
+from infrastructure.logging.logger_adapter import Logger
+from infrastructure.repositories.repository_account_series import RepositoryAccountSeries
+from infrastructure.uow.uow import UowFactory
+
+
+def get_account_series_usecase() -> GetAccountSeriesUseCase:
+    config = ConfigAdapter()
+    logger = Logger(config)
+    repository: RepositoryAccountSeriesPort = RepositoryAccountSeries(
+        config=config,
+        logger=logger,
+    )
+    uow_factory = UowFactory(session_factory=repository.Session)
+    return GetAccountSeriesUseCase(repository=repository, uow_factory=uow_factory)

--- a/presentation/backend/routers/account_charts.py
+++ b/presentation/backend/routers/account_charts.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from application.usecases.get_account_series import GetAccountSeriesUseCase
+from presentation.backend.dependencies.account_chart_dependencies import (
+    get_account_series_usecase,
+)
+from presentation.backend.dto.chart_dto import ChartDTO, PlotlyTraceDTO
+
+router = APIRouter(
+    prefix="/api/charts/accounts",
+    tags=["charts"],
+)
+
+
+@router.get("/line/{ticker}", response_model=ChartDTO)
+async def get_account_line_chart(
+    ticker: str,
+    account_code: str = Query(..., description="Código da conta, ex: 02.03"),
+    start_date: date | None = Query(None),
+    end_date: date | None = Query(None),
+    usecase: GetAccountSeriesUseCase = Depends(get_account_series_usecase),
+) -> ChartDTO:
+    series = usecase(
+        ticker=ticker,
+        account_code=account_code,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    if not series.points:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Série temporal vazia para esta conta",
+        )
+
+    trace = PlotlyTraceDTO(
+        x=[point.date for point in series.points],
+        y=[point.value for point in series.points],
+        type="scatter",
+        mode="lines",
+        name=f"{series.account_code} – {series.label}",
+        extra={
+            "hovertemplate": "%{x}<br>Valor: %{y}<extra></extra>",
+        },
+    )
+
+    layout = {
+        "title": f"{series.label} – {series.ticker}",
+        "xaxis": {"title": "Data"},
+        "yaxis": {"title": "Valor"},
+    }
+
+    return ChartDTO(data=[trace], layout=layout)

--- a/presentation/frontend/src/App.vue
+++ b/presentation/frontend/src/App.vue
@@ -2,7 +2,8 @@
 <template>
   <div class="component-box">
     <a href="http://localhost:5173/">Home</a> |
-    <a href="http://localhost:5173/charts">Chart</a>
+    <a href="http://localhost:5173/charts">Chart</a> |
+    <a href="http://localhost:5173/charts/accounts">Contas</a>
   </div>
   <div>
     <header>

--- a/presentation/frontend/src/components/PlotlyViewer.vue
+++ b/presentation/frontend/src/components/PlotlyViewer.vue
@@ -1,21 +1,21 @@
 <template>
   <section class="plotly-viewer">
-    <div v-if="isLoading" role="status" aria-live="polite">
+    <div v-if="resolvedIsLoading" role="status" aria-live="polite">
       Carregando gráfico...
     </div>
 
-    <div v-else-if="error" role="alert">
-      {{ error }}
+    <div v-else-if="resolvedError" role="alert">
+      {{ resolvedError }}
     </div>
 
     <div
-      v-else-if="chart"
+      v-else-if="resolvedChart"
       role="img"
-      :aria-label="chart.title"
+      :aria-label="resolvedAriaLabel"
     >
       <VuePlotly
-        :data="chart.data"
-        :layout="chart.layout"
+        :data="resolvedChart.data"
+        :layout="resolvedChart.layout"
         :useResizeHandler="true"
         style="width: 100%; height: 400px;"
       />
@@ -29,11 +29,56 @@
 
 <script setup>
 import { computed } from 'vue'
+import { VuePlotly } from 'vue3-plotly'
 import { useChartStore } from '../store/chartStore'
+
+const props = defineProps({
+  chart: {
+    type: Object,
+    default: null,
+  },
+  isLoading: {
+    type: Boolean,
+    default: undefined,
+  },
+  error: {
+    type: String,
+    default: undefined,
+  },
+})
 
 const store = useChartStore()
 
-const chart = computed(() => store.chart)
-const isLoading = computed(() => store.isLoading)
-const error = computed(() => store.error)
+const storeChart = computed(() => store.chart)
+const storeIsLoading = computed(() => store.isLoading)
+const storeError = computed(() => store.error)
+
+const resolvedChart = computed(() =>
+  props.chart !== null ? props.chart : storeChart.value,
+)
+
+const resolvedIsLoading = computed(() =>
+  typeof props.isLoading === 'boolean'
+    ? props.isLoading
+    : storeIsLoading.value,
+)
+
+const resolvedError = computed(() =>
+  typeof props.error === 'string' ? props.error : storeError.value,
+)
+
+const resolvedAriaLabel = computed(() => {
+  const chart = resolvedChart.value
+  if (!chart) {
+    return 'Gráfico'
+  }
+  const title = chart.layout?.title
+  if (typeof title === 'string') {
+    return title
+  }
+  if (title && typeof title.text === 'string') {
+    return title.text
+  }
+  return 'Gráfico'
+})
 </script>

--- a/presentation/frontend/src/router/index.js
+++ b/presentation/frontend/src/router/index.js
@@ -2,6 +2,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import ChartView from '../views/ChartView.vue'
+import AccountChartsView from '../views/AccountChartsView.vue'
 
 const routes = [
   {
@@ -13,6 +14,11 @@ const routes = [
     path: '/charts',
     name: 'charts',
     component: ChartView,
+  },
+  {
+    path: '/charts/accounts',
+    name: 'accountCharts',
+    component: AccountChartsView,
   },
 ]
 

--- a/presentation/frontend/src/services/apiService.js
+++ b/presentation/frontend/src/services/apiService.js
@@ -23,6 +23,26 @@ export async function fetchChart(params) {
   return res.data
 }
 
+export async function fetchAccountLineChart(ticker, accountCode, params = {}) {
+  const t = String(ticker || '').trim()
+  const a = String(accountCode || '').trim()
+
+  if (!t || !a) {
+    throw new Error('Ticker e accountCode são obrigatórios')
+  }
+
+  const res = await api.get(
+    `/api/charts/accounts/line/${encodeURIComponent(t)}`,
+    {
+      params: {
+        account_code: a,
+        ...params,
+      },
+    },
+  )
+  return res.data
+}
+
 export async function searchCompanies(filterQuery) {
   const res = await api.post('/companies/search', filterQuery || { clauses: [] })
   return res.data

--- a/presentation/frontend/src/store/accountChartsStore.js
+++ b/presentation/frontend/src/store/accountChartsStore.js
@@ -1,0 +1,77 @@
+import { defineStore } from 'pinia'
+import { fetchAccountLineChart } from '../services/apiService'
+
+export const useAccountChartsStore = defineStore('accountCharts', {
+  state: () => ({
+    ticker: '',
+    charts: {
+      '02.03': null,
+      '03.01': null,
+    },
+    isLoading: {
+      '02.03': false,
+      '03.01': false,
+    },
+    error: {
+      '02.03': '',
+      '03.01': '',
+    },
+  }),
+  actions: {
+    setTicker(ticker) {
+      this.ticker = String(ticker || '').trim()
+    },
+
+    _ensureKeys(code) {
+      if (!(code in this.charts)) {
+        this.charts = { ...this.charts, [code]: null }
+      }
+      if (!(code in this.isLoading)) {
+        this.isLoading = { ...this.isLoading, [code]: false }
+      }
+      if (!(code in this.error)) {
+        this.error = { ...this.error, [code]: '' }
+      }
+    },
+
+    async loadAccountChart(accountCode, params = {}) {
+      const code = String(accountCode || '').trim()
+      if (!code) {
+        return
+      }
+
+      this._ensureKeys(code)
+
+      if (!this.ticker) {
+        this.error = {
+          ...this.error,
+          [code]: 'Ticker e código da conta são obrigatórios',
+        }
+        return
+      }
+
+      this.isLoading = { ...this.isLoading, [code]: true }
+      this.error = { ...this.error, [code]: '' }
+
+      try {
+        const chart = await fetchAccountLineChart(this.ticker, code, params)
+        this.charts = { ...this.charts, [code]: chart }
+      } catch (err) {
+        console.error(err)
+        const message = err?.message || 'Falha ao carregar gráfico'
+        this.error = { ...this.error, [code]: message }
+        this.charts = { ...this.charts, [code]: null }
+      } finally {
+        this.isLoading = { ...this.isLoading, [code]: false }
+      }
+    },
+
+    async loadMultipleAccounts(accountCodes, params = {}) {
+      const codes = (accountCodes || [])
+        .map(code => String(code || '').trim())
+        .filter(Boolean)
+
+      await Promise.all(codes.map(code => this.loadAccountChart(code, params)))
+    },
+  },
+})

--- a/presentation/frontend/src/views/AccountChartsView.vue
+++ b/presentation/frontend/src/views/AccountChartsView.vue
@@ -1,0 +1,118 @@
+<template>
+  <section class="account-charts">
+    <header class="account-charts__header">
+      <h2>Gráficos por conta contábil</h2>
+      <p>
+        Informe um ticker e visualize múltiplas contas financeiras usando o mesmo
+        pipeline.
+      </p>
+    </header>
+
+    <div class="account-charts__controls">
+      <label for="ticker-input">Ticker</label>
+      <input
+        id="ticker-input"
+        v-model="localTicker"
+        type="text"
+        placeholder="Ex.: PETR4"
+        @keyup.enter="load"
+      />
+
+      <button type="button" @click="load">
+        Carregar gráficos
+      </button>
+    </div>
+
+    <div class="account-charts__grid">
+      <section class="account-chart" aria-live="polite">
+        <h3>02.03 – Patrimônio Líquido</h3>
+        <PlotlyViewer
+          :chart="charts['02.03']"
+          :isLoading="isLoading['02.03']"
+          :error="error['02.03']"
+        />
+      </section>
+
+      <section class="account-chart" aria-live="polite">
+        <h3>03.01 – Receita Líquida</h3>
+        <PlotlyViewer
+          :chart="charts['03.01']"
+          :isLoading="isLoading['03.01']"
+          :error="error['03.01']"
+        />
+      </section>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { useAccountChartsStore } from '../store/accountChartsStore'
+import PlotlyViewer from '../components/PlotlyViewer.vue'
+
+const store = useAccountChartsStore()
+const localTicker = ref(store.ticker)
+
+const charts = computed(() => store.charts)
+const isLoading = computed(() => store.isLoading)
+const error = computed(() => store.error)
+
+async function load() {
+  store.setTicker(localTicker.value)
+  await store.loadMultipleAccounts(['02.03', '03.01'])
+}
+</script>
+
+<style scoped>
+.account-charts {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1rem;
+}
+
+.account-charts__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.account-charts__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.account-charts__controls input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  min-width: 160px;
+}
+
+.account-charts__controls button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: #2563eb;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.account-charts__controls button:hover {
+  background-color: #1d4ed8;
+}
+
+.account-charts__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.account-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- refactor PlotlyViewer to resolve optional props safely while preserving chart store fallbacks
- improve accessibility by deriving an aria-label from the resolved chart metadata

## Testing
- pytest --override-ini=addopts= *(fails: missing optional dependencies sqlalchemy and pandas in the test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911bd15054c832ebc793c5cbfd1eb08)