### PR TITLE
Remove cascade handling from company facets

### DIFF
--- a/presentation/frontend/src/components/CompanySearchBuilder.vue
+++ b/presentation/frontend/src/components/CompanySearchBuilder.vue
@@ -83,16 +83,6 @@ const parseError = ref('')
 const draftFacets = ref({})
 const DEFAULT_OPERATOR = 'IN'
 
-const COMPANY_FACET_FIELD_MAP = {
-  industry_sector: 'sector',
-  industry_subsector: 'subsector',
-  industry_segment: 'segment',
-}
-
-function isCompanyFacetField(field) {
-  return Object.prototype.hasOwnProperty.call(COMPANY_FACET_FIELD_MAP, field)
-}
-
 const queryTextModel = computed({
   get: () => store.queryText,
   set: (value) => {
@@ -104,8 +94,6 @@ const queryTextModel = computed({
 const companies = computed(() => store.filteredCompanies || [])
 const total = computed(() => (store.filteredCompanies || []).length)
 const facets = computed(() => store.facets || {})
-const companyFacets = computed(() => store.companyFacets || {})
-const companyFilter = computed(() => store.companyFilter || {})
 const isLoading = computed(() => store.isLoading)
 const error = computed(() => store.error)
 
@@ -153,10 +141,6 @@ function booleanLabel(value) {
 
 function facetOptions(facet) {
   const field = facet.field
-  if (isCompanyFacetField(field)) {
-    const facetId = COMPANY_FACET_FIELD_MAP[field]
-    return companyFacets.value[facetId] || []
-  }
   const dynamic = facets.value[field] || []
 
   if (facet.type === 'boolean') {
@@ -211,9 +195,6 @@ function facetLogical(field) {
   if (draft && draft.logical) {
     return draft.logical
   }
-  if (isCompanyFacetField(field)) {
-    return 'AND'
-  }
   return store.clauseByField[field]?.logical || 'AND'
 }
 
@@ -222,17 +203,10 @@ function facetOperator(field) {
   if (draft && draft.operator) {
     return draft.operator
   }
-  if (isCompanyFacetField(field)) {
-    return DEFAULT_OPERATOR
-  }
   return store.clauseByField[field]?.condition?.operator || ''
 }
 
 function facetValues(field) {
-  if (isCompanyFacetField(field)) {
-    const facetId = COMPANY_FACET_FIELD_MAP[field]
-    return companyFilter.value[facetId] || []
-  }
   const draft = draftFacets.value[field]
   if (draft && Array.isArray(draft.values)) {
     return draft.values
@@ -241,11 +215,6 @@ function facetValues(field) {
 }
 
 function onFacetDraftChange({ field, logical, values, operator }) {
-  if (isCompanyFacetField(field)) {
-    const facetId = COMPANY_FACET_FIELD_MAP[field]
-    store.setCompanyFacetFilter({ facetId, values })
-    return
-  }
   draftFacets.value = {
     ...draftFacets.value,
     [field]: {
@@ -257,11 +226,6 @@ function onFacetDraftChange({ field, logical, values, operator }) {
 }
 
 function onFacetCommit({ field, logical, values, operator }) {
-  if (isCompanyFacetField(field)) {
-    const facetId = COMPANY_FACET_FIELD_MAP[field]
-    store.setCompanyFacetFilter({ facetId, values })
-    return
-  }
   const finalLogical = logical || 'AND'
   const finalValues = Array.isArray(values) ? [...values] : []
   const finalOperator = operator || DEFAULT_OPERATOR

--- a/presentation/frontend/src/store/companyStore.js
+++ b/presentation/frontend/src/store/companyStore.js
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { searchCompanies, fetchCompanyFacets } from '../services/apiService'
-import { applyCompanyFilter, buildCompanyFacets } from '../core/companyFacetEngine'
 
 const DEFAULT_OPERATOR = 'IN'
 const SELECTION_SEPARATOR = '::'
@@ -29,14 +28,6 @@ const OPERATOR_ALIASES = {
   STARTSWITH: 'STARTS_WITH',
   PREFIX: 'STARTS_WITH',
   BETWEEN: 'BETWEEN',
-}
-
-function createEmptyCompanyFilter() {
-  return {
-    sector: [],
-    subsector: [],
-    segment: [],
-  }
 }
 
 const FIELD_ALIASES = {
@@ -570,8 +561,6 @@ export const useCompanyStore = defineStore('companyStore', {
     filteredCompanies: [],
     total: 0,
     facets: {},
-    companyFilter: createEmptyCompanyFilter(),
-    companyFacets: createEmptyCompanyFilter(),
     selectedItems: [],
     isLoading: false,
     error: null,
@@ -593,19 +582,6 @@ export const useCompanyStore = defineStore('companyStore', {
   },
 
   actions: {
-    setCompanyFacetFilter({ facetId, values }) {
-      const normalizedValues = Array.isArray(values)
-        ? values.map((v) => String(v || '').trim()).filter(Boolean)
-        : []
-
-      this.companyFilter = {
-        ...this.companyFilter,
-        [facetId]: normalizedValues,
-      }
-
-      this.rebuildCompanyFacets()
-    },
-
     setFacetSelection(field, logical, values, operator = DEFAULT_OPERATOR) {
       const normalizedField = normalizeField(field) || field
       const normalizedLogical = normalizeLogical(logical) || 'AND'
@@ -652,8 +628,6 @@ export const useCompanyStore = defineStore('companyStore', {
     resetFilters() {
       this.filterQuery = { clauses: [] }
       this.queryText = ''
-      this.companyFilter = createEmptyCompanyFilter()
-      this.companyFacets = createEmptyCompanyFilter()
       this.filteredCompanies = this.companies || []
       this.selectedItems = []
       this.loadCompanies()
@@ -674,7 +648,7 @@ export const useCompanyStore = defineStore('companyStore', {
         this.companies = payload.items || []
         this.total = payload.total || 0
 
-        this.rebuildCompanyFacets()
+        this.filteredCompanies = this.companies
         this._pruneSelection()
         if (!this.queryText) {
           this.queryText = this.serializeQuery(this.filterQuery)
@@ -708,22 +682,6 @@ export const useCompanyStore = defineStore('companyStore', {
         return { clauses: [] }
       }
       return parseTextToQuery(text)
-    },
-
-    rebuildCompanyFacets() {
-      const allCompanies = this.companies || []
-      const filter = this.companyFilter || createEmptyCompanyFilter()
-
-      const normalizedFilter = {
-        sector: Array.isArray(filter.sector) ? filter.sector : [],
-        subsector: Array.isArray(filter.subsector) ? filter.subsector : [],
-        segment: Array.isArray(filter.segment) ? filter.segment : [],
-      }
-
-      const filtered = applyCompanyFilter(allCompanies, normalizedFilter)
-
-      this.companyFacets = buildCompanyFacets(filtered)
-      this.filteredCompanies = filtered
     },
 
     _pruneSelection() {


### PR DESCRIPTION
## Summary
- simplify company facet handling by removing cascade-specific UI logic in the search builder
- drop cascade filtering state from the company store so filtered companies mirror backend results

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a63ee55d8832eb835a6827f94eb82)