### PR TITLE
Fix ratio filter handling after whitelist feedback

### DIFF
--- a/application/usecases/get_company_ratios_frame.py
+++ b/application/usecases/get_company_ratios_frame.py
@@ -25,6 +25,11 @@ from domain.value_objects import SearchFilterTree
 from infrastructure.utils.pandas_visitor import PandasVisitor
 
 
+ALLOWED_RATIO_FILTER_FIELDS: set[str] = {
+    "date",
+}
+
+
 @dataclass
 class GetCompanyRatiosFrameUseCase:
     config: ConfigPort
@@ -105,12 +110,16 @@ class GetCompanyRatiosFrameUseCase:
             code_hash=self._normalize_usecase.ratios_code_hash,
         )
 
-        df = self._apply_filters(df, filters)
+        effective_filters: Optional[SearchFilterTree] = None
+        if filters is not None and not filters.is_empty():
+            effective_filters = filters.filtered_by_fields(ALLOWED_RATIO_FILTER_FIELDS)
+
+        df = self._apply_filters(df, effective_filters)
 
         ticker = next(iter(company.ticker_codes), None)
         meta = {
             "company_id": company.id,
-            "filters": filters.to_dict() if filters else None,
+            "filters": effective_filters.to_dict() if effective_filters else None,
         }
 
         return CompanyRatiosFrameDTO(
@@ -126,12 +135,22 @@ class GetCompanyRatiosFrameUseCase:
         df: pd.DataFrame,
         filters: Optional[SearchFilterTree],
     ) -> pd.DataFrame:
+        if df is None or df.empty:
+            return df
         if filters is None or filters.is_empty():
             return df
 
-        spec = FilterBuilder().build_spec(filters.to_dict())
-        mask = spec.accept(PandasVisitor(), df)
-        return df.loc[mask].copy()
+        try:
+            spec = FilterBuilder().build_spec(filters.to_dict())
+            mask = spec.accept(PandasVisitor(), df)
+            return df.loc[mask].copy()
+        except Exception as exc:  # pragma: no cover - defensive branch
+            if self.logger:
+                self.logger.warning(
+                    "Falha ao aplicar filtros em GetCompanyRatiosFrameUseCase: %s",
+                    exc,
+                )
+            return df
 
     def _load_treated_indicators(self) -> dict[str, dict[str, pd.DataFrame]]:
         with self.uow_factory() as uow:

--- a/domain/value_objects/search_filter_tree.py
+++ b/domain/value_objects/search_filter_tree.py
@@ -77,6 +77,65 @@ class SearchFilterTree:
         payload = json.dumps(self.raw, sort_keys=True, default=str).encode("utf-8")
         return hashlib.sha256(payload).hexdigest()
 
+    def filtered_by_fields(
+        self,
+        allowed: set[str],
+    ) -> Optional["SearchFilterTree"]:
+        """Return a copy of the tree keeping only leaves for ``allowed`` fields.
+
+        Logical nodes (``and``/``or``/``not``) are collapsed when all children are
+        pruned. Returns ``None`` when no condition survives.
+        """
+
+        if self.is_empty():
+            return None
+
+        def _filter_node(node: Any) -> Any | None:
+            if isinstance(node, dict):
+                keys = set(node.keys())
+
+                if keys == {"and"}:
+                    children = [_filter_node(child) for child in node["and"]]
+                    children = [child for child in children if child is not None]
+                    if not children:
+                        return None
+                    return {"and": children}
+
+                if keys == {"or"}:
+                    children = [_filter_node(child) for child in node["or"]]
+                    children = [child for child in children if child is not None]
+                    if not children:
+                        return None
+                    return {"or": children}
+
+                if keys == {"not"}:
+                    child = _filter_node(node["not"])
+                    if child is None:
+                        return None
+                    return {"not": child}
+
+                if len(node) == 1:
+                    field, condition = next(iter(node.items()))
+                    if field in allowed:
+                        return {field: condition}
+                    return None
+
+                return node
+
+            if isinstance(node, list):
+                children = [_filter_node(child) for child in node]
+                children = [child for child in children if child is not None]
+                if not children:
+                    return None
+                return children
+
+            return None
+
+        filtered = _filter_node(self.raw)
+        if filtered is None:
+            return None
+        return SearchFilterTree(raw=filtered)
+
     @staticmethod
     def _empty_hash() -> str:
         return hashlib.sha256(b"EMPTY_FILTER").hexdigest()

--- a/tests/domain/test_search_filter_tree.py
+++ b/tests/domain/test_search_filter_tree.py
@@ -1,0 +1,53 @@
+import pandas as pd
+
+from application.processors.filter_builder import FilterBuilder
+from domain.value_objects import SearchFilterTree
+from infrastructure.utils.pandas_visitor import PandasVisitor
+
+
+def test_filtered_by_fields_keeps_only_allowed_leaves():
+    tree_raw = {
+        "and": [
+            {"industry_segment": {"in": ["TECNOLOGIA"]}},
+            {"date": {">=": "2020-01-01"}},
+        ]
+    }
+    tree = SearchFilterTree.from_raw(tree_raw)
+
+    filtered = tree.filtered_by_fields({"date"})
+
+    assert filtered is not None
+    assert filtered.to_dict() == {"and": [{"date": {">=": "2020-01-01"}}]}
+
+
+def test_filtered_by_fields_returns_none_when_all_pruned():
+    tree_raw = {"industry_segment": {"in": ["TECNOLOGIA"]}}
+    tree = SearchFilterTree.from_raw(tree_raw)
+
+    assert tree.filtered_by_fields({"date"}) is None
+
+
+def test_filtered_tree_works_with_filter_builder():
+    tree_raw = {
+        "and": [
+            {"industry_segment": {"in": ["TECNOLOGIA"]}},
+            {"date": {">=": "2020-01-01"}},
+        ]
+    }
+    tree = SearchFilterTree.from_raw(tree_raw)
+    filtered = tree.filtered_by_fields({"date"})
+
+    df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2019-01-01", "2021-05-10"]),
+            "value": [1, 2],
+        }
+    )
+
+    spec = FilterBuilder().build_spec(filtered.to_dict())
+    mask = spec.accept(PandasVisitor(), df)
+
+    filtered_df = df[mask]
+
+    assert len(filtered_df) == 1
+    assert filtered_df.iloc[0]["value"] == 2


### PR DESCRIPTION
## Summary
- keep company ratio filtering exclusive to the whitelist and reuse the defensive `_apply_filters` path
- document that `SearchFilterTree.filtered_by_fields` collapses logical nodes and can return `None`

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69167a9d3a40832ea2ee76e4df9d6584)