### PR TITLE
refactor: rely on button state for charts action

### DIFF
--- a/presentation/frontend/src/components/SelectedCompaniesPanel.vue
+++ b/presentation/frontend/src/components/SelectedCompaniesPanel.vue
@@ -1,0 +1,114 @@
+<template>
+  <section
+    v-if="hasSelection"
+    class="home__selected-companies"
+    aria-labelledby="selected-companies-heading"
+  >
+    <h3 id="selected-companies-heading">Empresas selecionadas</h3>
+
+    <table class="home__selected-table">
+      <thead>
+        <tr>
+          <th scope="col">Companhia</th>
+          <th scope="col">Ticker</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="pair in safePairs"
+          :key="`${pair.company}::${pair.ticker}`"
+        >
+          <td>{{ pair.company }}</td>
+          <td>{{ pair.ticker }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="home__selected-actions-bar">
+      <button
+        type="button"
+        class="home__charts-button"
+        :disabled="!hasSelection"
+        @click="emitVisualizarGraficos"
+      >
+        Visualizar Gráficos
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  selectedPairs: {
+    type: Array,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['visualizar-graficos'])
+
+const safePairs = computed(() =>
+  Array.isArray(props.selectedPairs) ? props.selectedPairs : [],
+)
+
+const hasSelection = computed(() => safePairs.value.length > 0)
+
+const emitVisualizarGraficos = () => {
+  emit('visualizar-graficos')
+}
+</script>
+
+<style scoped>
+.home__selected-companies {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.home__selected-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.home__selected-table th,
+.home__selected-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.home__selected-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.home__selected-actions-bar {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.home__charts-button {
+  padding: 0.75rem 1.5rem;
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.home__charts-button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.home__charts-button:not(:disabled):hover {
+  background: #1d4ed8;
+}
+</style>

--- a/presentation/frontend/src/views/HomeView.vue
+++ b/presentation/frontend/src/views/HomeView.vue
@@ -7,42 +7,10 @@
 
       <CompanySelectionSummary />
 
-      <section
-        v-if="selectedPairs.length"
-        class="home__selected-companies"
-        aria-labelledby="selected-companies-heading"
-      >
-        <h3 id="selected-companies-heading">Empresas selecionadas</h3>
-
-        <table class="home__selected-table">
-          <thead>
-            <tr>
-              <th scope="col">Companhia</th>
-              <th scope="col">Ticker</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="pair in selectedPairs"
-              :key="`${pair.company}::${pair.ticker}`"
-            >
-              <td>{{ pair.company }}</td>
-              <td>{{ pair.ticker }}</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <div class="home__selected-actions-bar">
-          <button
-            type="button"
-            class="home__charts-button"
-            @click="onVisualizarGraficos"
-            :disabled="!selectedPairs.length"
-          >
-            Visualizar Gráficos
-          </button>
-        </div>
-      </section>
+      <SelectedCompaniesPanel
+        :selected-pairs="selectedPairs"
+        @visualizar-graficos="onVisualizarGraficos"
+      />
 
       <section
         class="home__charts-results"
@@ -66,6 +34,7 @@ import { storeToRefs } from 'pinia'
 
 import CompanySearchBuilder from '../components/CompanySearchBuilder.vue'
 import CompanySelectionSummary from '../components/CompanySelectionSummary.vue'
+import SelectedCompaniesPanel from '../components/SelectedCompaniesPanel.vue'
 import AccountChartsView from './AccountChartsView.vue'
 
 import { useCompanyStore } from '../store/companyStore'
@@ -113,58 +82,7 @@ const onVisualizarGraficos = () => {
   max-width: 100%;
 }
 
-.home__selected-companies {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.home__selected-table {
-  width: 100%;
-  border-collapse: collapse;
-  background: #fff;
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
-}
-
-.home__selected-table th,
-.home__selected-table td {
-  padding: 0.75rem 1rem;
-  text-align: left;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.home__selected-table tbody tr:last-child td {
-  border-bottom: none;
-}
-
 .home__charts-empty {
   color: #64748b;
-}
-
-.home__selected-actions-bar {
-  margin-top: 1rem;
-  display: flex;
-  justify-content: flex-end;
-}
-
-.home__charts-button {
-  padding: 0.75rem 1.5rem;
-  background: #2563eb;
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-weight: 600;
-  transition: background 0.2s ease;
-}
-
-.home__charts-button:disabled {
-  background: #94a3b8;
-  cursor: not-allowed;
-}
-
-.home__charts-button:not(:disabled):hover {
-  background: #1d4ed8;
 }
 </style>


### PR DESCRIPTION
## Summary
- remove the redundant safeguard before emitting the visualizar-graficos event so the button state drives availability

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917211d85b8832e8a9658ca7da126a6)