### PR TITLE
Alinha dashboards multiempresa

### DIFF
--- a/presentation/frontend/src/store/accountChartsStore.js
+++ b/presentation/frontend/src/store/accountChartsStore.js
@@ -1,3 +1,4 @@
+// presentation/frontend/src/store/accountChartsStore.js
 import { defineStore } from 'pinia'
 
 import { fetchCompanyRatiosChart } from '../services/apiService'
@@ -5,17 +6,24 @@ import { buildChartFilterTree } from '../utils/chartFilters'
 
 export const useAccountChartsStore = defineStore('accountCharts', {
   state: () => ({
-    companyName: '',
-    selectedAccounts: [],
-    filterTree: null,
-    chart: null,
+    companies: [],          // [{ company, ticker }]
+    selectedAccounts: [],   // ['02.03', '03.01', ...]
+    filterTree: null,       // árvore de filtros
+    chartsByAccount: {},    // { '02.03': ChartDTO, '03.01': ChartDTO, ... }
     isLoading: false,
     error: null,
   }),
 
   actions: {
-    setCompanyName(name) {
-      this.companyName = String(name || '').trim()
+    setCompanies(pairs) {
+      this.companies = Array.isArray(pairs)
+        ? pairs
+            .map((p) => ({
+              company: String(p.company || '').trim(),
+              ticker: String(p.ticker || '').trim(),
+            }))
+            .filter((p) => p.company)
+        : []
     },
 
     setSelectedAccounts(accounts) {
@@ -28,43 +36,98 @@ export const useAccountChartsStore = defineStore('accountCharts', {
       this.filterTree = buildChartFilterTree(filterQuery)
     },
 
-    resetChart() {
-      this.chart = null
+    resetCharts() {
+      this.chartsByAccount = {}
       this.error = null
     },
 
-    async loadChart() {
-      if (!this.companyName) {
-        this.error = 'Selecione uma companhia antes de carregar o gráfico'
-        this.chart = null
+    async loadCharts() {
+      if (!this.companies.length) {
+        this.error =
+          'Selecione ao menos uma companhia antes de visualizar os gráficos'
+        this.chartsByAccount = {}
         return
       }
 
       if (!this.selectedAccounts.length) {
         this.error = 'Selecione ao menos uma conta para exibir'
-        this.chart = null
+        this.chartsByAccount = {}
         return
       }
 
       this.isLoading = true
       this.error = null
+      this.chartsByAccount = {}
 
       try {
-        const dto = await fetchCompanyRatiosChart(
-          this.companyName,
-          this.selectedAccounts,
-          this.filterTree,
-        )
-        this.chart = dto
+        const results = {}
+
+        // 1 gráfico por account
+        for (const accountCode of this.selectedAccounts) {
+          const chart = await this._loadChartForAccount(accountCode)
+          results[accountCode] = chart
+        }
+
+        this.chartsByAccount = results
       } catch (err) {
         console.error(err)
-        const message = err?.response?.data?.detail || err?.message || 'Falha ao carregar gráfico de ratios'
+        const message =
+          err?.response?.data?.detail ||
+          err?.message ||
+          'Falha ao carregar gráficos de ratios'
         this.error = message
-        this.chart = null
+        this.chartsByAccount = {}
       } finally {
         this.isLoading = false
       }
     },
+
+    async _loadChartForAccount(accountCode) {
+      const traces = []
+      let baseLayout = null
+      let baseMeta = null
+
+      for (const pair of this.companies) {
+        const companyName = pair.company
+        const ticker = pair.ticker
+
+        // Backend continua consumindo 1 empresa + 1 conta
+        const dto = await fetchCompanyRatiosChart(
+          companyName,
+          [accountCode],
+          this.filterTree,
+        )
+
+        if (!baseLayout) {
+          baseLayout = { ...(dto.layout || {}) }
+          baseMeta = { ...(dto.meta || {}) }
+        }
+
+        const [trace] = Array.isArray(dto.data) ? dto.data : []
+        if (!trace) continue
+
+        traces.push({
+          ...trace,
+          name: ticker ? `${companyName} – ${ticker}` : companyName,
+        })
+      }
+
+      if (!traces.length) {
+        throw new Error(`Nenhuma série retornada para a conta ${accountCode}`)
+      }
+
+      return {
+        data: traces,
+        layout: {
+          ...baseLayout,
+          title: `${accountCode} – séries por companhia`,
+        },
+        meta: {
+          ...baseMeta,
+          account_code: accountCode,
+          companies: this.companies,
+        },
+      }
+    },
   },
 })
-

--- a/presentation/frontend/src/views/AccountChartsView.vue
+++ b/presentation/frontend/src/views/AccountChartsView.vue
@@ -1,50 +1,65 @@
+<!-- presentation/frontend/src/views/AccountChartsView.vue -->
 <template>
   <section class="account-charts">
     <header class="account-charts__header">
       <h2>Gráficos de ratios por empresa</h2>
 
-      <p v-if="activeCompanyName">
-        Companhia selecionada:
-        <strong>{{ activeCompanyName }}</strong>
+      <p v-if="companies.length">
+        Companhias selecionadas:
+        <strong>
+          {{ companies.map((c) => `${c.company} (${c.ticker})`).join(' · ') }}
+        </strong>
       </p>
       <p v-else class="muted">
-        Nenhuma companhia selecionada. Utilize os filtros na Home para escolher uma.
+        Nenhuma companhia selecionada. Use a Home para escolher e clique em
+        “Visualizar Gráficos”.
       </p>
 
       <p class="muted">
-        Exibindo automaticamente 4 contas principais:
-        02.03, 03.01, 04.02 e 05.01.
+        Exibindo as contas:
+        {{ selectedAccounts.join(', ') }}.
       </p>
     </header>
 
     <main class="account-charts__body">
       <div v-if="chartsStore.isLoading" role="status" aria-live="polite">
-        Carregando gráficos de ratios...
+        Carregando gráficos...
       </div>
 
       <div v-else-if="chartsStore.error" role="alert">
         {{ chartsStore.error }}
       </div>
 
-      <PlotlyViewer
-        v-else-if="chartsStore.chart"
-        :chart="chartsStore.chart"
-        :isLoading="chartsStore.isLoading"
-        :error="chartsStore.error"
-        aria-label="Gráfico de séries de ratios da empresa selecionada"
-      />
+      <div v-else-if="hasCharts">
+        <section
+          v-for="accountCode in selectedAccounts"
+          :key="accountCode"
+          class="account-charts__chart-block"
+        >
+          <h3 class="account-charts__chart-title">
+            Conta {{ accountCode }}
+          </h3>
+
+          <PlotlyViewer
+            :chart="chartsStore.chartsByAccount[accountCode]"
+            :isLoading="chartsStore.isLoading"
+            :error="chartsStore.error"
+            :aria-label="`Gráfico da conta ${accountCode} para as companhias selecionadas`"
+          />
+        </section>
+      </div>
 
       <div v-else class="muted">
-        Selecione uma companhia na Home. Os gráficos das 4 contas principais serão carregados automaticamente.
+        Selecione companhias na Home e clique em “Visualizar Gráficos” para
+        carregar os dados.
       </div>
     </main>
   </section>
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, watch } from 'vue'
 import { storeToRefs } from 'pinia'
-import { useRoute } from 'vue-router'
 
 import PlotlyViewer from '../components/PlotlyViewer.vue'
 import { useAccountChartsStore } from '../store/accountChartsStore'
@@ -52,35 +67,11 @@ import { useCompanyStore } from '../store/companyStore'
 
 const chartsStore = useAccountChartsStore()
 const companyStore = useCompanyStore()
-const route = useRoute()
 
-const { selectedPairs, filterQuery } = storeToRefs(companyStore)
+const { filterQuery } = storeToRefs(companyStore)
+const { companies, selectedAccounts } = storeToRefs(chartsStore)
 
-const activeCompanyName = computed(() => {
-  const fromRoute = route.query.company
-  if (typeof fromRoute === 'string' && fromRoute.trim().length > 0) {
-    return fromRoute.trim()
-  }
-
-  const pairs = selectedPairs.value || []
-  if (!pairs.length) {
-    return ''
-  }
-  return pairs[0].company || ''
-})
-
-// 4 contas padrão
-const localAccounts = ref(['02.03', '03.01', '04.02', '05.01'])
-
-watch(
-  activeCompanyName,
-  (name) => {
-    chartsStore.setCompanyName(name)
-    chartsStore.resetChart()
-  },
-  { immediate: true },
-)
-
+// Mantém o filtro estruturado sincronizado com a CompanyStore
 watch(
   filterQuery,
   (query) => {
@@ -89,26 +80,16 @@ watch(
   { deep: true, immediate: true },
 )
 
-watch(
-  localAccounts,
-  (accounts) => {
-    chartsStore.setSelectedAccounts(accounts)
-    chartsStore.resetChart()
-  },
-  { deep: true, immediate: true },
-)
+// Caso ninguém tenha setado contas ainda, usa defaults
+const defaultAccounts = ['02.03', '03.01']
+if (!selectedAccounts.value.length) {
+  chartsStore.setSelectedAccounts(defaultAccounts)
+}
 
-watch(
-  [activeCompanyName, localAccounts, filterQuery],
-  async ([name, accounts]) => {
-    if (!name || !accounts.length || chartsStore.isLoading) {
-      return
-    }
-
-    await chartsStore.loadChart()
-  },
-  { deep: true, immediate: true },
-)
+const hasCharts = computed(() => {
+  const charts = chartsStore.chartsByAccount || {}
+  return Object.keys(charts).length > 0
+})
 </script>
 
 <style scoped>
@@ -127,9 +108,17 @@ watch(
   min-height: 280px;
 }
 
+.account-charts__chart-block {
+  margin-bottom: 2rem;
+}
+
+.account-charts__chart-title {
+  margin-bottom: 0.5rem;
+  font-size: 1.05rem;
+}
+
 .muted {
   color: #64748b;
   font-size: 0.95rem;
 }
 </style>
-

--- a/presentation/frontend/src/views/HomeView.vue
+++ b/presentation/frontend/src/views/HomeView.vue
@@ -31,6 +31,17 @@
             </tr>
           </tbody>
         </table>
+
+        <div class="home__selected-actions-bar">
+          <button
+            type="button"
+            class="home__charts-button"
+            @click="onVisualizarGraficos"
+            :disabled="!selectedPairs.length"
+          >
+            Visualizar Gráficos
+          </button>
+        </div>
       </section>
 
       <section
@@ -42,7 +53,7 @@
         <AccountChartsView v-if="selectedPairs.length" />
 
         <p v-else class="home__charts-empty">
-          Selecione uma companhia na busca para ver os gráficos.
+          Selecione uma ou mais companhias e clique em “Visualizar Gráficos”.
         </p>
       </section>
     </section>
@@ -58,16 +69,24 @@ import CompanySelectionSummary from '../components/CompanySelectionSummary.vue'
 import AccountChartsView from './AccountChartsView.vue'
 
 import { useCompanyStore } from '../store/companyStore'
+import { useAccountChartsStore } from '../store/accountChartsStore'
 
 const title = ref('Dashboard de Indicadores')
 
 const companyStore = useCompanyStore()
+const chartsStore = useAccountChartsStore()
 const { selectedPairs: selectedPairsRef } = storeToRefs(companyStore)
 
 const selectedPairs = computed(() => {
   const pairs = selectedPairsRef.value
   return Array.isArray(pairs) ? pairs : []
 })
+
+const onVisualizarGraficos = () => {
+  chartsStore.setCompanies(selectedPairs.value)
+  chartsStore.setSelectedAccounts(['02.03', '03.01'])
+  chartsStore.loadCharts()
+}
 </script>
 
 <style scoped>
@@ -121,5 +140,31 @@ const selectedPairs = computed(() => {
 
 .home__charts-empty {
   color: #64748b;
+}
+
+.home__selected-actions-bar {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.home__charts-button {
+  padding: 0.75rem 1.5rem;
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.home__charts-button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.home__charts-button:not(:disabled):hover {
+  background: #1d4ed8;
 }
 </style>


### PR DESCRIPTION
## Summary
- normaliza o store de gráficos para multiempresas com charts por conta coerentes
- atualiza a AccountChartsView para exibir um plotly por conta usando o novo store
- mantém a HomeView disparando o carregamento para todas as companhias selecionadas

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913b016fb80832e942ae16daefe5d00)