### PR TITLE
Normalize company filter field aliases for universal search

### DIFF
--- a/presentation/backend/routers/companies.py
+++ b/presentation/backend/routers/companies.py
@@ -26,6 +26,7 @@ from presentation.backend.dto.company_search_dto import (
     CompanyFilterQueryDTO,
     CompanySearchResponseDTO,
 )
+from presentation.backend.routers.company_field_normalizer import normalize_field
 
 
 router = APIRouter(prefix="/companies", tags=["companies"])
@@ -105,12 +106,8 @@ def _map_condition(
 ) -> CompanyFilterCondition | None:
     if condition_dto is None:
         return None
-    field_value = (condition_dto.field or "").strip()
-    if not field_value:
-        return None
-    try:
-        field = CompanyField(field_value)
-    except ValueError:
+    field = normalize_field(condition_dto.field)
+    if field is None:
         return None
 
     operator_value = (condition_dto.operator or "IN").strip().upper()

--- a/presentation/backend/routers/company_field_normalizer.py
+++ b/presentation/backend/routers/company_field_normalizer.py
@@ -1,0 +1,38 @@
+"""Helpers to coerce request field names to :class:`CompanyField`."""
+
+from __future__ import annotations
+
+from domain.value_objects.company_filters import CompanyField
+
+
+def normalize_field(value: str | None) -> CompanyField | None:
+    """Map raw field names (including aliases) to :class:`CompanyField`.
+
+    Accepts case-insensitive inputs and common aliases used by the frontend and
+    CLI (e.g. ``codigo`` or ``ticker`` for ``code``).
+    """
+
+    if not value:
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+
+    aliases = {
+        "codigo": CompanyField.CODE,
+        "ticker": CompanyField.CODE,
+        "code": CompanyField.CODE,
+        "cnpj": CompanyField.CNPJ,
+    }
+
+    if normalized in aliases:
+        return aliases[normalized]
+
+    try:
+        return CompanyField(normalized)
+    except ValueError:
+        return None
+
+
+__all__ = ["normalize_field"]

--- a/tests/presentation/test_companies_router.py
+++ b/tests/presentation/test_companies_router.py
@@ -1,0 +1,15 @@
+from domain.value_objects.company_filters import CompanyField
+from presentation.backend.routers.company_field_normalizer import normalize_field
+
+
+def test_normalize_field_accepts_code_aliases():
+    assert normalize_field("codigo") == CompanyField.CODE
+    assert normalize_field("ticker") == CompanyField.CODE
+    assert normalize_field("code") == CompanyField.CODE
+    assert normalize_field("CNPJ") == CompanyField.CNPJ
+
+
+def test_normalize_field_returns_none_for_unknown_fields():
+    assert normalize_field(None) is None
+    assert normalize_field(" ") is None
+    assert normalize_field("unknown") is None


### PR DESCRIPTION
## Summary
- add a shared normalizer for company filter fields to accept aliases like codigo, ticker and cnpj
- refactor the companies router to use the centralized normalization helper
- add unit tests covering the alias normalization behaviour

## Testing
- PYTHONPATH=. pytest tests/presentation/test_companies_router.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a8c219c80832eb12f0a8d5d20ba47)