### PR TITLE
Expose issuing company fields in company search results

### DIFF
--- a/application/dtos/company_search_result_dto.py
+++ b/application/dtos/company_search_result_dto.py
@@ -15,3 +15,6 @@ class CompanySearchResultDTO:
     market: str | None = None
     institution_common: str | None = None
     institution_preferred: str | None = None
+    issuing_company: str | None = None
+    code: str | None = None
+    cnpj: str | None = None

--- a/application/usecases/search_companies.py
+++ b/application/usecases/search_companies.py
@@ -47,5 +47,8 @@ class SearchCompaniesUseCase:
             market=dto.market,
             institution_common=dto.institution_common,
             institution_preferred=dto.institution_preferred,
+            issuing_company=dto.issuing_company,
+            code=dto.code or (dto.ticker_codes[0] if dto.ticker_codes else None),
+            cnpj=dto.cnpj,
         )
 

--- a/bcb_series/application/dtos/company_search_result_dto.py
+++ b/bcb_series/application/dtos/company_search_result_dto.py
@@ -15,3 +15,6 @@ class CompanySearchResultDTO:
     market: str | None = None
     institution_common: str | None = None
     institution_preferred: str | None = None
+    issuing_company: str | None = None
+    code: str | None = None
+    cnpj: str | None = None

--- a/bcb_series/application/usecases/search_companies.py
+++ b/bcb_series/application/usecases/search_companies.py
@@ -47,5 +47,8 @@ class SearchCompaniesUseCase:
             market=dto.market,
             institution_common=dto.institution_common,
             institution_preferred=dto.institution_preferred,
+            issuing_company=dto.issuing_company,
+            code=dto.code or (dto.ticker_codes[0] if dto.ticker_codes else None),
+            cnpj=dto.cnpj,
         )
 

--- a/bcb_series/presentation/backend/dto/company_search_result_dto.py
+++ b/bcb_series/presentation/backend/dto/company_search_result_dto.py
@@ -15,3 +15,7 @@ class CompanySearchResultDTO(BaseModel):
     market: Optional[str] = None
     institution_common: Optional[str] = None
     institution_preferred: Optional[str] = None
+
+    issuing_company: Optional[str] = None
+    code: Optional[str] = None
+    cnpj: Optional[str] = None

--- a/presentation/backend/dto/company_search_result_dto.py
+++ b/presentation/backend/dto/company_search_result_dto.py
@@ -15,3 +15,7 @@ class CompanySearchResultDTO(BaseModel):
     market: Optional[str] = None
     institution_common: Optional[str] = None
     institution_preferred: Optional[str] = None
+
+    issuing_company: Optional[str] = None
+    code: Optional[str] = None
+    cnpj: Optional[str] = None


### PR DESCRIPTION
## Summary
- extend company search result DTOs to include issuing company, primary code, and CNPJ fields in both standard and bcb_series presentations
- propagate issuing company identifiers, main code fallback, and CNPJ from the company search use case into API responses

## Testing
- python -m pytest tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a8f3c0554832ebe37ac5ea6f44ad3)