### PR TITLE
Update company facets filtering behavior

### DIFF
--- a/application/usecases/get_company_facets.py
+++ b/application/usecases/get_company_facets.py
@@ -7,9 +7,7 @@ from application.dtos.company_facets_dto import CompanyFacetsResponseDTO
 from application.ports.uow_port import UowFactoryPort
 from domain.dtos.company_eligible_dto import CompanyEligibleDTO
 from domain.ports.repository_company_eligible_port import RepositoryCompanyEligiblePort
-from domain.value_objects.company_filters import CompanyField
-
-DEFAULT_FACETS_BATCH_SIZE = 500
+from domain.value_objects.company_filters import CompanyField, CompanyFilterQuery
 
 
 @dataclass
@@ -17,11 +15,13 @@ class GetCompanyFacetsUseCase:
     repository: RepositoryCompanyEligiblePort
     uow_factory: UowFactoryPort
 
-    def __call__(self) -> CompanyFacetsResponseDTO:
+    def __call__(self, query: CompanyFilterQuery | None = None) -> CompanyFacetsResponseDTO:
+        query = query or CompanyFilterQuery()
         with self.uow_factory() as uow:
-            items: List[CompanyEligibleDTO] = self.repository.get_all(
+            items: List[CompanyEligibleDTO] = self.repository.search(
+                query,
                 uow=uow,
-                batch_size=DEFAULT_FACETS_BATCH_SIZE,
+                limit=None,
             )
 
         facets = self._build_facets(items)

--- a/presentation/backend/routers/companies.py
+++ b/presentation/backend/routers/companies.py
@@ -41,11 +41,13 @@ async def search_companies(
     return CompanySearchResponseDTO(**asdict(result))
 
 
-@router.get("/facets", response_model=CompanyFacetsResponseDTO)
+@router.post("/facets", response_model=CompanyFacetsResponseDTO)
 async def get_company_facets(
+    filters: CompanyFilterQueryDTO = Body(default_factory=CompanyFilterQueryDTO),
     use_case: GetCompanyFacetsUseCase = Depends(get_company_facets_usecase),
 ) -> CompanyFacetsResponseDTO:
-    result = use_case()
+    query = _map_to_domain(filters)
+    result = use_case(query=query)
     return CompanyFacetsResponseDTO(**asdict(result))
 
 

--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -348,7 +348,7 @@ function onFacetDraftChange({ field, logical, values, operator }) {
   }
 }
 
-function onFacetCommit({ field, logical, values, operator }) {
+async function onFacetCommit({ field, logical, values, operator }) {
   const finalLogical = logical || 'AND'
   const finalValues = Array.isArray(values) ? [...values] : []
   const finalOperator = operator || DEFAULT_OPERATOR
@@ -363,10 +363,12 @@ function onFacetCommit({ field, logical, values, operator }) {
       values: [],
     },
   }
+
+  await Promise.all([store.loadCompanies(), store.loadFacets()])
 }
 
-function applyQuery() {
-  const result = store.applyQueryText()
+async function applyQuery() {
+  const result = await store.applyQueryText()
   if (!result.ok) {
     parseError.value = result.message || 'Não foi possível interpretar a consulta.'
     return
@@ -374,8 +376,8 @@ function applyQuery() {
   parseError.value = ''
 }
 
-function clearFilters() {
-  store.resetFilters()
+async function clearFilters() {
+  await store.resetFilters()
   parseError.value = ''
   draftFacets.value = {}
 }

--- a/presentation/frontend/src/services/apiService.js
+++ b/presentation/frontend/src/services/apiService.js
@@ -48,8 +48,9 @@ export async function searchCompanies(filterQuery) {
   return res.data
 }
 
-export async function fetchCompanyFacets() {
-  const res = await api.get('/companies/facets')
+export async function fetchCompanyFacets(filters = { clauses: [] }) {
+  const payload = filters || { clauses: [] }
+  const res = await api.post('/companies/facets', payload)
   return res.data
 }
 

--- a/presentation/frontend/src/store/companyStore.js
+++ b/presentation/frontend/src/store/companyStore.js
@@ -618,12 +618,15 @@ export const useCompanyStore = defineStore('companyStore', {
       this.queryText = text
     },
 
-    applyQueryText() {
+    async applyQueryText() {
       try {
         const parsed = this.parseQuery(this.queryText)
         this.filterQuery = parsed
         this.queryText = this.serializeQuery(parsed)
-        this.loadCompanies()
+        await Promise.all([
+          this.loadCompanies(),
+          this.loadFacets(this.filterQuery),
+        ])
         return { ok: true }
       } catch (error) {
         const message = error instanceof ParseError ? error.message : 'Consulta inválida.'
@@ -631,11 +634,14 @@ export const useCompanyStore = defineStore('companyStore', {
       }
     },
 
-    resetFilters() {
+    async resetFilters() {
       this.filterQuery = { clauses: [] }
       this.queryText = ''
       this.selectedItems = []
-      this.loadCompanies()
+      await Promise.all([
+        this.loadCompanies(),
+        this.loadFacets({ clauses: [] }),
+      ])
     },
 
     setSelectedItems(values) {
@@ -666,9 +672,11 @@ export const useCompanyStore = defineStore('companyStore', {
       }
     },
 
-    async loadFacets() {
+    async loadFacets(filters = null) {
       try {
-        const payload = await fetchCompanyFacets()
+        const payload = await fetchCompanyFacets(
+          filters?.clauses ? filters : this.filterQuery,
+        )
         this.facets = payload.facets || {}
       } catch (err) {
         console.error(err)


### PR DESCRIPTION
## Summary
- allow the facets endpoint to accept filter queries so results reflect current selections
- refresh company and facet data whenever filters are committed or cleared in the UI
- adjust frontend API client and store to post filter queries for facet retrieval

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4ec3ff4c832e9f3bc492b60ccc42)